### PR TITLE
Improve reminder message readability and fix leaderboard week calculation bug

### DIFF
--- a/internal/app/usecase/get_leaderboard_usecase.go
+++ b/internal/app/usecase/get_leaderboard_usecase.go
@@ -43,7 +43,7 @@ func (uc *GetLeaderboardUsecase) Execute(ctx context.Context) (string, error) {
 	// Count active vs lost for recap
 	activeCount := 0
 	lostCount := 0
-	currentWeekStart := domain.GetStartOfISOWeek(displayDate)
+	currentWeekStart := domain.GetStartOfISOWeek(now)
 	for _, r := range reports {
 		lastWeekStart := domain.GetStartOfISOWeek(r.LastReportDate)
 		weeksSinceLastReport := int(math.Round(currentWeekStart.Sub(lastWeekStart).Hours() / (24 * 7)))

--- a/internal/app/usecase/remind_inactive_users_usecase.go
+++ b/internal/app/usecase/remind_inactive_users_usecase.go
@@ -39,12 +39,24 @@ var motivationsLong = []string{
 	"Tubuhmu merindukanmu berolahraga. Yuk mulai hari ini! 🌅",
 }
 
+// inactiveUserInfo holds pre-computed info for an inactive user.
+type inactiveUserInfo struct {
+	user         *domain.Report
+	daysInactive int
+}
+
+// inactivity tier thresholds
+const (
+	tierCriticalDays = 60 // 2+ months
+	tierWarningDays  = 30 // 1-2 months
+	// everything else is 1-4 weeks (7-29 days)
+)
+
 func (u *RemindInactiveUsersUsecase) Execute(ctx context.Context, client *whatsmeow.Client, groupID string) (string, error) {
 	if groupID == "" {
 		return "", fmt.Errorf("group ID is not configured")
 	}
 
-	// Get users who haven't reported in 7 days
 	inactiveUsers, err := u.repo.GetInactiveUsers(ctx, 7)
 	if err != nil {
 		return "", fmt.Errorf("failed to get inactive users: %w", err)
@@ -55,61 +67,51 @@ func (u *RemindInactiveUsersUsecase) Execute(ctx context.Context, client *whatsm
 	}
 
 	now := time.Now()
-	var sb strings.Builder
-	sb.WriteString("📢 *PENGUMUMAN OLAHRAGA*\n\n")
-	sb.WriteString("Halo teman-teman, sudah seminggu lebih nih beberapa dari kita belum lapor aktivitas:\n\n")
+	todayDate := domain.GetToday(now)
 
-	var mentions []string
+	// Pre-compute days inactive for each user
+	users := make([]inactiveUserInfo, 0, len(inactiveUsers))
 	for _, user := range inactiveUsers {
-		lastReport := user.LastReportDate
-		lastReportDate := domain.GetToday(lastReport)
-		todayDate := domain.GetToday(now)
+		lastReportDate := domain.GetToday(user.LastReportDate)
 		daysInactive := int(math.Round(todayDate.Sub(lastReportDate).Hours() / 24))
+		users = append(users, inactiveUserInfo{user: user, daysInactive: daysInactive})
+	}
 
-		// Personalized info with lost streak
-		sb.WriteString(fmt.Sprintf("- @%s (%s)", user.UserID, user.Name))
-		if user.MaxStreak > 0 {
-			sb.WriteString(fmt.Sprintf(" — pernah streak %d minggu 🔥, sudah %d hari absen", user.MaxStreak, daysInactive))
-		} else {
-			sb.WriteString(fmt.Sprintf(" — sudah %d hari absen", daysInactive))
+	// Bucket into tiers
+	var critical, warning, mild []inactiveUserInfo
+	for _, u := range users {
+		switch {
+		case u.daysInactive >= tierCriticalDays:
+			critical = append(critical, u)
+		case u.daysInactive >= tierWarningDays:
+			warning = append(warning, u)
+		default:
+			mild = append(mild, u)
 		}
+	}
 
-		// Mention potential comeback achievement
+	// Collect hall of fame - users with max streak >= 4 weeks (notable achievers)
+	var hallOfFame []inactiveUserInfo
+	for _, u := range users {
+		if u.user.MaxStreak >= 4 {
+			hallOfFame = append(hallOfFame, u)
+		}
+	}
+
+	// Count users eligible for each comeback achievement
+	comebackCounts := make(map[string]int)
+	for _, u := range users {
 		for _, a := range domain.AllComebackAchievements {
-			if daysInactive >= a.MinInactiveDays && !domain.HasAchievement(user.Achievements, a.ID) {
-				sb.WriteString(fmt.Sprintf(" (💡 bisa unlock \"%s\"!)", a.Name))
+			if u.daysInactive >= a.MinInactiveDays && !domain.HasAchievement(u.user.Achievements, a.ID) {
+				comebackCounts[a.Name]++
 				break
 			}
 		}
-		sb.WriteString("\n")
-
-		mentions = append(mentions, user.UserID+"@s.whatsapp.net")
 	}
 
-	// Add motivation based on how long most users have been inactive
-	sb.WriteString("\n")
-	maxInactive := 0
-	for _, user := range inactiveUsers {
-		lastReport := user.LastReportDate
-		lastReportDate := time.Date(lastReport.Year(), lastReport.Month(), lastReport.Day(), 0, 0, 0, 0, time.UTC)
-		todayDate := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-		days := int(math.Round(todayDate.Sub(lastReportDate).Hours() / 24))
-		if days > maxInactive {
-			maxInactive = days
-		}
-	}
+	messageText, mentions := BuildReminderMessage(users, critical, warning, mild, hallOfFame, comebackCounts)
 
-	if maxInactive > 14 {
-		sb.WriteString(motivationsLong[rand.Intn(len(motivationsLong))])
-	} else {
-		sb.WriteString(motivationsShort[rand.Intn(len(motivationsShort))])
-	}
-
-	messageText := sb.String()
-
-	// Send message to group
 	targetJID, _ := types.ParseJID(groupID)
-
 	msg := &waE2E.Message{
 		ExtendedTextMessage: &waE2E.ExtendedTextMessage{
 			Text: &messageText,
@@ -126,4 +128,98 @@ func (u *RemindInactiveUsersUsecase) Execute(ctx context.Context, client *whatsm
 
 	log.Printf("Sent inactivity reminder to %d users in group %s", len(inactiveUsers), groupID)
 	return fmt.Sprintf("Berhasil mengirim pengingat ke %d user.", len(inactiveUsers)), nil
+}
+
+// BuildReminderMessage builds the formatted reminder message and mention list.
+// Extracted as a pure function for testability.
+func BuildReminderMessage(
+	users []inactiveUserInfo,
+	critical, warning, mild, hallOfFame []inactiveUserInfo,
+	comebackCounts map[string]int,
+) (string, []string) {
+	var sb strings.Builder
+	var mentions []string
+
+	sb.WriteString("📢 *PENGUMUMAN OLAHRAGA*\n\n")
+	sb.WriteString(fmt.Sprintf("Ada *%d orang* yang belum lapor aktivitas lebih dari seminggu:\n", len(users)))
+
+	// Hall of fame callout (if any)
+	if len(hallOfFame) > 0 {
+		sb.WriteString("\n⭐ *Pernah jadi juara streak:*\n")
+		for _, u := range hallOfFame {
+			sb.WriteString(fmt.Sprintf("  @%s (%s) - streak %d minggu 🔥\n", u.user.UserID, u.user.Name, u.user.MaxStreak))
+			mentions = append(mentions, u.user.UserID+"@s.whatsapp.net")
+		}
+		sb.WriteString("Kalian pernah buktiin bisa konsisten, pasti bisa lagi!\n")
+	}
+
+	// Critical tier: 2+ months
+	if len(critical) > 0 {
+		sb.WriteString(fmt.Sprintf("\n🔴 *Sudah 2+ bulan absen* (%d orang)\n", len(critical)))
+		writeTierUsers(&sb, critical, &mentions)
+	}
+
+	// Warning tier: 1-2 months
+	if len(warning) > 0 {
+		sb.WriteString(fmt.Sprintf("\n🟠 *Sudah 1-2 bulan absen* (%d orang)\n", len(warning)))
+		writeTierUsers(&sb, warning, &mentions)
+	}
+
+	// Mild tier: 1-4 weeks
+	if len(mild) > 0 {
+		sb.WriteString(fmt.Sprintf("\n🟡 *Sudah 1-4 minggu absen* (%d orang)\n", len(mild)))
+		writeTierUsers(&sb, mild, &mentions)
+	}
+
+	// Grouped comeback achievement hints
+	if len(comebackCounts) > 0 {
+		sb.WriteString("\n💡 *Comeback challenge tersedia:*\n")
+		for _, a := range domain.AllComebackAchievements {
+			if count, ok := comebackCounts[a.Name]; ok {
+				sb.WriteString(fmt.Sprintf("  \"%s\" - %d orang bisa unlock! (%s)\n", a.Name, count, a.Description))
+			}
+		}
+	}
+
+	// Motivational closing
+	sb.WriteString("\n")
+	maxInactive := 0
+	for _, u := range users {
+		if u.daysInactive > maxInactive {
+			maxInactive = u.daysInactive
+		}
+	}
+	if maxInactive > 14 {
+		sb.WriteString(motivationsLong[rand.Intn(len(motivationsLong))])
+	} else {
+		sb.WriteString(motivationsShort[rand.Intn(len(motivationsShort))])
+	}
+
+	mentions = deduplicateMentions(mentions)
+	return sb.String(), mentions
+}
+
+// writeTierUsers writes a compact comma-separated list of @mentions for a tier.
+func writeTierUsers(sb *strings.Builder, users []inactiveUserInfo, mentions *[]string) {
+	for i, u := range users {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(fmt.Sprintf("@%s", u.user.UserID))
+		*mentions = append(*mentions, u.user.UserID+"@s.whatsapp.net")
+	}
+	sb.WriteString("\n")
+}
+
+// deduplicateMentions removes duplicate JIDs while preserving order.
+func deduplicateMentions(mentions []string) []string {
+	seen := make(map[string]bool, len(mentions))
+	result := make([]string, 0, len(mentions))
+	for _, m := range mentions {
+		if !seen[m] {
+			seen[m] = true
+			result = append(result, m)
+		}
+	}
+	return result
 }

--- a/internal/app/usecase/remind_inactive_users_usecase_test.go
+++ b/internal/app/usecase/remind_inactive_users_usecase_test.go
@@ -1,0 +1,142 @@
+package usecase
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/fardannozami/whatsapp-gateway/internal/domain"
+)
+
+func TestBuildReminderMessage(t *testing.T) {
+	now := time.Now()
+
+	// Simulate the same users from the real announcement
+	testUsers := []struct {
+		id          string
+		name        string
+		maxStreak   int
+		daysInactive int
+	}{
+		// Critical tier (60+ days)
+		{"6281289281245", "S.Pratama", 1, 80},
+		{"6282340599539", "Deimos", 1, 80},
+		{"6283157206433", "Dea", 1, 80},
+		{"6281334228595", "Aufa Wibowo", 1, 80},
+		{"6287765797036", "Ydh", 1, 80},
+		{"6287791194987", "Anwar Abdullah", 1, 80},
+		{"628977275056", "Zainal", 1, 80},
+		{"6285211486365", "Agus W", 1, 80},
+		{"62895352983939", "Day", 1, 80},
+		{"6281274429667", "Ahmad Amri", 1, 78},
+		{"6285695744459", "Fauzan Azhari", 1, 77},
+		{"6281383287559", "enjangsetiawan", 1, 75},
+		{"6282231878575", "Novi", 1, 75},
+		{"6285795094888", "Finn Christoffer", 1, 75},
+		{"6282153481251", "Rakhel", 1, 74},
+		{"628119292778", "M Fauzi", 2, 73},
+		{"628978574686", "Fadli Asyhari", 1, 70},
+		{"6281276307723", "Maulana", 1, 70},
+		{"6285156354193", "cecep wandy", 1, 70},
+		{"6285171231336", "Naufal Fawwaz", 1, 67},
+		{"6289643373386", "Risa", 2, 60},
+		// Warning tier (30-59 days)
+		{"6281398447822", "yusnar", 1, 59},
+		{"6285846132417", "Taupik Pirdian", 1, 58},
+		{"6282293119116", "Fadli Rusandy", 4, 54},
+		{"6281277753811", "Rezki Nasrullah", 1, 49},
+		{"6287878970037", "Iqbal M", 2, 46},
+		{"6282121455132", "Asep Ardi", 4, 45},
+		{"6285237264054", "Ahmad Sufyan", 4, 44},
+		{"6281919101990", "naufal nazaruddin", 5, 44},
+		{"6285866473926", "nuribnuu", 3, 43},
+		{"6285817110632", "Bayu Santoso", 4, 42},
+		{"6285719602421", "Ismail S", 4, 41},
+		{"628996423135", "Faqih Nur Fahmi", 6, 37},
+		{"6282338588078", "swegrowthid", 3, 35},
+		{"6282127070014", "Muhammad Syarifudin", 4, 34},
+		{"6287868126244", "Mochammad Rizqi", 4, 33},
+		{"6281264808425", "fajar setiawan", 1, 33},
+		{"628986389685", "Agus Setyawan", 1, 32},
+		{"6285769476484", "M Idrus Salam", 1, 28},  // actually mild (< 30)
+		// Mild tier (7-29 days)
+		{"6281329262095", "Haddawi", 2, 21},
+		{"6285724230162", "fajardsutera", 4, 20},
+		{"6282121632543", "aabar", 1, 18},
+		{"628115420582", "Kasjful Kurniawan", 1, 16},
+		{"6285740482440", "Arif Faizin", 3, 15},
+		{"6287875228746", "Otniel", 1, 14},
+		{"6289634879461", "fauzandp", 1, 11},
+	}
+
+	// Build inactiveUserInfo slice
+	var users []inactiveUserInfo
+	for _, tu := range testUsers {
+		users = append(users, inactiveUserInfo{
+			user: &domain.Report{
+				UserID:         tu.id,
+				Name:           tu.name,
+				MaxStreak:      tu.maxStreak,
+				LastReportDate: now.AddDate(0, 0, -tu.daysInactive),
+				Achievements:   "", // no achievements yet
+			},
+			daysInactive: tu.daysInactive,
+		})
+	}
+
+	// Bucket into tiers
+	var critical, warning, mild []inactiveUserInfo
+	for _, u := range users {
+		switch {
+		case u.daysInactive >= tierCriticalDays:
+			critical = append(critical, u)
+		case u.daysInactive >= tierWarningDays:
+			warning = append(warning, u)
+		default:
+			mild = append(mild, u)
+		}
+	}
+
+	// Hall of fame
+	var hallOfFame []inactiveUserInfo
+	for _, u := range users {
+		if u.user.MaxStreak >= 4 {
+			hallOfFame = append(hallOfFame, u)
+		}
+	}
+
+	// Comeback counts
+	comebackCounts := make(map[string]int)
+	for _, u := range users {
+		for _, a := range domain.AllComebackAchievements {
+			if u.daysInactive >= a.MinInactiveDays && !domain.HasAchievement(u.user.Achievements, a.ID) {
+				comebackCounts[a.Name]++
+				break
+			}
+		}
+	}
+
+	msg, mentions := BuildReminderMessage(users, critical, warning, mild, hallOfFame, comebackCounts)
+
+	// Print the actual message so you can see it
+	fmt.Println("=== GENERATED MESSAGE ===")
+	fmt.Println(msg)
+	fmt.Println("=== END MESSAGE ===")
+	fmt.Printf("\nTotal mentions: %d\n", len(mentions))
+	fmt.Printf("Critical: %d, Warning: %d, Mild: %d, Hall of Fame: %d\n",
+		len(critical), len(warning), len(mild), len(hallOfFame))
+
+	// Basic assertions
+	if len(mentions) == 0 {
+		t.Error("expected mentions to be non-empty")
+	}
+	if msg == "" {
+		t.Error("expected message to be non-empty")
+	}
+	if len(critical) == 0 {
+		t.Error("expected critical tier to have users")
+	}
+	if len(hallOfFame) == 0 {
+		t.Error("expected hall of fame to have users")
+	}
+}


### PR DESCRIPTION
## Summary

The PENGUMUMAN OLAHRAGA reminder message was a wall of 45+ identical-looking lines that nobody reads. This PR restructures it into a scannable, grouped format - cutting message length by ~60%. Also fixes a bug where the leaderboard misclassified inactive users as active due to a double-applied date offset.

## Changes

**Reminder message redesign**
- Group inactive users into severity tiers (2+ months, 1-2 months, 1-4 weeks) with compact comma-separated mentions instead of one bullet per person
- Move comeback achievement hints to a single grouped footer instead of repeating on every line
- Add hall of fame callout for users with 4+ week streaks (social proof)
- Add summary count header
- Extract message building into a pure `BuildReminderMessage` function for testability
- Add test with realistic data (46 users)

**Leaderboard bug fix**
- `GetStartOfISOWeek(displayDate)` double-applied the 30-minute cutoff offset because `displayDate` was already processed by `GetToday()`. This shifted the current week start back a day, causing 2-week-absent users to appear as 1-week (active instead of lost streak)
- Fix: pass raw `now` to `GetStartOfISOWeek()` so the offset is applied once

## Test plan
- Run `go test ./...` - all tests pass including the previously failing `TestLeaderboard_RanksByActivityCount`
- Review `TestBuildReminderMessage` output for message formatting