### PR TITLE
Switch to season cycles and enable level tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ Bot hanya merespon perintah berikut di dalam grup yang telah dikonfigurasi (`GRO
 | `#job [id]` | Memilih hunter job. Contoh: `#job ranger`. |
 | `#comeback` | Menampilkan status comeback challenge setelah absen. |
 | `#motivasi` | Menampilkan pesan motivasi acak untuk semangat berolahraga. |
-| `#help` | Menampilkan panduan penggunaan bot dan daftar command. |
+| `#help` | Menampilkan list command yang tersedia. |
+| `#tutorial` | Menampilkan panduan lengkap cara memakai bot. |
 | `#strava` | Menghubungkan akun Strava untuk laporan otomatis. |
 | `#setname [nama]` | Mengubah nama tampilan di leaderboard. |
 
@@ -103,7 +104,7 @@ Bot hanya merespon perintah berikut di dalam grup yang telah dikonfigurasi (`GRO
 - **Season Ranks (`#ranks`)**: Rank ala hunter dihitung dari seasonal points dan reset setiap season.
 - **Hunter Jobs (`#jobs`, `#job [id]`)**: Pilih job profile seperti fighter, tanker, assassin, mage, ranger, healer, atau necromancer. Job tampil di `#mystats` dan laporan harian.
 - **Season Badges**: Badge reset setiap season supaya semua member mulai berburu dari awal.
-- **Lifetime Level & EXP**: Total poin, level, streak mingguan, dan progress penting user tetap tersimpan lintas season.
+- **Lifetime Level & EXP**: Total poin dan level numerik (`Lv.0+`) tetap tersimpan lintas season. EXP naik level memakai kurva `5×level² + 50×level + 100` agar makin tinggi level makin lama naiknya.
 - **Milestone Notification**: Dapat notifikasi khusus saat mencapai streak tertenu (7, 14, 30 hari, dst).
 - **Leaderboard**: Bersaing dengan teman untuk streak tertinggi.
 

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -230,7 +230,7 @@ func main() {
 
 	log.Println("Bot is running... Press Ctrl+C to exit.")
 
-	// Schedule Session 2 reset at May 1, 2026 00:00 WIB
+	// Schedule seasonal reset every 4 months at 00:00 WIB.
 	resetCtx, resetCancel := context.WithCancel(context.Background())
 	defer resetCancel()
 	usecase.ScheduleSessionReset(resetCtx, resetSessionUC, func() *whatsmeow.Client {

--- a/internal/app/usecase/broadcast_update_usecase.go
+++ b/internal/app/usecase/broadcast_update_usecase.go
@@ -1,5 +1,10 @@
 package usecase
 
+import (
+	"fmt"
+	"time"
+)
+
 type BroadcastUpdateUsecase struct{}
 
 func NewBroadcastUpdateUsecase() *BroadcastUpdateUsecase {
@@ -7,28 +12,36 @@ func NewBroadcastUpdateUsecase() *BroadcastUpdateUsecase {
 }
 
 func (uc *BroadcastUpdateUsecase) Execute() string {
-	return `📢 *PENGUMUMAN PENTING: SESSION 1 BERAKHIR!* ⚠️
+	seasonNumber, _ := GetCurrentSessionInfo(time.Now())
+	nextSeason, _ := GetCurrentSessionInfo(GetNextResetTime(time.Now()))
+
+	return fmt.Sprintf(`📢 *PENGUMUMAN SEASON CHALLENGE* ⚠️
 
 Halo para pejuang keringat! 🏋️‍♂️
 
-Kami ingin mengumumkan bahwa *Session 1* dari challenge "30 Days of Sweat" akan *resmi berakhir pada tanggal 30 April 2026*.
+Season %d sedang berjalan. Setelah season berjalan selesai, bot akan otomatis lanjut ke Season %d dan seterusnya setiap 4 bulan.
 
 ⏰ *Jadwal Penting:*
-• 📅 *30 April 2026* — Hari terakhir Session 1
-• 🔄 *1 Mei 2026* — Session 2 dimulai dari NOL
+• 📅 Season berjalan: *Season %d*
+• 🔄 Reset berikutnya: *Season %d* dimulai dari seasonal progress baru
 
-🗑️ *Yang Akan Di-Reset pada Session 2:*
-• 🏆 Leaderboard — reset total
-• 🔥 Streak mingguan — mulai dari 0
-• 📊 Jumlah hari aktif — mulai dari 0
-• 🏅 Achievements — reset semua
-• ⭐ Points & Level — mulai dari awal
-• 🛡️ Centurion Cycles — reset
+🗑️ *Yang Akan Di-Reset Saat Season Baru:*
+• 📊 Seasonal Points
+• 📅 Seasonal Activity
+• ⚔️ Seasonal Max Streak
+• 🏅 Season Badges
+• 🏆 Rank & Seasonal Leaderboard
+
+💾 *Yang Tetap Aman:*
+• ⭐ Total Points, EXP & Level lifetime
+• 🔥 Streak mingguan
+• 🏅 Achievement archive
+• 🛡️ Centurion Cycles
 
 💡 *Artinya:*
-Semua data akan *dihapus* dan kita akan mulai dari awal lagi di Session 2. Ini adalah kesempatan baru bagi semua orang untuk bersaing dari titik yang sama! 🎯
+Seasonal ranking mulai dari awal, tapi progres lifetime tetap lanjut. Ini kesempatan baru untuk berburu rank tanpa kehilangan level! 🎯
 
-📌 Manfaatkan sisa waktu di Session 1 ini sebaik mungkin. Laporkan aktivitas terakhirmu sebelum 30 April!
+📌 Manfaatkan Season %d ini sebaik mungkin. Laporkan aktivitasmu dengan #lapor!
 
-*Session 2 dimulai 1 Mei 2026. Siap-siap untuk petualangan baru!* 🚀🔥`
+*Semangat Season %d!* 🚀🔥`, seasonNumber, nextSeason, seasonNumber, nextSeason, seasonNumber, seasonNumber)
 }

--- a/internal/app/usecase/get_achievements_usecase.go
+++ b/internal/app/usecase/get_achievements_usecase.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/fardannozami/whatsapp-gateway/internal/domain"
 )
@@ -39,9 +40,12 @@ func (uc *GetAchievementsUsecase) Execute(ctx context.Context) (string, error) {
 		}
 	}
 
+	seasonNumber, _ := GetCurrentSessionInfo(time.Now())
+
 	sb := strings.Builder{}
-	sb.WriteString("🎖️ *Season Badge Challenge*\n")
-	sb.WriteString("Badge di bawah ini reset setiap season. Level & EXP lifetime tetap aman.\n\n")
+	sb.WriteString(fmt.Sprintf("🎖️ *Season Badge Challenge — Season %d*\n", seasonNumber))
+	sb.WriteString("Badge di bawah ini reset setiap season. Level & EXP lifetime tetap aman.\n")
+	sb.WriteString("Notifikasi #lapor hanya menampilkan badge terbaru; detail lengkapnya ada di sini.\n\n")
 
 	for _, ach := range domain.AllSeasonAchievements {
 		count := stats[ach.ID]
@@ -52,8 +56,25 @@ func (uc *GetAchievementsUsecase) Execute(ctx context.Context) (string, error) {
 			icon = "🔒"
 		}
 
-		sb.WriteString(fmt.Sprintf("%s %s — %s (%d/%d member)\n", icon, ach.Name, ach.Description, count, totalMembers))
+		sb.WriteString(fmt.Sprintf("%s *%s* (+%d pts)\n", icon, ach.Name, ach.Points))
+		sb.WriteString(fmt.Sprintf("   Syarat: %s (%d/%d member)\n", ach.Description, count, totalMembers))
+		if ach.UnlockMessage != "" {
+			sb.WriteString(fmt.Sprintf("   _%s_\n", ach.UnlockMessage))
+		}
+		sb.WriteString("\n")
 	}
+
+	sb.WriteString("🔄 *Comeback Badges*\n")
+	for _, ach := range domain.AllComebackAchievements {
+		sb.WriteString(fmt.Sprintf("%s *%s* (+%d pts)\n", ach.DisplayEmoji, ach.Name, ach.Points))
+		sb.WriteString(fmt.Sprintf("   Syarat: absen minimal %d hari, lalu comeback streak %d minggu.\n", ach.MinInactiveDays, ach.MinComebackStreak))
+		if ach.UnlockMessage != "" {
+			sb.WriteString(fmt.Sprintf("   _%s_\n", ach.UnlockMessage))
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("⚔️ Level numerik memakai EXP lifetime: Lv berikutnya butuh `5×level² + 50×level + 100` EXP.")
 
 	return sb.String(), nil
 }

--- a/internal/app/usecase/get_help_usecase.go
+++ b/internal/app/usecase/get_help_usecase.go
@@ -61,6 +61,27 @@ func NewGetHelpUsecase() *GetHelpUsecase {
 }
 
 func (uc *GetHelpUsecase) Execute() string {
+	return `🤖 *Command Lapor Bot*
+
+📝 #lapor — laporan aktivitas harian
+❌ #cancel — batalkan laporan hari ini
+📊 #mystats — statistik personal
+🏆 #leaderboard — leaderboard lifetime
+📅 #leaderboard-weekly — leaderboard minggu ini
+🏹 #leaderboard-seasonal — leaderboard season
+🎖️ #ranks — rank hunter season
+🏅 #achievements — detail badge dan syarat unlock
+🔄 #comeback — progress comeback challenge
+🧭 #jobs — daftar job
+🧭 #job [id] — pilih job hunter
+✨ #motivasi — quote motivasi
+🏃 #strava — hubungkan Strava via chat pribadi
+✏️ #setname [nama] — ubah nama tampil
+📚 #tutorial — cara pakai bot lengkap
+❓ #help — list command ini`
+}
+
+func (uc *GetHelpUsecase) ExecuteTutorial() string {
 	msg := "📚 *Panduan Penggunaan Lapor Bot* 📚\n\n"
 	msg += "Halo! Aku adalah bot untuk melacak aktivitas harian workout dan olahraga grup ini.\n"
 	msg += "Kamu bisa menggunakan perintah berikut:\n\n"
@@ -69,6 +90,10 @@ func (uc *GetHelpUsecase) Execute() string {
 		msg += fmt.Sprintf("%d. %s *%s*\n%s\n\n", i+1, section.emoji, section.title, section.content)
 	}
 
+	msg += "⚔️ *Level Numerik*\n"
+	msg += "Level lifetime dimulai dari Lv.0 dan naik dari total points/EXP. Semakin tinggi level, EXP yang dibutuhkan makin besar: `5×level² + 50×level + 100`. Season boleh reset, tapi level lifetime tetap lanjut.\n\n"
+	msg += "🏅 *Badge*\n"
+	msg += "Notifikasi #lapor hanya menampilkan badge terbaru supaya ringkas. Untuk syarat, poin, dan cerita unlock lengkap, buka #achievements.\n\n"
 	msg += "_Catatan: Bot hanya merespon di grup yang sudah dikonfigurasi. Semangat terus! 💪_"
 	return msg
 }

--- a/internal/app/usecase/get_leaderboard_usecase.go
+++ b/internal/app/usecase/get_leaderboard_usecase.go
@@ -30,7 +30,6 @@ func (uc *GetLeaderboardUsecase) Execute(ctx context.Context) (string, error) {
 
 	// Session-aware start date (auto-cycles every 4 months)
 	sessionNumber, sessionStart := GetCurrentSessionInfo(now)
-	_ = sessionNumber
 	startDate := time.Date(sessionStart.Year(), sessionStart.Month(), sessionStart.Day(), 0, 0, 0, 0, time.UTC)
 
 	challengeDay := int(displayDate.Sub(startDate).Hours()/24) + 1
@@ -84,7 +83,7 @@ func (uc *GetLeaderboardUsecase) Execute(ctx context.Context) (string, error) {
 
 		seasonalInfo := ""
 		if r.SeasonalPoints > 0 {
-			seasonalInfo = fmt.Sprintf(" | Season: %d pts", r.SeasonalPoints)
+			seasonalInfo = fmt.Sprintf(" | Season %d: %d pts", sessionNumber, r.SeasonalPoints)
 		}
 
 		if weeksSinceLastReport <= 1 {
@@ -107,7 +106,7 @@ func (uc *GetLeaderboardUsecase) ExecuteSeasonal(ctx context.Context) (string, e
 	}
 
 	now := time.Now()
-	_, sessionStart := GetCurrentSessionInfo(now)
+	seasonNumber, sessionStart := GetCurrentSessionInfo(now)
 	_ = sessionStart
 
 	// Sort by seasonal points descending
@@ -119,7 +118,7 @@ func (uc *GetLeaderboardUsecase) ExecuteSeasonal(ctx context.Context) (string, e
 	})
 
 	sb := strings.Builder{}
-	sb.WriteString("🏆 *Seasonal Leaderboard*\n\n")
+	sb.WriteString(fmt.Sprintf("🏆 *Season %d Leaderboard*\n\n", seasonNumber))
 
 	if len(reports) == 0 {
 		sb.WriteString("Belum ada yang aktif di season ini.\n")

--- a/internal/app/usecase/get_mystats_usecase.go
+++ b/internal/app/usecase/get_mystats_usecase.go
@@ -39,7 +39,7 @@ func (uc *GetMyStatsUsecase) Execute(ctx context.Context, userID, name string) (
 		return "", err
 	}
 
-	_, sessionStart := GetCurrentSessionInfo(now)
+	seasonNumber, sessionStart := GetCurrentSessionInfo(now)
 	seasonStart := time.Date(sessionStart.Year(), sessionStart.Month(), sessionStart.Day(), 0, 0, 0, 0, time.UTC)
 	seasonEnd := GetNextResetTime(now)
 	seasonEntries, err := uc.repo.GetActivityCountsByDateRange(ctx, seasonStart, seasonEnd)
@@ -67,11 +67,16 @@ func (uc *GetMyStatsUsecase) Execute(ctx context.Context, userID, name string) (
 	sb.WriteString(fmt.Sprintf("📊 Statistik kamu, %s:\n\n", report.Name))
 
 	// Level display
-	sb.WriteString(fmt.Sprintf("🎖️ Level: %s (lifetime)\n", domain.FormatLevel(report.TotalPoints)))
+	actualLevel := domain.NumericLevelFromTotalPoints(report.TotalPoints)
+	if report.Level != actualLevel {
+		report.Level = actualLevel
+	}
+	sb.WriteString(fmt.Sprintf("🎖️ Level: Lv.%d • %s (lifetime)\n", report.Level, domain.FormatLevel(report.TotalPoints)))
 	sb.WriteString(fmt.Sprintf("🧭 Job: %s\n", domain.FormatJobClass(report.JobClass)))
-	sb.WriteString(fmt.Sprintf("📈 %s\n\n", domain.FormatProgressBar(report.TotalPoints)))
+	sb.WriteString(fmt.Sprintf("📈 %s\n", domain.FormatNumericLevelProgressBar(report.TotalPoints)))
+	sb.WriteString(fmt.Sprintf("📊 %s\n\n", domain.FormatProgressBar(report.TotalPoints)))
 
-	sb.WriteString(fmt.Sprintf("🏹 Rank season: %s\n", domain.FormatSeasonRank(report.SeasonalPoints)))
+	sb.WriteString(fmt.Sprintf("🏹 Rank Season %d: %s\n", seasonNumber, domain.FormatSeasonRank(report.SeasonalPoints)))
 	sb.WriteString(fmt.Sprintf("🌟 Poin season: %d\n", report.SeasonalPoints))
 	sb.WriteString(fmt.Sprintf("🏅 Badge season: %d/%d\n", seasonBadgeCount, len(domain.AllSeasonAchievements)))
 	sb.WriteString(fmt.Sprintf("🗓️ Hari season: %d\n", seasonCount))
@@ -92,6 +97,13 @@ func (uc *GetMyStatsUsecase) Execute(ctx context.Context, userID, name string) (
 	sb.WriteString(fmt.Sprintf("📅 Total hari aktif (lifetime): %d\n", report.ActivityCount))
 	sb.WriteString(fmt.Sprintf("⭐ Total poin (lifetime): %d\n", report.TotalPoints))
 
+	if recentBadges := domain.RecentAchievementSummaries(report.Achievements, 3); len(recentBadges) > 0 {
+		sb.WriteString("\n🏅 Badge terbaru:\n")
+		for _, badge := range recentBadges {
+			sb.WriteString(fmt.Sprintf("%s %s\n", badge.DisplayEmoji, badge.Name))
+		}
+	}
+
 	// Comeback status
 	if report.InactiveDays > 0 && report.ComebackStreak > 0 && report.ComebackStreak < 30 {
 		sb.WriteString(fmt.Sprintf("\n🔄 Comeback streak: %d minggu (setelah %d hari absen)\n", report.ComebackStreak, report.InactiveDays))
@@ -109,8 +121,8 @@ func (uc *GetMyStatsUsecase) Execute(ctx context.Context, userID, name string) (
 		}
 	}
 
-	sb.WriteString("\nLihat ranking season: #ranks\n")
-	sb.WriteString("Lihat daftar badge: #achievements")
+	sb.WriteString(fmt.Sprintf("\nLihat ranking Season %d: #ranks\n", seasonNumber))
+	sb.WriteString("Detail semua badge: #achievements")
 
 	return sb.String(), nil
 }

--- a/internal/app/usecase/handle_message_usecase.go
+++ b/internal/app/usecase/handle_message_usecase.go
@@ -62,6 +62,11 @@ func NewHandleMessageUsecase(
 func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, message string) (MessageResponse, error) {
 	msg := strings.ToLower(strings.TrimSpace(message))
 
+	if strings.Contains(msg, "#tutorial") {
+		text := uc.helpUC.ExecuteTutorial()
+		return MessageResponse{Text: text}, nil
+	}
+
 	if strings.Contains(msg, "#help") {
 		text := uc.helpUC.Execute()
 		return MessageResponse{Text: text}, nil

--- a/internal/app/usecase/report_activity_usecase.go
+++ b/internal/app/usecase/report_activity_usecase.go
@@ -120,6 +120,7 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 	if report.MaxStreak == 0 {
 		report.MaxStreak = 1
 	}
+	oldNumericLevel := domain.NumericLevelFromTotalPoints(report.TotalPoints)
 
 	// 1. Update Max Streak
 	newRecord := false
@@ -144,13 +145,9 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 	report.TotalPoints += reportPoints
 	report.SeasonalPoints += reportPoints
 
-	// 3. Store old level to detect level-up
-	oldLevel := domain.GetLevel(report.TotalPoints)
-
 	// 3. Check for new season badges. Badge progress resets every season, but
 	// lifetime EXP/level remains preserved.
 	newAchievements := domain.CheckNewSeasonAchievements(report)
-	var unlockedNames []string
 	pointsGained := 0
 
 	for _, ach := range newAchievements {
@@ -161,7 +158,6 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 		report.TotalPoints += ach.Points
 		report.SeasonalPoints += ach.Points
 		pointsGained += ach.Points
-		unlockedNames = append(unlockedNames, fmt.Sprintf("%s %s (%d pts)", ach.DisplayEmoji, ach.Name, ach.Points))
 	}
 
 	// 4. Check for new comeback achievements
@@ -170,7 +166,6 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 		report.Achievements = domain.AddAchievement(report.Achievements, ach.ID)
 		report.TotalPoints += ach.Points
 		pointsGained += ach.Points
-		unlockedNames = append(unlockedNames, fmt.Sprintf("%s %s (%d pts)", ach.DisplayEmoji, ach.Name, ach.Points))
 	}
 
 	freezeAwarded := false
@@ -181,9 +176,10 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 		}
 	}
 
-	// 5. Detect level-up
-	newLevel := domain.GetLevel(report.TotalPoints)
-	leveledUp := newLevel.Tier > oldLevel.Tier
+	// 5. Persist numeric RPG level. It is derived from lifetime EXP, then stored
+	// so the value remains available across season resets and deployments.
+	report.Level = domain.NumericLevelFromTotalPoints(report.TotalPoints)
+	leveledUp := report.Level > oldNumericLevel
 
 	if err := uc.repo.UpsertReportWithActivity(ctx, report, today); err != nil {
 		return "", err
@@ -201,7 +197,7 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 		if report.JobClass != "" {
 			response += fmt.Sprintf("🧭 Job: %s\n", domain.FormatJobClass(report.JobClass))
 		}
-		response += fmt.Sprintf("\n📊 Level: %s (Total: %d pts)\n", domain.FormatLevel(report.TotalPoints), report.TotalPoints)
+		response += fmt.Sprintf("\n📊 Level: Lv.%d • %s (Total: %d pts)\n", report.Level, domain.FormatLevel(report.TotalPoints), report.TotalPoints)
 		response += fmt.Sprintf("📅 Total hari aktif: %d\n", report.ActivityCount)
 
 		// Show comeback challenge info
@@ -261,29 +257,23 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 	}
 
 	if leveledUp {
-		response += fmt.Sprintf("\n\n⬆️ LEVEL UP! %s → %s %s", oldLevel.Name, newLevel.Name, newLevel.Icon)
+		response += fmt.Sprintf("\n\n⚔️ *LEVEL UP!* Lv.%d → Lv.%d", oldNumericLevel, report.Level)
 	}
 
-	if len(unlockedNames) > 0 {
-		response += "\n\n🎉 *SEASON BADGE UNLOCKED!* 🎉"
-
+	if len(newAchievements)+len(comebackAchievements) > 0 {
+		response += "\n\n🏅 *Badge baru:*"
 		for _, ach := range newAchievements {
-			response += fmt.Sprintf("\n\n%s *%s* (+%d pts)", ach.DisplayEmoji, ach.Name, ach.Points)
-			if ach.UnlockMessage != "" {
-				response += fmt.Sprintf("\n_%s_", ach.UnlockMessage)
-			}
+			response += fmt.Sprintf("\n%s %s (+%d pts)", ach.DisplayEmoji, ach.Name, ach.Points)
 		}
 		for _, ach := range comebackAchievements {
-			response += fmt.Sprintf("\n\n%s *%s* (+%d pts)", ach.DisplayEmoji, ach.Name, ach.Points)
-			if ach.UnlockMessage != "" {
-				response += fmt.Sprintf("\n_%s_", ach.UnlockMessage)
-			}
+			response += fmt.Sprintf("\n%s %s (+%d pts)", ach.DisplayEmoji, ach.Name, ach.Points)
 		}
 
 		if freezeAwarded {
 			response += fmt.Sprintf("\n\n❄️ Bonus: +1 Streak Freeze! (Total: %d)", report.StreakFreezes)
 		}
 
+		response += "\nDetail badge & cerita unlock: #achievements"
 		response += fmt.Sprintf("\n\n💬 _\"%s\"_", RandomQuote())
 	}
 
@@ -293,8 +283,8 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 	}
 
 	// Show progress bar
-	progressBar := domain.FormatProgressBar(report.TotalPoints)
-	response += fmt.Sprintf("\n%s", progressBar)
+	response += fmt.Sprintf("\n%s", domain.FormatNumericLevelProgressBar(report.TotalPoints))
+	response += fmt.Sprintf("\n%s", domain.FormatProgressBar(report.TotalPoints))
 
 	return response, nil
 }

--- a/internal/app/usecase/reset_session_usecase.go
+++ b/internal/app/usecase/reset_session_usecase.go
@@ -24,19 +24,22 @@ func NewResetSessionUsecase(repo domain.ReportRepository) *ResetSessionUsecase {
 	return &ResetSessionUsecase{repo: repo}
 }
 
-// GetCurrentSessionInfo returns the current session number and its start date.
-// Sessions cycle every 4 months starting from January 2026.
-// Session 1: Jan 1, 2026 - Apr 30, 2026
-// Session 2: May 1, 2026 - Aug 31, 2026
-// Session 3: Sep 1, 2026 - Dec 31, 2026
-// Session 4: Jan 1, 2027 - Apr 30, 2027
+// GetCurrentSessionInfo returns the current season number and its start date.
+// Seasons cycle every 4 months. This bot's public season counter starts from
+// the current launch season so members see Season 1 first, then Season 2 after
+// the next reset.
+// Season 1: May 1, 2026 - Aug 31, 2026
+// Season 2: Sep 1, 2026 - Dec 31, 2026
+// Season 3: Jan 1, 2027 - Apr 30, 2027
 // ...and so on.
 func GetCurrentSessionInfo(now time.Time) (sessionNumber int, sessionStart time.Time) {
 	loc := time.FixedZone("WIB", 7*3600)
 	now = now.In(loc)
 
-	// Base: Session 1 starts Jan 1, 2026
+	// Base: Season 1 starts with this bot's launch season.
 	baseYear := 2026
+	baseMonth := time.May
+	baseStart := time.Date(baseYear, baseMonth, 1, 0, 0, 0, 0, loc)
 	baseSession := 1
 
 	// Find which session period we're in
@@ -57,18 +60,24 @@ func GetCurrentSessionInfo(now time.Time) (sessionNumber int, sessionStart time.
 	if currentStart.IsZero() {
 		currentStart = time.Date(year-1, time.September, 1, 0, 0, 0, 0, loc)
 	}
+	if currentStart.Before(baseStart) {
+		currentStart = baseStart
+	}
 
 	// Calculate session number from base
 	// Each year has 3 sessions. Calculate total sessions elapsed.
 	yearDiff := currentStart.Year() - baseYear
 	monthIndex := 0
+	baseMonthIndex := 0
 	for i, m := range SessionResetMonths {
 		if currentStart.Month() == m {
 			monthIndex = i
-			break
+		}
+		if baseMonth == m {
+			baseMonthIndex = i
 		}
 	}
-	sessionNumber = baseSession + (yearDiff * 3) + monthIndex
+	sessionNumber = baseSession + (yearDiff * len(SessionResetMonths)) + (monthIndex - baseMonthIndex)
 
 	return sessionNumber, currentStart
 }
@@ -92,46 +101,20 @@ func GetNextResetTime(now time.Time) time.Time {
 	return time.Date(year+1, SessionResetMonths[0], 1, 0, 0, 0, 0, loc)
 }
 
-// Execute resets all report data and sends an announcement to the group.
+// Execute resets seasonal report data and sends an announcement to the group.
 func (uc *ResetSessionUsecase) Execute(ctx context.Context, client *whatsmeow.Client, groupID string, sessionNumber int) error {
-	log.Printf("[SESSION RESET] Starting Season %d reset — clearing all report data...", sessionNumber)
+	log.Printf("[SESSION RESET] Starting Season %d reset — clearing seasonal data...", sessionNumber)
 
 	// Reset all reports in the database
 	if err := uc.repo.ResetAllReports(ctx); err != nil {
 		return fmt.Errorf("failed to reset all reports: %w", err)
 	}
 
-	log.Printf("[SESSION RESET] All report data has been cleared for Season %d!", sessionNumber)
+	log.Printf("[SESSION RESET] Seasonal data has been reset for Season %d!", sessionNumber)
 
 	// Send announcement to the group
 	if groupID != "" && client != nil && client.IsConnected() {
-		announcement := fmt.Sprintf(`🔄 *SEASON %d TELAH DIMULAI!* 🔄
-
-Halo para pejuang keringat! 🏋️‍♂️
-
-Season %d telah resmi berakhir! 🎉
-
-✅ *Yang di-reset:*
-• 📊 Seasonal Points — mulai dari 0
-• 📅 Seasonal Activity — mulai dari 0
-• ⚔️ Seasonal Max Streak — mulai dari 0
-• 🏅 Season Badges — mulai berburu dari awal
-• 🏆 Rank & Seasonal Leaderboard — reset
-
-💾 *Yang tetap tersimpan:*
-• 🔥 Streak mingguan — lanjutkan!
-• ⭐ Total Points & Level — lifetime progress aman
-• 🏅 Achievement archive — yang sudah pernah unlock tetap tersimpan
-• 🛡️ Centurion Cycles — tetap berlaku
-
-❄️ *Streak Freeze* — reset ke 1 tiap season. Dapat +1 lagi saat capai 4 minggu streak!
-
-🆕 *Season %d dimulai SEKARANG!*
-Semua peserta mulai dari titik yang sama untuk seasonal ranking. Tapi level dan EXP lifetime kamu tetap ada! 💪
-
-📌 Langsung laporkan aktivitas pertamamu di Season %d dengan mengirim #lapor!
-
-*Semangat Season %d!* 🚀🔥`, sessionNumber, sessionNumber-1, sessionNumber, sessionNumber, sessionNumber)
+		announcement := buildSeasonResetAnnouncement(sessionNumber)
 
 		targetJID, _ := types.ParseJID(groupID)
 		msg := &waE2E.Message{
@@ -146,6 +129,41 @@ Semua peserta mulai dari titik yang sama untuk seasonal ranking. Tapi level dan 
 	}
 
 	return nil
+}
+
+func buildSeasonResetAnnouncement(sessionNumber int) string {
+	seasonTransition := "Season perdana telah resmi dimulai. Semua hunter mulai berburu dari titik yang sama! 🎉"
+	if sessionNumber > 1 {
+		seasonTransition = fmt.Sprintf("Season %d telah resmi berakhir! 🎉", sessionNumber-1)
+	}
+
+	return fmt.Sprintf(`🔄 *SEASON %d TELAH DIMULAI!* 🔄
+
+Halo para pejuang keringat! 🏋️‍♂️
+
+%s
+
+✅ *Yang di-reset:*
+• 📊 Seasonal Points — mulai dari 0
+• 📅 Seasonal Activity — mulai dari 0
+• ⚔️ Seasonal Max Streak — mulai dari 0
+• 🏅 Season Badges — mulai berburu dari awal
+• 🏆 Rank & Seasonal Leaderboard — reset
+
+💾 *Yang tetap tersimpan:*
+• 🔥 Streak mingguan — lanjutkan!
+• ⭐ Total Points, EXP & Level — lifetime progress aman
+• 🏅 Achievement archive — yang sudah pernah unlock tetap tersimpan
+• 🛡️ Centurion Cycles — tetap berlaku
+
+❄️ *Streak Freeze* — reset ke 1 tiap season. Dapat +1 lagi saat capai 4 minggu streak!
+
+🆕 *Season %d dimulai SEKARANG!*
+Semua peserta mulai dari titik yang sama untuk seasonal ranking. Tapi level dan EXP lifetime kamu tetap ada! 💪
+
+📌 Langsung laporkan aktivitas pertamamu di Season %d dengan mengirim #lapor!
+
+*Semangat Season %d!* 🚀🔥`, sessionNumber, seasonTransition, sessionNumber, sessionNumber, sessionNumber)
 }
 
 // ScheduleSessionReset starts a background goroutine that automatically resets

--- a/internal/app/usecase/reset_session_usecase_test.go
+++ b/internal/app/usecase/reset_session_usecase_test.go
@@ -1,0 +1,59 @@
+package usecase
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGetCurrentSessionInfo_CurrentLaunchSeasonStartsAtOne(t *testing.T) {
+	loc := time.FixedZone("WIB", 7*3600)
+
+	tests := []struct {
+		name      string
+		now       time.Time
+		season    int
+		startDate string
+	}{
+		{
+			name:      "launch period is season one",
+			now:       time.Date(2026, time.June, 5, 12, 0, 0, 0, loc),
+			season:    1,
+			startDate: "2026-05-01",
+		},
+		{
+			name:      "next reset increments to season two",
+			now:       time.Date(2026, time.September, 1, 0, 0, 0, 0, loc),
+			season:    2,
+			startDate: "2026-09-01",
+		},
+		{
+			name:      "following year keeps incrementing",
+			now:       time.Date(2027, time.January, 1, 0, 0, 0, 0, loc),
+			season:    3,
+			startDate: "2027-01-01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			season, start := GetCurrentSessionInfo(tt.now)
+			if season != tt.season {
+				t.Fatalf("expected season %d, got %d", tt.season, season)
+			}
+			if got := start.Format(time.DateOnly); got != tt.startDate {
+				t.Fatalf("expected start %s, got %s", tt.startDate, got)
+			}
+		})
+	}
+}
+
+func TestBuildSeasonResetAnnouncement_DoesNotMentionSeasonZero(t *testing.T) {
+	announcement := buildSeasonResetAnnouncement(1)
+	if strings.Contains(announcement, "Season 0") {
+		t.Fatalf("season 1 announcement must not mention Season 0: %s", announcement)
+	}
+	if !strings.Contains(announcement, "SEASON 1 TELAH DIMULAI") {
+		t.Fatalf("expected season 1 start announcement, got %s", announcement)
+	}
+}

--- a/internal/app/usecase/wellness_reminder.go
+++ b/internal/app/usecase/wellness_reminder.go
@@ -27,14 +27,26 @@ var tipsOlahraga = []string{
 	"🚶 *Olahraga:* Jangan duduk terlalu lama. Bangun, regangkan badan, dan jalan kaki sebentar tiap jam.",
 	"🧘 *Olahraga:* Mulai dari yang ringan kalau sudah lama vakum. Konsistensi lebih penting daripada intensitas.",
 	"🚴 *Olahraga:* Pilih aktivitas yang kamu nikmati supaya bertahan lama. Sepeda, renang, badminton — bebas, asal gerak!",
+	"💪 *Olahraga:* Gabungkan kardio, strength, dan mobility dalam seminggu. Biar stamina, otot, dan sendi sama-sama naik level.",
+	"🦵 *Olahraga:* Pemanasan 5-10 menit sebelum latihan dan cooldown setelahnya. Cedera kecil bisa mengganggu streak panjang.",
 }
 
 var tipsMakanan = []string{
-	"🥗 *Makanan:* Perbanyak sayur, buah, dan protein. Kurangi gorengan dan minuman manis ya!",
-	"💧 *Makanan:* Jangan lupa minum air putih cukup, minimal 8 gelas sehari. Dehidrasi bikin lemas.",
-	"🍚 *Makanan:* Makan secukupnya, jangan berlebihan. Porsi seimbang = energi seimbang.",
-	"🍳 *Makanan:* Sarapan itu penting buat bahan bakar harimu. Jangan dilewatkan!",
-	"🥦 *Makanan:* Isi setengah piringmu dengan sayur dan buah. Tubuhmu butuh nutrisi, bukan cuma kenyang.",
+	"🥗 *Makan:* Utamakan real food: sayur, buah, protein, karbo kompleks, dan lemak sehat. Tubuh butuh nutrisi, bukan cuma kenyang.",
+	"🍱 *Makan:* Pakai patokan piring seimbang: ½ sayur/buah, ¼ protein, ¼ karbo kompleks. Simpel dan gampang diingat.",
+	"🥚 *Makan:* Tambahkan protein di tiap makan — telur, ikan, ayam, tempe, tahu, atau kacang. Protein bantu kenyang dan recovery.",
+	"🌾 *Makan:* Pilih karbo yang lebih utuh seperti nasi, kentang, oats, ubi, atau roti gandum. Energi lebih stabil untuk aktivitas.",
+	"🚫 *Makan:* Kurangi makanan ultra-olahan, gorengan berlebihan, snack tinggi gula/garam, dan fast food. Boleh sesekali, jangan jadi default.",
+	"🍳 *Makan:* Jangan asal skip makan setelah latihan. Isi ulang energi dengan protein + karbo agar recovery lebih optimal.",
+	"🧂 *Makan:* Cek kebiasaan bumbu tinggi garam, saus, dan minuman manis. Yang kecil-kecil sering jadi sumber kalori tersembunyi.",
+	"🛒 *Makan:* Kalau belanja, prioritaskan bahan segar dulu sebelum snack kemasan. Lingkungan menentukan pilihan saat lapar.",
+}
+
+var tipsMinum = []string{
+	"💧 *Minum:* Minum air putih cukup sepanjang hari. Jangan tunggu haus berat — dehidrasi bikin lemas dan fokus turun.",
+	"🚰 *Minum:* Bawa botol minum agar intake air lebih konsisten. Target sederhana: urine kuning muda sebagian besar hari.",
+	"🥤 *Minum:* Kurangi minuman manis, soda, dan boba harian. Kalori cair cepat masuk tapi sering tidak bikin kenyang.",
+	"☕ *Minum:* Kopi boleh, tapi imbangi dengan air putih dan hindari kafein terlalu sore agar tidur tetap berkualitas.",
 }
 
 var tipsIstirahat = []string{
@@ -43,6 +55,8 @@ var tipsIstirahat = []string{
 	"🛌 *Istirahat:* Pemulihan sama pentingnya dengan latihan. Beri tubuhmu waktu untuk recovery.",
 	"☕ *Istirahat:* Ambil jeda sejenak di tengah kesibukan. Istirahat singkat bikin fokus kembali segar.",
 	"🕗 *Istirahat:* Tidur dan bangun di jam yang teratur. Ritme tubuh yang stabil = energi lebih stabil.",
+	"🌌 *Tidur:* Buat ritual 20 menit sebelum tidur: redupkan lampu, jauhkan layar, dan tenangkan napas.",
+	"⏰ *Tidur:* Kalau tidur kurang, turunkan intensitas latihan besok. Recovery buruk bukan tanda lemah — itu sinyal tubuh.",
 }
 
 var tipsStres = []string{
@@ -51,12 +65,14 @@ var tipsStres = []string{
 	"💬 *Kelola stres:* Cerita ke teman atau keluarga kalau lagi penat. Kamu tidak harus memikul semuanya sendiri.",
 	"📵 *Kelola stres:* Sesekali jauhkan diri dari notifikasi dan media sosial. Beri ruang untuk pikiranmu bernapas.",
 	"🙏 *Kelola stres:* Syukuri hal-hal kecil hari ini. Rasa syukur adalah penawar stres yang ampuh.",
+	"🧠 *Kelola stres:* Tulis 3 hal yang bikin pikiran penuh, lalu pilih 1 langkah kecil yang bisa kamu lakukan hari ini.",
+	"🚶 *Kelola stres:* Jalan santai 10 menit tanpa scrolling bisa menurunkan tegang dan membantu pikiran lebih jernih.",
 }
 
 // BuildWellnessReminder returns a formatted block containing one random
-// motivational opener plus a fresh tip for each of the four health pillars:
-// olahraga (exercise), makanan (food), istirahat (rest), and mengelola stres
-// (stress management). It is appended to scheduled notifications.
+// motivational opener plus a fresh tip for each health pillar: olahraga,
+// makanan, minum, istirahat, and mengelola stres. It is appended to scheduled
+// notifications.
 func BuildWellnessReminder() string {
 	var sb strings.Builder
 
@@ -67,6 +83,8 @@ func BuildWellnessReminder() string {
 	sb.WriteString(tipsOlahraga[rand.Intn(len(tipsOlahraga))])
 	sb.WriteString("\n")
 	sb.WriteString(tipsMakanan[rand.Intn(len(tipsMakanan))])
+	sb.WriteString("\n")
+	sb.WriteString(tipsMinum[rand.Intn(len(tipsMinum))])
 	sb.WriteString("\n")
 	sb.WriteString(tipsIstirahat[rand.Intn(len(tipsIstirahat))])
 	sb.WriteString("\n")

--- a/internal/domain/achievement.go
+++ b/internal/domain/achievement.go
@@ -326,6 +326,13 @@ type ComebackAchievement struct {
 	MinComebackStreak int
 }
 
+// BadgeSummary is a compact display model for recent badge notifications.
+type BadgeSummary struct {
+	ID           string
+	Name         string
+	DisplayEmoji string
+}
+
 // AllComebackAchievements defines achievements for users who return after inactivity.
 var AllComebackAchievements = []ComebackAchievement{
 	{
@@ -392,6 +399,48 @@ func AddAchievement(achievements string, id string) string {
 		return id
 	}
 	return achievements + "," + id
+}
+
+// FindBadgeSummary returns compact badge display data by ID.
+func FindBadgeSummary(id string) (BadgeSummary, bool) {
+	for _, a := range AllSeasonAchievements {
+		if a.ID == id {
+			return BadgeSummary{ID: a.ID, Name: a.Name, DisplayEmoji: a.DisplayEmoji}, true
+		}
+	}
+	for _, a := range AllComebackAchievements {
+		if a.ID == id {
+			return BadgeSummary{ID: a.ID, Name: a.Name, DisplayEmoji: a.DisplayEmoji}, true
+		}
+	}
+	for _, a := range AllAchievements {
+		if a.ID == id {
+			return BadgeSummary{ID: a.ID, Name: a.Name, DisplayEmoji: a.DisplayEmoji}, true
+		}
+	}
+	return BadgeSummary{}, false
+}
+
+// RecentAchievementSummaries returns the latest achieved badges in newest-first order.
+func RecentAchievementSummaries(achievements string, limit int) []BadgeSummary {
+	if achievements == "" || limit <= 0 {
+		return nil
+	}
+
+	ids := strings.Split(achievements, ",")
+	summaries := make([]BadgeSummary, 0, limit)
+	seen := make(map[string]bool, limit)
+	for i := len(ids) - 1; i >= 0 && len(summaries) < limit; i-- {
+		id := strings.TrimSpace(ids[i])
+		if id == "" || seen[id] {
+			continue
+		}
+		if summary, ok := FindBadgeSummary(id); ok {
+			summaries = append(summaries, summary)
+			seen[id] = true
+		}
+	}
+	return summaries
 }
 
 // CheckNewAchievements evaluates all achievements against the report and returns newly unlocked ones.

--- a/internal/domain/level.go
+++ b/internal/domain/level.go
@@ -1,6 +1,9 @@
 package domain
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // Level represents a gamification level that users progress through.
 type Level struct {
@@ -25,6 +28,60 @@ type JobClass struct {
 	Icon        string
 	Description string
 	Trait       string
+}
+
+// NumericLevelProgress represents persistent lifetime RPG level progress.
+// The level itself is season-independent; only lifetime points move it forward.
+type NumericLevelProgress struct {
+	Level       int
+	CurrentXP   int
+	RequiredXP  int
+	TotalPoints int
+}
+
+const (
+	levelXPQuadratic = 5
+	levelXPLinear    = 50
+	levelXPBase      = 100
+)
+
+// XPForNextNumericLevel returns the EXP required to advance from level N to N+1.
+// It follows the battle-tested quadratic chatbot curve: 5L² + 50L + 100.
+// Level 0 starts at 100 EXP so new deployments can begin cleanly from Lv.0.
+func XPForNextNumericLevel(level int) int {
+	if level < 0 {
+		level = 0
+	}
+	return levelXPQuadratic*level*level + levelXPLinear*level + levelXPBase
+}
+
+// GetNumericLevelProgress derives the persistent numeric RPG level from lifetime points.
+// The existing points/EXP value remains the source of truth, so old data migrates safely.
+func GetNumericLevelProgress(totalPoints int) NumericLevelProgress {
+	if totalPoints < 0 {
+		totalPoints = 0
+	}
+
+	level := 0
+	remaining := totalPoints
+	for {
+		required := XPForNextNumericLevel(level)
+		if remaining < required {
+			return NumericLevelProgress{
+				Level:       level,
+				CurrentXP:   remaining,
+				RequiredXP:  required,
+				TotalPoints: totalPoints,
+			}
+		}
+		remaining -= required
+		level++
+	}
+}
+
+// NumericLevelFromTotalPoints returns only the persistent numeric level.
+func NumericLevelFromTotalPoints(totalPoints int) int {
+	return GetNumericLevelProgress(totalPoints).Level
 }
 
 // AllLevels defines the progression tiers in ascending order.
@@ -160,4 +217,28 @@ func FormatProgressBar(totalPoints int) string {
 	}
 
 	return fmt.Sprintf("[%s] %d/%d pts → %s %s", bar, totalPoints, next.MinPoints, next.Name, next.Icon)
+}
+
+// FormatNumericLevelProgressBar returns compact Solo-Leveling-style lifetime progress.
+func FormatNumericLevelProgressBar(totalPoints int) string {
+	progress := GetNumericLevelProgress(totalPoints)
+	barLen := 10
+	filled := 0
+	if progress.RequiredXP > 0 {
+		filled = (progress.CurrentXP * barLen) / progress.RequiredXP
+	}
+	if filled > barLen {
+		filled = barLen
+	}
+
+	var bar strings.Builder
+	for i := 0; i < barLen; i++ {
+		if i < filled {
+			bar.WriteString("█")
+		} else {
+			bar.WriteString("░")
+		}
+	}
+
+	return fmt.Sprintf("Lv.%d [%s] %d/%d EXP", progress.Level, bar.String(), progress.CurrentXP, progress.RequiredXP)
 }

--- a/internal/domain/report.go
+++ b/internal/domain/report.go
@@ -14,6 +14,7 @@ type Report struct {
 	LastReportDate        time.Time `json:"last_report_date" db:"last_report_date"`
 	MaxStreak             int       `json:"max_streak" db:"max_streak"`
 	TotalPoints           int       `json:"total_points" db:"total_points"`
+	Level                 int       `json:"level" db:"level"`
 	Achievements          string    `json:"achievements" db:"achievements"`
 	ComebackStreak        int       `json:"comeback_streak" db:"comeback_streak"`
 	InactiveDays          int       `json:"inactive_days" db:"inactive_days"`

--- a/internal/infra/sqlite/report_repository.go
+++ b/internal/infra/sqlite/report_repository.go
@@ -21,7 +21,7 @@ func NewReportRepository(db *sql.DB) *ReportRepository {
 }
 
 const selectColumns = `user_id, name, COALESCE(job_class, ''), streak, activity_count, last_report_date, 
-	COALESCE(max_streak, 0), COALESCE(total_points, 0), COALESCE(achievements, ''),
+	COALESCE(max_streak, 0), COALESCE(total_points, 0), COALESCE(level, 0), COALESCE(achievements, ''),
 	COALESCE(comeback_streak, 0), COALESCE(inactive_days, 0), COALESCE(centurion_cycles, 0),
 	COALESCE(seasonal_points, 0), COALESCE(seasonal_activity_count, 0),
 	COALESCE(seasonal_max_streak, 0), COALESCE(seasonal_achievements, ''),
@@ -32,7 +32,7 @@ func scanReport(scanner interface{ Scan(dest ...any) error }) (*domain.Report, e
 	var lastReportDate string
 	err := scanner.Scan(
 		&report.UserID, &report.Name, &report.JobClass, &report.Streak, &report.ActivityCount,
-		&lastReportDate, &report.MaxStreak, &report.TotalPoints, &report.Achievements,
+		&lastReportDate, &report.MaxStreak, &report.TotalPoints, &report.Level, &report.Achievements,
 		&report.ComebackStreak, &report.InactiveDays, &report.CenturionCycles,
 		&report.SeasonalPoints, &report.SeasonalActivityCount,
 		&report.SeasonalMaxStreak, &report.SeasonalAchievements,
@@ -61,8 +61,8 @@ func (r *ReportRepository) GetReport(ctx context.Context, userID string) (*domai
 
 func upsertReport(ctx context.Context, execer execContexter, report *domain.Report) error {
 	query := `
-		INSERT INTO user_reports (user_id, name, job_class, streak, activity_count, last_report_date, max_streak, total_points, achievements, comeback_streak, inactive_days, centurion_cycles, seasonal_points, seasonal_activity_count, seasonal_max_streak, seasonal_achievements, streak_freezes)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO user_reports (user_id, name, job_class, streak, activity_count, last_report_date, max_streak, total_points, level, achievements, comeback_streak, inactive_days, centurion_cycles, seasonal_points, seasonal_activity_count, seasonal_max_streak, seasonal_achievements, streak_freezes)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(user_id) DO UPDATE SET
 			name = excluded.name,
 			job_class = excluded.job_class,
@@ -71,6 +71,7 @@ func upsertReport(ctx context.Context, execer execContexter, report *domain.Repo
 			last_report_date = excluded.last_report_date,
 			max_streak = excluded.max_streak,
 			total_points = excluded.total_points,
+			level = excluded.level,
 			achievements = excluded.achievements,
 			comeback_streak = excluded.comeback_streak,
 			inactive_days = excluded.inactive_days,
@@ -84,7 +85,7 @@ func upsertReport(ctx context.Context, execer execContexter, report *domain.Repo
 	_, err := execer.ExecContext(ctx, query,
 		report.UserID, report.Name, report.JobClass, report.Streak, report.ActivityCount,
 		report.LastReportDate.Format(time.RFC3339), report.MaxStreak, report.TotalPoints,
-		report.Achievements, report.ComebackStreak, report.InactiveDays, report.CenturionCycles,
+		report.Level, report.Achievements, report.ComebackStreak, report.InactiveDays, report.CenturionCycles,
 		report.SeasonalPoints, report.SeasonalActivityCount, report.SeasonalMaxStreak,
 		report.SeasonalAchievements, report.StreakFreezes,
 	)
@@ -263,6 +264,7 @@ func (r *ReportRepository) InitTable(ctx context.Context) error {
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN job_class TEXT DEFAULT ''")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN max_streak INTEGER DEFAULT 0")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN total_points INTEGER DEFAULT 0")
+	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN level INTEGER DEFAULT 0")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN achievements TEXT DEFAULT ''")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN comeback_streak INTEGER DEFAULT 0")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN inactive_days INTEGER DEFAULT 0")
@@ -279,6 +281,9 @@ func (r *ReportRepository) InitTable(ctx context.Context) error {
 		return err
 	}
 	if err := r.MigrateCenturionPrestige(ctx); err != nil {
+		return err
+	}
+	if err := r.MigrateNumericLevels(ctx); err != nil {
 		return err
 	}
 
@@ -354,6 +359,56 @@ func (r *ReportRepository) MigrateCenturionPrestige(ctx context.Context) error {
 
 	_, err = r.db.ExecContext(ctx, "INSERT INTO sys_migrations (name) VALUES ('centurion_prestige_v1')")
 	return err
+}
+
+func (r *ReportRepository) MigrateNumericLevels(ctx context.Context) error {
+	var exists int
+	err := r.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM sys_migrations WHERE name = 'numeric_level_v1'").Scan(&exists)
+	if err != nil {
+		return err
+	}
+	if exists > 0 {
+		return nil
+	}
+
+	rows, err := r.db.QueryContext(ctx, `SELECT user_id, COALESCE(total_points, 0) FROM user_reports`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	type levelUpdate struct {
+		userID string
+		level  int
+	}
+	var updates []levelUpdate
+	for rows.Next() {
+		var userID string
+		var totalPoints int
+		if err := rows.Scan(&userID, &totalPoints); err != nil {
+			return err
+		}
+		updates = append(updates, levelUpdate{userID: userID, level: domain.NumericLevelFromTotalPoints(totalPoints)})
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	for _, update := range updates {
+		if _, err := tx.ExecContext(ctx, `UPDATE user_reports SET level = ? WHERE user_id = ?`, update.level, update.userID); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+	if _, err := tx.ExecContext(ctx, "INSERT INTO sys_migrations (name) VALUES ('numeric_level_v1')"); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	return tx.Commit()
 }
 
 // ResolveLIDToPhone looks up a LID in the whatsmeow_lid_map table and returns the phone number.


### PR DESCRIPTION
- Migrate resets from fixed sessions to a 4-month season cycle starting May 2026
- Add season number to reports and season-aware stats
- Add numeric level support and format in outputs
- Add Level field to Report and display Level/EXP
- Introduce #tutorial and implement tutorial output
- Update #help to include #tutorial and new commands
- Update announcements to describe Season-based progress and resets
- Expand wellness tips with extra exercise, nutrition, and hydration guidance
- Add BadgeSummary type and reflect season badge in UI
- Update DB queries to read level with default 0 for legacy rows