### PR TITLE
Add seasonal badges, ranks, and job tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,11 @@ Bot hanya merespon perintah berikut di dalam grup yang telah dikonfigurasi (`GRO
 | `#cancel` | Membatalkan laporan hari ini. Hanya bisa digunakan di hari yang sama. |
 | `#leaderboard` | Menampilkan klasemen streak, daftar yang "Keep Streak" 🔥 dan "Lose Streak" 💔. |
 | `#leaderboard-weekly` | Menampilkan klasemen total hari aktif minggu ini. |
-| `#mystats` | Menampilkan statistik personal (streak, poin, achievements). |
-| `#achievements` | Menampilkan daftar semua achievement dan progress member. |
+| `#ranks` | Menampilkan ranking hunter selama season berjalan. |
+| `#mystats` | Menampilkan statistik personal ringkas (level, rank, streak, poin). |
+| `#achievements` | Menampilkan daftar badge season dan progress member. |
+| `#jobs` | Menampilkan daftar hunter jobs yang bisa dipilih. |
+| `#job [id]` | Memilih hunter job. Contoh: `#job ranger`. |
 | `#comeback` | Menampilkan status comeback challenge setelah absen. |
 | `#motivasi` | Menampilkan pesan motivasi acak untuk semangat berolahraga. |
 | `#help` | Menampilkan panduan penggunaan bot dan daftar command. |
@@ -97,7 +100,10 @@ Bot hanya merespon perintah berikut di dalam grup yang telah dikonfigurasi (`GRO
 | `#setname [nama]` | Mengubah nama tampilan di leaderboard. |
 
 ### Fitur Gamifikasi 🏅
-- **Points & Achievements**: Dapatkan poin dan badge unik dengan menjaga streak dan aktif melapor.
+- **Season Ranks (`#ranks`)**: Rank ala hunter dihitung dari seasonal points dan reset setiap season.
+- **Hunter Jobs (`#jobs`, `#job [id]`)**: Pilih job profile seperti fighter, tanker, assassin, mage, ranger, healer, atau necromancer. Job tampil di `#mystats` dan laporan harian.
+- **Season Badges**: Badge reset setiap season supaya semua member mulai berburu dari awal.
+- **Lifetime Level & EXP**: Total poin, level, streak mingguan, dan progress penting user tetap tersimpan lintas season.
 - **Milestone Notification**: Dapat notifikasi khusus saat mencapai streak tertenu (7, 14, 30 hari, dst).
 - **Leaderboard**: Bersaing dengan teman untuk streak tertinggi.
 
@@ -126,4 +132,3 @@ Kontribusi sangat dipersilakan! Silakan ikuti langkah-langkah berikut:
 5.  Buat **Pull Request**.
 
 Jangan ragu untuk membuka _Issue_ jika menemukan bug atau memiliki saran fitur baru.
-

--- a/internal/app/usecase/get_achievements_usecase.go
+++ b/internal/app/usecase/get_achievements_usecase.go
@@ -27,11 +27,12 @@ func (uc *GetAchievementsUsecase) Execute(ctx context.Context) (string, error) {
 		return "Belum ada member yang aktif.", nil
 	}
 
-	// Calculate stats for each achievement
+	// Calculate season badge stats. Lifetime achievements are preserved in the
+	// database, but the visible badge race resets every season.
 	stats := make(map[string]int)
 	for _, r := range reports {
-		if r.Achievements != "" {
-			ids := strings.Split(r.Achievements, ",")
+		if r.SeasonalAchievements != "" {
+			ids := strings.Split(r.SeasonalAchievements, ",")
 			for _, id := range ids {
 				stats[strings.TrimSpace(id)]++
 			}
@@ -39,23 +40,10 @@ func (uc *GetAchievementsUsecase) Execute(ctx context.Context) (string, error) {
 	}
 
 	sb := strings.Builder{}
-	sb.WriteString("🎖️ *Daftar Achievement Challenge*\n\n")
+	sb.WriteString("🎖️ *Season Badge Challenge*\n")
+	sb.WriteString("Badge di bawah ini reset setiap season. Level & EXP lifetime tetap aman.\n\n")
 
-	for _, ach := range domain.AllAchievements {
-		count := stats[ach.ID]
-		var icon string
-		if count > 0 {
-			icon = ach.DisplayEmoji
-		} else {
-			icon = "🔒"
-		}
-
-		sb.WriteString(fmt.Sprintf("%s %s — %s (%d/%d member)\n", icon, ach.Name, ach.Description, count, totalMembers))
-	}
-
-	sb.WriteString("\n🔄 *Comeback Achievements*\n")
-	sb.WriteString("_Kembali aktif setelah absen & bangun streak lagi!_\n\n")
-	for _, ach := range domain.AllComebackAchievements {
+	for _, ach := range domain.AllSeasonAchievements {
 		count := stats[ach.ID]
 		var icon string
 		if count > 0 {

--- a/internal/app/usecase/get_help_usecase.go
+++ b/internal/app/usecase/get_help_usecase.go
@@ -20,12 +20,17 @@ var helpSections = []struct {
 	{
 		emoji:   "🏆",
 		title:   "Leaderboard & Statistik",
-		content: "*#leaderboard* — Lihat klasemen lifetime (total hari aktif).\n*#leaderboard-weekly* — Lihat klasemen total hari aktif minggu ini.\n*#leaderboard-seasonal* — Lihat klasemen seasonal points.\n*#mystats* — Cek statistik personal (streak, poin, achievements, seasonal progress).",
+		content: "*#leaderboard* — Lihat klasemen lifetime (total hari aktif).\n*#leaderboard-weekly* — Lihat klasemen total hari aktif minggu ini.\n*#leaderboard-seasonal* — Lihat klasemen seasonal points.\n*#ranks* — Lihat ranking hunter selama season ini.\n*#mystats* — Cek statistik personal ringkas.",
 	},
 	{
 		emoji:   "🎖️",
 		title:   "Achievements",
-		content: "*#achievements* — Lihat daftar semua achievement yang tersedia.\n*#comeback* — Cek progress comeback challenge-mu setelah absen.\n\n🏅 Kumpulkan badge dengan menjaga streak dan total hari aktif!",
+		content: "*#achievements* — Lihat daftar badge season yang tersedia. Badge reset tiap season; level dan EXP lifetime tetap aman.\n*#comeback* — Cek progress comeback challenge-mu setelah absen.\n\n🏅 Kumpulkan badge dengan menjaga streak dan total hari aktif selama season!",
+	},
+	{
+		emoji:   "🧭",
+		title:   "Hunter Jobs",
+		content: "*#jobs* — Lihat daftar job yang bisa dipilih.\n*#job [id]* — Pilih job untuk profilmu. Contoh: `#job ranger`\n\nJob tersedia: fighter, tank, assassin, mage, ranger, healer, necromancer. Job tampil di #mystats dan laporan #lapor.",
 	},
 	{
 		emoji:   "✨",

--- a/internal/app/usecase/get_leaderboard_usecase.go
+++ b/internal/app/usecase/get_leaderboard_usecase.go
@@ -154,3 +154,66 @@ func (uc *GetLeaderboardUsecase) ExecuteSeasonal(ctx context.Context) (string, e
 
 	return sb.String(), nil
 }
+
+// ExecuteRanks returns a concise season ranking for the #ranks command.
+func (uc *GetLeaderboardUsecase) ExecuteRanks(ctx context.Context) (string, error) {
+	reports, err := uc.repo.GetAllReports(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	now := time.Now()
+	seasonNumber, _ := GetCurrentSessionInfo(now)
+	nextReset := GetNextResetTime(now)
+
+	sort.Slice(reports, func(i, j int) bool {
+		if reports[i].SeasonalPoints == reports[j].SeasonalPoints {
+			if reports[i].SeasonalActivityCount == reports[j].SeasonalActivityCount {
+				return reports[i].Name < reports[j].Name
+			}
+			return reports[i].SeasonalActivityCount > reports[j].SeasonalActivityCount
+		}
+		return reports[i].SeasonalPoints > reports[j].SeasonalPoints
+	})
+
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf("🏹 *Season %d Ranks*\n", seasonNumber))
+	sb.WriteString(fmt.Sprintf("Reset badge/rank: %s\n", nextReset.Format("02-01-2006")))
+	sb.WriteString("Level & EXP lifetime tetap aman.\n\n")
+
+	rank := 1
+	for _, r := range reports {
+		if r.SeasonalPoints == 0 && r.SeasonalActivityCount == 0 {
+			continue
+		}
+
+		badges := 0
+		if r.SeasonalAchievements != "" {
+			badges = len(strings.Split(r.SeasonalAchievements, ","))
+		}
+
+		sb.WriteString(fmt.Sprintf(
+			"%d. %s — %s | %d pts | %d hari | %d badge\n",
+			rank,
+			r.Name,
+			domain.FormatSeasonRank(r.SeasonalPoints),
+			r.SeasonalPoints,
+			r.SeasonalActivityCount,
+			badges,
+		))
+
+		rank++
+		if rank > 10 {
+			break
+		}
+	}
+
+	if rank == 1 {
+		sb.WriteString("Belum ada hunter aktif season ini. Mulai dengan #lapor 💪")
+		return sb.String(), nil
+	}
+
+	sb.WriteString("\nRank dihitung dari seasonal points. Badge season ikut menambah poin, lalu reset saat season baru.")
+
+	return sb.String(), nil
+}

--- a/internal/app/usecase/get_motivation_usecase.go
+++ b/internal/app/usecase/get_motivation_usecase.go
@@ -78,6 +78,12 @@ var motivationalQuotes = []string{
 	"🏀 \"Kalau aku punya masalah, setelah bermain pikiranku jadi lebih jernih. Olahraga itu seperti terapi.\" — Michael Jordan",
 	"🌿 \"Hidup sehat bukan tujuan yang harus dicapai, melainkan cara untuk menjalani hidup setiap hari.\" — Anonim",
 	"🔁 \"Hasil datang seiring waktu, bukan dalam semalam. Kerja keras, tetap konsisten.\" — Anonim",
+	"🫀 \"Mereka yang tidak menyediakan waktu untuk berolahraga pada akhirnya harus menyediakan waktu untuk sakit.\" — Edward Stanley",
+	"🏃 \"Jika olahraga bisa dikemas dalam pil, itu akan menjadi obat paling banyak diresepkan di dunia.\" — Robert Butler",
+	"🌤️ \"Bergeraklah bukan karena membenci tubuhmu, tapi karena kamu menghargai hidup yang ditopangnya.\" — Anonim",
+	"🧱 \"Latihan hari ini adalah suara kecil yang berkata: aku sedang membangun diriku, bukan menghukum diriku.\" — Anonim",
+	"🥗 \"Kesehatan bukan segalanya, tapi tanpa kesehatan segalanya terasa lebih berat.\" — Arthur Schopenhauer",
+	"🧭 \"Tubuh yang aktif menolong pikiran tetap jernih. Saat ragu, mulai dari berjalan kaki.\" — Anonim",
 }
 
 type GetMotivationUsecase struct {

--- a/internal/app/usecase/get_mystats_usecase.go
+++ b/internal/app/usecase/get_mystats_usecase.go
@@ -58,16 +58,28 @@ func (uc *GetMyStatsUsecase) Execute(ctx context.Context, userID, name string) (
 
 	weeklyCount := getActivityCount(weeklyEntries)
 	seasonCount := getActivityCount(seasonEntries)
+	seasonBadgeCount := 0
+	if report.SeasonalAchievements != "" {
+		seasonBadgeCount = len(strings.Split(report.SeasonalAchievements, ","))
+	}
 
 	sb := strings.Builder{}
 	sb.WriteString(fmt.Sprintf("📊 Statistik kamu, %s:\n\n", report.Name))
 
 	// Level display
-	sb.WriteString(fmt.Sprintf("🎖️ Level: %s\n", domain.FormatLevel(report.TotalPoints)))
+	sb.WriteString(fmt.Sprintf("🎖️ Level: %s (lifetime)\n", domain.FormatLevel(report.TotalPoints)))
+	sb.WriteString(fmt.Sprintf("🧭 Job: %s\n", domain.FormatJobClass(report.JobClass)))
 	sb.WriteString(fmt.Sprintf("📈 %s\n\n", domain.FormatProgressBar(report.TotalPoints)))
+
+	sb.WriteString(fmt.Sprintf("🏹 Rank season: %s\n", domain.FormatSeasonRank(report.SeasonalPoints)))
+	sb.WriteString(fmt.Sprintf("🌟 Poin season: %d\n", report.SeasonalPoints))
+	sb.WriteString(fmt.Sprintf("🏅 Badge season: %d/%d\n", seasonBadgeCount, len(domain.AllSeasonAchievements)))
+	sb.WriteString(fmt.Sprintf("🗓️ Hari season: %d\n", seasonCount))
+	sb.WriteString(fmt.Sprintf("📆 Hari minggu ini: %d\n\n", weeklyCount))
 
 	sb.WriteString(fmt.Sprintf("🔥 Streak saat ini: %d minggu\n", report.Streak))
 	sb.WriteString(fmt.Sprintf("🏆 Streak tertinggi: %d minggu\n", report.MaxStreak))
+	sb.WriteString(fmt.Sprintf("⚔️ Streak terbaik season: %d minggu\n", report.SeasonalMaxStreak))
 	streakFreezeInfo := fmt.Sprintf("❄️ Streak Freeze: %d", report.StreakFreezes)
 	if report.StreakFreezes == 0 {
 		streakFreezeInfo += " (capai 4 minggu streak untuk dapat +1 freeze!)"
@@ -78,11 +90,7 @@ func (uc *GetMyStatsUsecase) Execute(ctx context.Context, userID, name string) (
 	}
 	sb.WriteString(streakFreezeInfo + "\n")
 	sb.WriteString(fmt.Sprintf("📅 Total hari aktif (lifetime): %d\n", report.ActivityCount))
-	sb.WriteString(fmt.Sprintf("🗓️ Total hari season: %d\n", seasonCount))
-	sb.WriteString(fmt.Sprintf("📆 Total mingguan: %d\n", weeklyCount))
 	sb.WriteString(fmt.Sprintf("⭐ Total poin (lifetime): %d\n", report.TotalPoints))
-	sb.WriteString(fmt.Sprintf("🌟 Seasonal poin: %d\n", report.SeasonalPoints))
-	sb.WriteString(fmt.Sprintf("📊 Seasonal activity: %d\n", report.SeasonalActivityCount))
 
 	// Comeback status
 	if report.InactiveDays > 0 && report.ComebackStreak > 0 && report.ComebackStreak < 30 {
@@ -101,34 +109,8 @@ func (uc *GetMyStatsUsecase) Execute(ctx context.Context, userID, name string) (
 		}
 	}
 
-	sb.WriteString("\n🏅 *Achievements & Progress*\n")
-
-	// Show all standard achievements with status
-	for _, a := range domain.AllAchievements {
-		if domain.HasAchievement(report.Achievements, a.ID) {
-			sb.WriteString(fmt.Sprintf("%s %s — %s (%d pts)\n", a.DisplayEmoji, a.Name, a.Description, a.Points))
-		} else {
-			sb.WriteString(fmt.Sprintf("🔒 %s — %s (%d pts)\n", a.Name, a.Description, a.Points))
-		}
-	}
-
-	// Show comeback achievements with progress
-	sb.WriteString("\n🔄 *Comeback Achievements*\n")
-	sb.WriteString("_Khusus untuk yang kembali setelah absen!_\n")
-	for _, a := range domain.AllComebackAchievements {
-		if domain.HasAchievement(report.Achievements, a.ID) {
-			sb.WriteString(fmt.Sprintf("%s %s — %s (%d pts)\n", a.DisplayEmoji, a.Name, a.Description, a.Points))
-		} else if report.InactiveDays >= a.MinInactiveDays {
-			remaining := a.MinComebackStreak - report.ComebackStreak
-			if remaining > 0 {
-				sb.WriteString(fmt.Sprintf("🎯 %s — %d minggu lagi (%d pts)\n", a.Name, remaining, a.Points))
-			} else {
-				sb.WriteString(fmt.Sprintf("%s %s — Siap unlock! (%d pts)\n", a.DisplayEmoji, a.Name, a.Points))
-			}
-		} else {
-			sb.WriteString(fmt.Sprintf("🔒 %s — butuh absen >%d hari dulu (%d pts)\n", a.Name, a.MinInactiveDays, a.Points))
-		}
-	}
+	sb.WriteString("\nLihat ranking season: #ranks\n")
+	sb.WriteString("Lihat daftar badge: #achievements")
 
 	return sb.String(), nil
 }

--- a/internal/app/usecase/get_mystats_usecase_test.go
+++ b/internal/app/usecase/get_mystats_usecase_test.go
@@ -123,10 +123,10 @@ func TestGetMyStatsUsecase_IncludesSeasonAndWeeklyCounts(t *testing.T) {
 	if !repo.calls[1][0].Equal(seasonStart) || !repo.calls[1][1].Equal(seasonEnd) {
 		t.Fatalf("expected season range %v - %v, got %v - %v", seasonStart, seasonEnd, repo.calls[1][0], repo.calls[1][1])
 	}
-	if !contains(result, "🗓️ Total hari season: 8") {
+	if !contains(result, "🗓️ Hari season: 8") {
 		t.Fatalf("expected season count in response, got %q", result)
 	}
-	if !contains(result, "📆 Total mingguan: 3") {
+	if !contains(result, "📆 Hari minggu ini: 3") {
 		t.Fatalf("expected weekly count in response, got %q", result)
 	}
 }

--- a/internal/app/usecase/handle_message_usecase.go
+++ b/internal/app/usecase/handle_message_usecase.go
@@ -26,6 +26,7 @@ type HandleMessageUsecase struct {
 	broadcastUpdateUC   *BroadcastUpdateUsecase
 	motivationUC        *GetMotivationUsecase
 	helpUC              *GetHelpUsecase
+	jobUC               *JobUsecase
 }
 
 func NewHandleMessageUsecase(
@@ -54,6 +55,7 @@ func NewHandleMessageUsecase(
 		broadcastUpdateUC:   broadcastUpdateUC,
 		motivationUC:        motivationUC,
 		helpUC:              helpUC,
+		jobUC:               NewJobUsecase(leaderboardUC.repo),
 	}
 }
 
@@ -81,6 +83,20 @@ func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, messa
 		return MessageResponse{Text: text}, nil
 	}
 
+	if strings.Contains(msg, "#jobs") {
+		return MessageResponse{Text: uc.jobUC.List()}, nil
+	}
+
+	if strings.Contains(msg, "#job") {
+		idx := strings.Index(msg, "#job")
+		jobID := strings.TrimSpace(msg[idx+len("#job"):])
+		if jobID == "" {
+			return MessageResponse{Text: "Pilih job dengan format: #job <id>. Cek daftar job dengan #jobs."}, nil
+		}
+		text, err := uc.jobUC.Select(ctx, userID, name, jobID)
+		return MessageResponse{Text: text}, err
+	}
+
 	if strings.Contains(msg, "#setname") {
 		idx := strings.Index(msg, "#setname")
 		newName := strings.TrimSpace(message[idx+len("#setname"):])
@@ -95,6 +111,11 @@ func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, messa
 
 	if strings.Contains(msg, "#leaderboard-seasonal") {
 		text, err := uc.leaderboardUC.ExecuteSeasonal(ctx)
+		return MessageResponse{Text: text}, err
+	}
+
+	if strings.Contains(msg, "#ranks") {
+		text, err := uc.leaderboardUC.ExecuteRanks(ctx)
 		return MessageResponse{Text: text}, err
 	}
 

--- a/internal/app/usecase/handle_message_usecase_test.go
+++ b/internal/app/usecase/handle_message_usecase_test.go
@@ -421,8 +421,56 @@ func TestHandleMessage_GamificationCommands(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error for #achievements: %v", err)
 	}
-	if msg.Text == "" || !containsSubstring(msg.Text, "Daftar Achievement") {
+	if msg.Text == "" || !containsSubstring(msg.Text, "Season Badge Challenge") {
 		t.Errorf("#achievements response invalid: %s", msg.Text)
+	}
+}
+
+func TestHandleMessage_JobCommands(t *testing.T) {
+	repo := &mockReportRepo{reports: make(map[string]*domain.Report)}
+	reportUC := usecase.NewReportActivityUsecase(repo)
+	leaderboardUC := usecase.NewGetLeaderboardUsecase(repo)
+	myStatsUC := usecase.NewGetMyStatsUsecase(repo)
+	achievementsUC := usecase.NewGetAchievementsUsecase(repo)
+	comebackUC := usecase.NewComebackChallengeUsecase(repo)
+	updateNameUC := usecase.NewUpdateNameUsecase(repo)
+	handleUC := usecase.NewHandleMessageUsecase(reportUC, leaderboardUC, myStatsUC, achievementsUC, comebackUC, usecase.NewCancelReportUsecase(repo), updateNameUC, nil, usecase.NewBroadcastUpdateUsecase(), usecase.NewGetMotivationUsecase(), usecase.NewGetHelpUsecase())
+
+	ctx := context.Background()
+
+	msg, err := handleUC.Execute(ctx, "user1", "Hunter", "#jobs")
+	if err != nil {
+		t.Fatalf("unexpected error for #jobs: %v", err)
+	}
+	if !containsSubstring(msg.Text, "Daftar Hunter Jobs") || !containsSubstring(msg.Text, "#job ranger") {
+		t.Fatalf("#jobs response should include job list and selection example, got %q", msg.Text)
+	}
+
+	msg, err = handleUC.Execute(ctx, "user1", "Hunter", "#job ranger")
+	if err != nil {
+		t.Fatalf("unexpected error for #job: %v", err)
+	}
+	if !containsSubstring(msg.Text, "Job dipilih") || !containsSubstring(msg.Text, "Ranger") {
+		t.Fatalf("#job response should confirm selected job, got %q", msg.Text)
+	}
+	if repo.reports["user1"].JobClass != "ranger" {
+		t.Fatalf("expected stored job ranger, got %q", repo.reports["user1"].JobClass)
+	}
+
+	msg, err = handleUC.Execute(ctx, "user1", "Hunter", "#mystats")
+	if err != nil {
+		t.Fatalf("unexpected error for #mystats: %v", err)
+	}
+	if !containsSubstring(msg.Text, "Job: Ranger") {
+		t.Fatalf("#mystats should include selected job, got %q", msg.Text)
+	}
+
+	msg, err = handleUC.Execute(ctx, "user1", "Hunter", "#lapor")
+	if err != nil {
+		t.Fatalf("unexpected error for #lapor: %v", err)
+	}
+	if !containsSubstring(msg.Text, "Job: Ranger") {
+		t.Fatalf("#lapor should include selected job, got %q", msg.Text)
 	}
 }
 

--- a/internal/app/usecase/job_usecase.go
+++ b/internal/app/usecase/job_usecase.go
@@ -1,0 +1,62 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/fardannozami/whatsapp-gateway/internal/domain"
+)
+
+type JobUsecase struct {
+	repo domain.ReportRepository
+}
+
+func NewJobUsecase(repo domain.ReportRepository) *JobUsecase {
+	return &JobUsecase{repo: repo}
+}
+
+func (uc *JobUsecase) List() string {
+	sb := strings.Builder{}
+	sb.WriteString("🧭 *Daftar Hunter Jobs*\n")
+	sb.WriteString("Job bersifat role/profile permanen dan tidak reset saat season baru.\n")
+	sb.WriteString("Pilih dengan: `#job <id>`\n")
+	sb.WriteString("Contoh: `#job ranger`\n\n")
+
+	for _, job := range domain.AllJobClasses {
+		sb.WriteString(fmt.Sprintf("%s *%s* (`%s`)\n", job.Icon, job.Name, job.ID))
+		sb.WriteString(fmt.Sprintf("_%s — %s_\n", job.Description, job.Trait))
+	}
+
+	return sb.String()
+}
+
+func (uc *JobUsecase) Select(ctx context.Context, userID, name, jobID string) (string, error) {
+	jobID = strings.ToLower(strings.TrimSpace(jobID))
+	job, ok := domain.GetJobClass(jobID)
+	if !ok {
+		return fmt.Sprintf("Job `%s` tidak tersedia. Cek daftar job dengan #jobs.", jobID), nil
+	}
+
+	report, err := uc.repo.GetReport(ctx, userID)
+	if err != nil {
+		return "", err
+	}
+
+	if report == nil {
+		report = &domain.Report{
+			UserID:         userID,
+			Name:           name,
+			LastReportDate: time.Now().AddDate(-1, 0, 0),
+			Achievements:   "",
+		}
+	}
+
+	report.JobClass = job.ID
+	if err := uc.repo.UpsertReport(ctx, report); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("✅ Job dipilih: %s *%s*\n_%s_\n\nJob ini akan tampil di #mystats dan laporan #lapor berikutnya.", job.Icon, job.Name, job.Description), nil
+}

--- a/internal/app/usecase/report_activity_usecase.go
+++ b/internal/app/usecase/report_activity_usecase.go
@@ -77,6 +77,9 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 		}
 		report.ActivityCount++
 		report.SeasonalActivityCount++
+		if report.Streak > report.SeasonalMaxStreak {
+			report.SeasonalMaxStreak = report.Streak
+		}
 
 		// Handle Centurion Cycle Transition
 		isNewCycle := false
@@ -100,11 +103,13 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 			Streak:                1,
 			ActivityCount:         1,
 			SeasonalActivityCount: 1,
+			SeasonalMaxStreak:     1,
 			LastReportDate:        now,
 			MaxStreak:             0,
 			TotalPoints:           0,
 			SeasonalPoints:        0,
 			Achievements:          "",
+			SeasonalAchievements:  "",
 			ComebackStreak:        1,
 			InactiveDays:          0,
 			StreakFreezes:         1,
@@ -142,14 +147,19 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 	// 3. Store old level to detect level-up
 	oldLevel := domain.GetLevel(report.TotalPoints)
 
-	// 3. Check for new standard achievements
-	newAchievements := domain.CheckNewAchievements(report)
+	// 3. Check for new season badges. Badge progress resets every season, but
+	// lifetime EXP/level remains preserved.
+	newAchievements := domain.CheckNewSeasonAchievements(report)
 	var unlockedNames []string
 	pointsGained := 0
 
 	for _, ach := range newAchievements {
-		report.Achievements = domain.AddAchievement(report.Achievements, ach.ID)
+		report.SeasonalAchievements = domain.AddAchievement(report.SeasonalAchievements, ach.ID)
+		if !domain.HasAchievement(report.Achievements, ach.ID) {
+			report.Achievements = domain.AddAchievement(report.Achievements, ach.ID)
+		}
 		report.TotalPoints += ach.Points
+		report.SeasonalPoints += ach.Points
 		pointsGained += ach.Points
 		unlockedNames = append(unlockedNames, fmt.Sprintf("%s %s (%d pts)", ach.DisplayEmoji, ach.Name, ach.Points))
 	}
@@ -161,6 +171,14 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 		report.TotalPoints += ach.Points
 		pointsGained += ach.Points
 		unlockedNames = append(unlockedNames, fmt.Sprintf("%s %s (%d pts)", ach.DisplayEmoji, ach.Name, ach.Points))
+	}
+
+	freezeAwarded := false
+	for _, ach := range newAchievements {
+		if ach.ID == "streak_4" && report.StreakFreezes < 2 {
+			report.StreakFreezes++
+			freezeAwarded = true
+		}
 	}
 
 	// 5. Detect level-up
@@ -180,6 +198,9 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 		response = fmt.Sprintf("🎉 WELCOME BACK, %s! 🎉\n", name)
 		response += fmt.Sprintf("Kamu kembali setelah %d hari absen. Itu butuh keberanian! 💪\n", report.InactiveDays)
 		response += "Streak kamu direset, tapi totalmu tetap tersimpan.\n"
+		if report.JobClass != "" {
+			response += fmt.Sprintf("🧭 Job: %s\n", domain.FormatJobClass(report.JobClass))
+		}
 		response += fmt.Sprintf("\n📊 Level: %s (Total: %d pts)\n", domain.FormatLevel(report.TotalPoints), report.TotalPoints)
 		response += fmt.Sprintf("📅 Total hari aktif: %d\n", report.ActivityCount)
 
@@ -207,6 +228,9 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 
 		response = fmt.Sprintf("Laporan diterima, %s%s sudah berkeringat %d hari. Lanjutkan 🔥 (streak %d minggu)\n%s",
 			cyclePrefix, name, report.ActivityCount, report.Streak, expBreakdown)
+		if report.JobClass != "" {
+			response += fmt.Sprintf("\n🧭 Job: %s", domain.FormatJobClass(report.JobClass))
+		}
 	}
 
 	// 7. Add Centurion Milestone Message
@@ -241,14 +265,7 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 	}
 
 	if len(unlockedNames) > 0 {
-		freezeAwarded := false
-		for _, ach := range newAchievements {
-			if ach.ID == "streak_4" && report.StreakFreezes < 2 {
-				report.StreakFreezes++
-				freezeAwarded = true
-			}
-		}
-		response += "\n\n🎉 *ACHIEVEMENT UNLOCKED!* 🎉"
+		response += "\n\n🎉 *SEASON BADGE UNLOCKED!* 🎉"
 
 		for _, ach := range newAchievements {
 			response += fmt.Sprintf("\n\n%s *%s* (+%d pts)", ach.DisplayEmoji, ach.Name, ach.Points)

--- a/internal/app/usecase/report_activity_usecase_test.go
+++ b/internal/app/usecase/report_activity_usecase_test.go
@@ -127,16 +127,16 @@ func TestStreak_FirstReport(t *testing.T) {
 	if !containsSubstring(msg, expected) {
 		t.Errorf("Expected message to contain '%s', got '%s'", expected, msg)
 	}
-	// Should also have unlocked "Pemula" achievement
-	if !containsSubstring(msg, "Pemula") {
-		t.Errorf("Expected message to contain achievement 'Pemula', got '%s'", msg)
+	// Should also have unlocked the first season badge.
+	if !containsSubstring(msg, "Awakened Hunter") {
+		t.Errorf("Expected message to contain season badge 'Awakened Hunter', got '%s'", msg)
 	}
-	// Points: 10 base + 5 first season + 10 Pemula + 25 Konsisten = 50
+	// Points: 10 base + 5 first season + 10 Awakened Hunter + 25 E-Rank Consistency = 50
 	if r.TotalPoints != 50 {
 		t.Errorf("First report: expected TotalPoints=50, got %d", r.TotalPoints)
 	}
-	if r.SeasonalPoints != 15 {
-		t.Errorf("First report: expected SeasonalPoints=15, got %d", r.SeasonalPoints)
+	if r.SeasonalPoints != 50 {
+		t.Errorf("First report: expected SeasonalPoints=50, got %d", r.SeasonalPoints)
 	}
 }
 

--- a/internal/app/usecase/reset_session_usecase.go
+++ b/internal/app/usecase/reset_session_usecase.go
@@ -114,18 +114,20 @@ Season %d telah resmi berakhir! 🎉
 ✅ *Yang di-reset:*
 • 📊 Seasonal Points — mulai dari 0
 • 📅 Seasonal Activity — mulai dari 0
-• 🏆 Seasonal Leaderboard — reset
+• ⚔️ Seasonal Max Streak — mulai dari 0
+• 🏅 Season Badges — mulai berburu dari awal
+• 🏆 Rank & Seasonal Leaderboard — reset
 
 💾 *Yang tetap tersimpan:*
 • 🔥 Streak mingguan — lanjutkan!
 • ⭐ Total Points & Level — lifetime progress aman
-• 🏅 Achievements — yang sudah unlock tetap dimiliki
+• 🏅 Achievement archive — yang sudah pernah unlock tetap tersimpan
 • 🛡️ Centurion Cycles — tetap berlaku
 
 ❄️ *Streak Freeze* — reset ke 1 tiap season. Dapat +1 lagi saat capai 4 minggu streak!
 
 🆕 *Season %d dimulai SEKARANG!*
-Semua peserta mulai dari titik yang sama untuk seasonal ranking. Tapi level dan achievement lifetime kamu tetap ada! 💪
+Semua peserta mulai dari titik yang sama untuk seasonal ranking. Tapi level dan EXP lifetime kamu tetap ada! 💪
 
 📌 Langsung laporkan aktivitas pertamamu di Season %d dengan mengirim #lapor!
 

--- a/internal/domain/achievement.go
+++ b/internal/domain/achievement.go
@@ -182,6 +182,137 @@ var AllAchievements = []Achievement{
 	},
 }
 
+// AllSeasonAchievements defines resettable season badges. Lifetime level/EXP is
+// still preserved, but these badge unlock states reset at the season boundary.
+var AllSeasonAchievements = []Achievement{
+	{
+		ID:            "first_report",
+		Name:          "Awakened Hunter",
+		Description:   "Laporan pertama di season ini",
+		Points:        10,
+		DisplayEmoji:  "🐣",
+		UnlockMessage: "Awakening dimulai! Satu laporan pertama membuka gerbang dungeon season ini. Terus naikkan rank-mu! 🚪⚔️",
+		Check:         func(r *Report) bool { return r.SeasonalActivityCount >= 1 },
+	},
+	{
+		ID:            "streak_1",
+		Name:          "E-Rank Consistency",
+		Description:   "1 minggu streak di season ini",
+		Points:        25,
+		DisplayEmoji:  "🔥",
+		UnlockMessage: "Quest mingguan pertama selesai. Api disiplinmu sudah menyala — jangan biarkan padam!",
+		Check:         func(r *Report) bool { return r.SeasonalMaxStreak >= 1 },
+	},
+	{
+		ID:            "streak_2",
+		Name:          "D-Rank Momentum",
+		Description:   "2 minggu streak di season ini",
+		Points:        50,
+		DisplayEmoji:  "⚡",
+		UnlockMessage: "Momentum terbentuk! Dua minggu berturut-turut membuktikan kamu bukan hunter biasa. ⚡",
+		Check:         func(r *Report) bool { return r.SeasonalMaxStreak >= 2 },
+	},
+	{
+		ID:            "streak_3",
+		Name:          "C-Rank Grinder",
+		Description:   "3 minggu streak di season ini",
+		Points:        75,
+		DisplayEmoji:  "💎",
+		UnlockMessage: "Tiga minggu grinding! Stat disiplinmu naik drastis. Dungeon rasa malas mulai terasa kecil. 💎",
+		Check:         func(r *Report) bool { return r.SeasonalMaxStreak >= 3 },
+	},
+	{
+		ID:            "streak_4",
+		Name:          "B-Rank Vanguard",
+		Description:   "4 minggu streak di season ini",
+		Points:        100,
+		DisplayEmoji:  "🛡️",
+		UnlockMessage: "Sebulan penuh bertahan di garis depan. Kamu layak membawa tameng B-Rank Vanguard! 🛡️",
+		Check:         func(r *Report) bool { return r.SeasonalMaxStreak >= 4 },
+	},
+	{
+		ID:            "streak_8",
+		Name:          "A-Rank Hunter",
+		Description:   "8 minggu streak di season ini",
+		Points:        150,
+		DisplayEmoji:  "🏛️",
+		UnlockMessage: "Delapan minggu tanpa menyerah. Aura A-Rank mulai terasa — kamu jadi standar baru di grup! 🏛️",
+		Check:         func(r *Report) bool { return r.SeasonalMaxStreak >= 8 },
+	},
+	{
+		ID:            "streak_12",
+		Name:          "S-Rank Hunter",
+		Description:   "12 minggu streak di season ini",
+		Points:        300,
+		DisplayEmoji:  "⚔️",
+		UnlockMessage: "S-RANK! Dua belas minggu menaklukkan quest. Ini bukan motivasi sesaat — ini sistem hidup. ⚔️👑",
+		Check:         func(r *Report) bool { return r.SeasonalMaxStreak >= 12 },
+	},
+	{
+		ID:            "activity_10",
+		Name:          "Daily Quest x10",
+		Description:   "10 hari aktif di season ini",
+		Points:        20,
+		DisplayEmoji:  "🌟",
+		UnlockMessage: "10 daily quest selesai! Hal kecil yang diulang mulai jadi kekuatan besar. 🌟",
+		Check:         func(r *Report) bool { return r.SeasonalActivityCount >= 10 },
+	},
+	{
+		ID:            "activity_25",
+		Name:          "Dungeon Grinder",
+		Description:   "25 hari aktif di season ini",
+		Points:        50,
+		DisplayEmoji:  "⭐",
+		UnlockMessage: "25 hari aktif! Kamu terus masuk dungeon meski tidak selalu mudah. Respect, hunter. ⭐",
+		Check:         func(r *Report) bool { return r.SeasonalActivityCount >= 25 },
+	},
+	{
+		ID:            "activity_50",
+		Name:          "Raid Captain",
+		Description:   "50 hari aktif di season ini",
+		Points:        100,
+		DisplayEmoji:  "🏅",
+		UnlockMessage: "50 hari aktif dalam satu season. Kamu bukan cuma ikut raid — kamu memimpin ritmenya! 🏅",
+		Check:         func(r *Report) bool { return r.SeasonalActivityCount >= 50 },
+	},
+	{
+		ID:            "activity_100",
+		Name:          "Season Monarch",
+		Description:   "100 hari aktif di season ini",
+		Points:        200,
+		DisplayEmoji:  "💯",
+		UnlockMessage: "MONARCH OF THE SEASON! 100 hari aktif adalah bukti bahwa sistemmu sudah melampaui mood. 💯👑",
+		Check:         func(r *Report) bool { return r.SeasonalActivityCount >= 100 },
+	},
+	{
+		ID:            "streak_16",
+		Name:          "Season Conqueror",
+		Description:   "16 minggu streak di season ini",
+		Points:        400,
+		DisplayEmoji:  "👑",
+		UnlockMessage: "SEASON CONQUEROR! Kamu menaklukkan seluruh season dengan konsistensi. LEGEND! 👑🔥",
+		Check:         func(r *Report) bool { return r.SeasonalMaxStreak >= 16 },
+	},
+	{
+		ID:            "season_hunter",
+		Name:          "Point Hunter",
+		Description:   "Raih 300+ poin dalam season ini",
+		Points:        50,
+		DisplayEmoji:  "🏹",
+		UnlockMessage: "300 poin season! Kamu memburu progress seperti hunter yang tahu targetnya. 🏹🎯",
+		Check:         func(r *Report) bool { return r.SeasonalPoints >= 300 },
+	},
+	{
+		ID:            "season_master",
+		Name:          "Shadow Monarch",
+		Description:   "Raih 500+ poin dalam season ini",
+		Points:        100,
+		DisplayEmoji:  "🌑",
+		UnlockMessage: "500 poin season! Bayangan alasan sudah kamu taklukkan. Rise. 🌑",
+		Check:         func(r *Report) bool { return r.SeasonalPoints >= 500 },
+	},
+}
+
 // ComebackAchievement represents achievements earned by returning after inactivity.
 // These are checked separately because they need InactiveDays context.
 type ComebackAchievement struct {
@@ -268,6 +399,17 @@ func CheckNewAchievements(report *Report) []Achievement {
 	var newlyUnlocked []Achievement
 	for _, a := range AllAchievements {
 		if !HasAchievement(report.Achievements, a.ID) && a.Check(report) {
+			newlyUnlocked = append(newlyUnlocked, a)
+		}
+	}
+	return newlyUnlocked
+}
+
+// CheckNewSeasonAchievements evaluates resettable season badges.
+func CheckNewSeasonAchievements(report *Report) []Achievement {
+	var newlyUnlocked []Achievement
+	for _, a := range AllSeasonAchievements {
+		if !HasAchievement(report.SeasonalAchievements, a.ID) && a.Check(report) {
 			newlyUnlocked = append(newlyUnlocked, a)
 		}
 	}

--- a/internal/domain/level.go
+++ b/internal/domain/level.go
@@ -10,6 +10,23 @@ type Level struct {
 	MinPoints int
 }
 
+// Rank represents a season-scoped Solo-Leveling-inspired rank.
+type Rank struct {
+	Tier      int
+	Name      string
+	Icon      string
+	MinPoints int
+}
+
+// JobClass represents a selectable RPG hunter job for a user profile.
+type JobClass struct {
+	ID          string
+	Name        string
+	Icon        string
+	Description string
+	Trait       string
+}
+
 // AllLevels defines the progression tiers in ascending order.
 // Curved to reward early engagement while making max tier a long-term achievement.
 // With ~17 weeks per 4-month season, dedicated users can reach Tier 5-6 in season 1,
@@ -25,6 +42,30 @@ var AllLevels = []Level{
 	{Tier: 8, Name: "God", Icon: "⚡", MinPoints: 3500},
 }
 
+// AllSeasonRanks defines rank titles for the current season only.
+// Level remains lifetime; rank resets with seasonal points.
+var AllSeasonRanks = []Rank{
+	{Tier: 1, Name: "E-Rank Hunter", Icon: "🟫", MinPoints: 0},
+	{Tier: 2, Name: "D-Rank Hunter", Icon: "🟩", MinPoints: 100},
+	{Tier: 3, Name: "C-Rank Hunter", Icon: "🟦", MinPoints: 250},
+	{Tier: 4, Name: "B-Rank Hunter", Icon: "🟪", MinPoints: 450},
+	{Tier: 5, Name: "A-Rank Hunter", Icon: "🟥", MinPoints: 700},
+	{Tier: 6, Name: "S-Rank Hunter", Icon: "🟨", MinPoints: 1000},
+	{Tier: 7, Name: "Monarch", Icon: "👑", MinPoints: 1500},
+}
+
+// AllJobClasses defines jobs inspired by Solo Leveling hunter roles and common
+// RPG archetypes. Jobs are cosmetic profile flavor and do not reset per season.
+var AllJobClasses = []JobClass{
+	{ID: "fighter", Name: "Fighter", Icon: "⚔️", Description: "Melee hunter yang mengandalkan disiplin, stamina, dan daya tahan.", Trait: "cocok untuk yang suka latihan strength/functional"},
+	{ID: "tank", Name: "Tanker", Icon: "🛡️", Description: "Frontliner yang kuat bertahan dan konsisten menjaga formasi.", Trait: "cocok untuk yang fokus konsistensi dan habit jangka panjang"},
+	{ID: "assassin", Name: "Assassin", Icon: "🗡️", Description: "Hunter cepat, gesit, dan tajam mengeksekusi sesi singkat tapi intens.", Trait: "cocok untuk HIIT, sprint, atau workout cepat"},
+	{ID: "mage", Name: "Mage", Icon: "🔥", Description: "Damage dealer jarak jauh dengan energi eksplosif dan variasi latihan.", Trait: "cocok untuk yang suka eksplor banyak jenis olahraga"},
+	{ID: "ranger", Name: "Ranger", Icon: "🏹", Description: "Hunter presisi yang unggul di endurance, pace, dan jarak.", Trait: "cocok untuk lari, sepeda, jalan jauh, hiking"},
+	{ID: "healer", Name: "Healer", Icon: "💚", Description: "Support hunter yang menjaga recovery, mobilitas, dan kesehatan jangka panjang.", Trait: "cocok untuk yoga, mobility, recovery, pola hidup sehat"},
+	{ID: "necromancer", Name: "Necromancer", Icon: "🌑", Description: "Hidden job yang bangkit dari kegagalan dan mengubah comeback jadi kekuatan.", Trait: "cocok untuk comeback setelah absen dan bangun sistem baru"},
+}
+
 // GetLevel returns the current level for the given total points.
 func GetLevel(totalPoints int) Level {
 	current := AllLevels[0]
@@ -34,6 +75,42 @@ func GetLevel(totalPoints int) Level {
 		}
 	}
 	return current
+}
+
+// GetSeasonRank returns the current season rank for seasonal points.
+func GetSeasonRank(seasonalPoints int) Rank {
+	current := AllSeasonRanks[0]
+	for _, r := range AllSeasonRanks {
+		if seasonalPoints >= r.MinPoints {
+			current = r
+		}
+	}
+	return current
+}
+
+// FormatSeasonRank returns a display string like "C-Rank Hunter 🟦".
+func FormatSeasonRank(seasonalPoints int) string {
+	rank := GetSeasonRank(seasonalPoints)
+	return fmt.Sprintf("%s %s", rank.Name, rank.Icon)
+}
+
+// GetJobClass returns a job class by id.
+func GetJobClass(id string) (*JobClass, bool) {
+	for _, job := range AllJobClasses {
+		if job.ID == id {
+			return &job, true
+		}
+	}
+	return nil, false
+}
+
+// FormatJobClass returns the display string for a job id.
+func FormatJobClass(id string) string {
+	job, ok := GetJobClass(id)
+	if !ok {
+		return "Belum memilih job"
+	}
+	return fmt.Sprintf("%s %s", job.Name, job.Icon)
 }
 
 // GetNextLevel returns the next level and how many points are needed, or nil if max level.

--- a/internal/domain/report.go
+++ b/internal/domain/report.go
@@ -8,6 +8,7 @@ import (
 type Report struct {
 	UserID                string    `json:"user_id" db:"user_id"`
 	Name                  string    `json:"name" db:"name"`
+	JobClass              string    `json:"job_class" db:"job_class"`
 	Streak                int       `json:"streak" db:"streak"`
 	ActivityCount         int       `json:"activity_count" db:"activity_count"`
 	LastReportDate        time.Time `json:"last_report_date" db:"last_report_date"`
@@ -19,6 +20,8 @@ type Report struct {
 	CenturionCycles       int       `json:"centurion_cycles" db:"centurion_cycles"`
 	SeasonalPoints        int       `json:"seasonal_points" db:"seasonal_points"`
 	SeasonalActivityCount int       `json:"seasonal_activity_count" db:"seasonal_activity_count"`
+	SeasonalMaxStreak     int       `json:"seasonal_max_streak" db:"seasonal_max_streak"`
+	SeasonalAchievements  string    `json:"seasonal_achievements" db:"seasonal_achievements"`
 	StreakFreezes         int       `json:"streak_freezes" db:"streak_freezes"`
 }
 

--- a/internal/infra/sqlite/report_repository.go
+++ b/internal/infra/sqlite/report_repository.go
@@ -20,20 +20,22 @@ func NewReportRepository(db *sql.DB) *ReportRepository {
 	return &ReportRepository{db: db}
 }
 
-const selectColumns = `user_id, name, streak, activity_count, last_report_date, 
+const selectColumns = `user_id, name, COALESCE(job_class, ''), streak, activity_count, last_report_date, 
 	COALESCE(max_streak, 0), COALESCE(total_points, 0), COALESCE(achievements, ''),
 	COALESCE(comeback_streak, 0), COALESCE(inactive_days, 0), COALESCE(centurion_cycles, 0),
 	COALESCE(seasonal_points, 0), COALESCE(seasonal_activity_count, 0),
+	COALESCE(seasonal_max_streak, 0), COALESCE(seasonal_achievements, ''),
 	COALESCE(streak_freezes, 0)`
 
 func scanReport(scanner interface{ Scan(dest ...any) error }) (*domain.Report, error) {
 	var report domain.Report
 	var lastReportDate string
 	err := scanner.Scan(
-		&report.UserID, &report.Name, &report.Streak, &report.ActivityCount,
+		&report.UserID, &report.Name, &report.JobClass, &report.Streak, &report.ActivityCount,
 		&lastReportDate, &report.MaxStreak, &report.TotalPoints, &report.Achievements,
 		&report.ComebackStreak, &report.InactiveDays, &report.CenturionCycles,
 		&report.SeasonalPoints, &report.SeasonalActivityCount,
+		&report.SeasonalMaxStreak, &report.SeasonalAchievements,
 		&report.StreakFreezes,
 	)
 	if err == sql.ErrNoRows {
@@ -59,10 +61,11 @@ func (r *ReportRepository) GetReport(ctx context.Context, userID string) (*domai
 
 func upsertReport(ctx context.Context, execer execContexter, report *domain.Report) error {
 	query := `
-		INSERT INTO user_reports (user_id, name, streak, activity_count, last_report_date, max_streak, total_points, achievements, comeback_streak, inactive_days, centurion_cycles, seasonal_points, seasonal_activity_count, streak_freezes)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO user_reports (user_id, name, job_class, streak, activity_count, last_report_date, max_streak, total_points, achievements, comeback_streak, inactive_days, centurion_cycles, seasonal_points, seasonal_activity_count, seasonal_max_streak, seasonal_achievements, streak_freezes)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(user_id) DO UPDATE SET
 			name = excluded.name,
+			job_class = excluded.job_class,
 			streak = excluded.streak,
 			activity_count = excluded.activity_count,
 			last_report_date = excluded.last_report_date,
@@ -74,13 +77,16 @@ func upsertReport(ctx context.Context, execer execContexter, report *domain.Repo
 			centurion_cycles = excluded.centurion_cycles,
 			seasonal_points = excluded.seasonal_points,
 			seasonal_activity_count = excluded.seasonal_activity_count,
+			seasonal_max_streak = excluded.seasonal_max_streak,
+			seasonal_achievements = excluded.seasonal_achievements,
 			streak_freezes = excluded.streak_freezes
 	`
 	_, err := execer.ExecContext(ctx, query,
-		report.UserID, report.Name, report.Streak, report.ActivityCount,
+		report.UserID, report.Name, report.JobClass, report.Streak, report.ActivityCount,
 		report.LastReportDate.Format(time.RFC3339), report.MaxStreak, report.TotalPoints,
 		report.Achievements, report.ComebackStreak, report.InactiveDays, report.CenturionCycles,
-		report.SeasonalPoints, report.SeasonalActivityCount, report.StreakFreezes,
+		report.SeasonalPoints, report.SeasonalActivityCount, report.SeasonalMaxStreak,
+		report.SeasonalAchievements, report.StreakFreezes,
 	)
 	return err
 }
@@ -193,6 +199,8 @@ func (r *ReportRepository) ResetAllReports(ctx context.Context) error {
 		UPDATE user_reports
 		SET seasonal_points = 0,
 		    seasonal_activity_count = 0,
+		    seasonal_max_streak = 0,
+		    seasonal_achievements = '',
 		    streak_freezes = 1
 	`)
 	return err
@@ -252,6 +260,7 @@ func (r *ReportRepository) InitTable(ctx context.Context) error {
 	// Simple migration: try to add columns if they don't exist
 	// Ignore error if they already exist
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN activity_count INTEGER DEFAULT 0")
+	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN job_class TEXT DEFAULT ''")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN max_streak INTEGER DEFAULT 0")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN total_points INTEGER DEFAULT 0")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN achievements TEXT DEFAULT ''")
@@ -260,6 +269,8 @@ func (r *ReportRepository) InitTable(ctx context.Context) error {
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN centurion_cycles INTEGER DEFAULT 0")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN seasonal_points INTEGER DEFAULT 0")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN seasonal_activity_count INTEGER DEFAULT 0")
+	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN seasonal_max_streak INTEGER DEFAULT 0")
+	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN seasonal_achievements TEXT DEFAULT ''")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN streak_freezes INTEGER DEFAULT 1")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE strava_accounts ADD COLUMN name TEXT")
 


### PR DESCRIPTION
- Introduce seasonal badges system with AllSeasonAchievements and seasonal reset behavior; lifetime level/EXP preserved.
- Persist and display job selection by adding JobClass domain type, Report.JobClass, and repository support.
- Add hunter UI for jobs (#jobs, #job [id]) and display job in mystats.
- Implement #ranks with ExecuteRanks to render season-only rankings and reset info.
- Enrich mystats output with season rank, seasonal points, season badges, season days, weekly days, and best-season streak.
- Update reset session messaging to reflect season resets and lifetime preservation.
- Update help and README to include new commands and seasonal behaviors.
- Update tests to align with season badges, job features, and seasonal stats.