### PR TITLE
Add cancel-all support and daily limit tracking

### DIFF
--- a/internal/app/usecase/cancel_report_usecase.go
+++ b/internal/app/usecase/cancel_report_usecase.go
@@ -20,6 +20,14 @@ func NewCancelReportUsecase(repo domain.ReportRepository) *CancelReportUsecase {
 }
 
 func (uc *CancelReportUsecase) Execute(ctx context.Context, userID, name string) (string, error) {
+	return uc.cancelToday(ctx, userID, name, false)
+}
+
+func (uc *CancelReportUsecase) ExecuteAll(ctx context.Context, userID, name string) (string, error) {
+	return uc.cancelToday(ctx, userID, name, true)
+}
+
+func (uc *CancelReportUsecase) cancelToday(ctx context.Context, userID, name string, all bool) (string, error) {
 	report, err := uc.repo.GetReport(ctx, userID)
 	if err != nil {
 		return "", err
@@ -44,6 +52,36 @@ func (uc *CancelReportUsecase) Execute(ctx context.Context, userID, name string)
 
 	if len(dates) == 0 {
 		return fmt.Sprintf("Halo %s, tidak ada aktivitas yang tercatat.", report.Name), nil
+	}
+
+	dailyCount, err := uc.repo.GetDailyActivityCount(ctx, userID, today)
+	if err != nil {
+		return "", err
+	}
+	if dailyCount == 0 {
+		return fmt.Sprintf("Halo %s, tidak menemukan laporan untuk hari ini.", report.Name), nil
+	}
+
+	if !all && dailyCount > 1 {
+		remainingReports, err := uc.repo.DeleteLatestActivityLog(ctx, userID, today)
+		if err != nil {
+			return "", err
+		}
+		if remainingReports == 0 {
+			return uc.cancelToday(ctx, userID, name, true)
+		}
+
+		removeRepeatReportPoints(report)
+		if err := uc.repo.UpsertReport(ctx, report); err != nil {
+			return "", err
+		}
+
+		msg := fmt.Sprintf("✅ Laporan terakhir hari ini telah dibatalkan, %s.\n\n", report.Name)
+		msg += fmt.Sprintf("📌 Sisa laporan hari ini: %d/%d\n", remainingReports, MaxDailyReports)
+		msg += fmt.Sprintf("📅 Total hari aktif tetap: %d\n", report.ActivityCount)
+		msg += fmt.Sprintf("⭐ Total poin sekarang: %d\n", report.TotalPoints)
+		msg += "\nKalau ingin menghapus semua laporan hari ini, ketik #cancel-all."
+		return msg, nil
 	}
 
 	remainingDates := removeDate(dates, today)
@@ -78,7 +116,10 @@ func (uc *CancelReportUsecase) Execute(ctx context.Context, userID, name string)
 		return "", err
 	}
 
-	msg := fmt.Sprintf("✅ Laporan hari ini telah dibatalkan, %s.\n\n", report.Name)
+	msg := fmt.Sprintf("✅ Semua laporan hari ini telah dibatalkan, %s.\n\n", report.Name)
+	if !all {
+		msg = fmt.Sprintf("✅ Laporan hari ini telah dibatalkan, %s.\n\n", report.Name)
+	}
 	msg += fmt.Sprintf("📅 Total hari aktif: %d\n", newReport.ActivityCount)
 	msg += fmt.Sprintf("🔥 Streak saat ini: %d minggu\n", newReport.Streak)
 	msg += fmt.Sprintf("⭐ Total poin: %d\n", newReport.TotalPoints)
@@ -89,6 +130,19 @@ func (uc *CancelReportUsecase) Execute(ctx context.Context, userID, name string)
 
 	msg += "\n_Kamu bisa lapor lagi hari ini dengan #lapor._"
 	return msg, nil
+}
+
+func removeRepeatReportPoints(report *domain.Report) {
+	const repeatReportPoints = 5
+	report.TotalPoints -= repeatReportPoints
+	if report.TotalPoints < 0 {
+		report.TotalPoints = 0
+	}
+	report.SeasonalPoints -= repeatReportPoints
+	if report.SeasonalPoints < 0 {
+		report.SeasonalPoints = 0
+	}
+	report.Level = domain.NumericLevelFromTotalPoints(report.TotalPoints)
 }
 
 func removeDate(dates []time.Time, target time.Time) []time.Time {

--- a/internal/app/usecase/cancel_report_usecase_test.go
+++ b/internal/app/usecase/cancel_report_usecase_test.go
@@ -13,6 +13,9 @@ type cancelReportRepoStub struct {
 	dates          []time.Time
 	deletedLog     bool
 	deletedLogDate time.Time
+	latestDeleted  bool
+	dailyCount     int
+	remainingCount int
 	deletedReport  bool
 	upsertedReport *domain.Report
 }
@@ -65,7 +68,18 @@ func (r *cancelReportRepoStub) GetUserActivityDates(ctx context.Context, userID 
 func (r *cancelReportRepoStub) DeleteActivityLog(ctx context.Context, userID string, activityDate time.Time) error {
 	r.deletedLog = true
 	r.deletedLogDate = activityDate
+	r.dailyCount = 0
 	return nil
+}
+
+func (r *cancelReportRepoStub) DeleteLatestActivityLog(ctx context.Context, userID string, activityDate time.Time) (int, error) {
+	r.latestDeleted = true
+	r.deletedLogDate = activityDate
+	if r.dailyCount > 0 {
+		r.dailyCount--
+	}
+	r.remainingCount = r.dailyCount
+	return r.remainingCount, nil
 }
 
 func (r *cancelReportRepoStub) DeleteReport(ctx context.Context, userID string) error {
@@ -83,6 +97,10 @@ func (r *cancelReportRepoStub) GetStravaAccountByAthleteID(ctx context.Context, 
 
 func (r *cancelReportRepoStub) GetStravaAccountByUserID(ctx context.Context, userID string) (*domain.StravaAccount, error) {
 	return nil, nil
+}
+
+func (r *cancelReportRepoStub) GetDailyActivityCount(ctx context.Context, userID string, date time.Time) (int, error) {
+	return r.dailyCount, nil
 }
 
 func TestCancelReport_NoReport(t *testing.T) {
@@ -185,7 +203,8 @@ func TestCancelReport_SingleDay_CancelsWithoutDeletingAll(t *testing.T) {
 			Streak:         1,
 			TotalPoints:    10,
 		},
-		dates: []time.Time{today},
+		dates:      []time.Time{today},
+		dailyCount: 1,
 	}
 	uc := NewCancelReportUsecase(repo)
 
@@ -242,7 +261,8 @@ func TestCancelReport_MultipleDays_Recalculates(t *testing.T) {
 			Streak:         2,
 			TotalPoints:    20,
 		},
-		dates: []time.Time{lastWeek, today},
+		dates:      []time.Time{lastWeek, today},
+		dailyCount: 1,
 	}
 	uc := NewCancelReportUsecase(repo)
 

--- a/internal/app/usecase/get_achievements_usecase.go
+++ b/internal/app/usecase/get_achievements_usecase.go
@@ -74,7 +74,7 @@ func (uc *GetAchievementsUsecase) Execute(ctx context.Context) (string, error) {
 		sb.WriteString("\n")
 	}
 
-	sb.WriteString("⚔️ Level numerik memakai EXP lifetime: Lv berikutnya butuh `5×level² + 50×level + 100` EXP.")
+	sb.WriteString("⚔️ Level numerik naik dari total EXP lifetime. Semakin tinggi level, semakin banyak EXP yang dibutuhkan.")
 
 	return sb.String(), nil
 }

--- a/internal/app/usecase/get_help_usecase.go
+++ b/internal/app/usecase/get_help_usecase.go
@@ -10,12 +10,12 @@ var helpSections = []struct {
 	{
 		emoji:   "📝",
 		title:   "Melaporkan Aktivitas",
-		content: "*#lapor* — Laporkan workout atau aktivitas harianmu.\nContoh: `#lapor` atau `#lapor Push Day`\n\n🔄 Setiap laporan yang valid akan menambah streak mingguanmu dan total hari aktif.\n❄️ *Streak Freeze* — kamu punya 1 freeze gratis per season. Freeze otomatis melindungi 1 minggu absen. Dapatkan +1 freeze lagi saat kamu mencapai 4 minggu streak!",
+		content: "*#lapor* — Laporkan workout atau aktivitas harianmu.\nContoh: `#lapor` atau `#lapor Push Day`\n\n🔄 Setiap laporan yang valid akan menambah streak mingguanmu dan total hari aktif.\n❄️ *Streak Freeze* — kamu punya 1 freeze gratis per season. Freeze otomatis melindungi 1 minggu absen. Dapatkan +1 freeze lagi saat kamu mencapai 4 minggu streak!\n\n📌 *Max 3x laporan per hari*: Kamu bisa lapor maksimal 3x dalam sehari. Laporan ke-2 dan ke-3 tetap dihitung 1 hari tapi XP dibagi 2.\n📌 *#lapor-kemarin* — Laporan khusus untuk hari kemarin. Sama seperti #lapor, XP dibagi 2. Max 3x per hari.",
 	},
 	{
 		emoji:   "❌",
 		title:   "Membatalkan Laporan",
-		content: "*#cancel* — Batalkan laporan hari ini jika kamu salah lapor.\nHanya bisa digunakan pada hari yang sama dengan laporan.",
+		content: "*#cancel* — Batalkan laporan terakhir hari ini jika kamu salah input. Kalau hari ini ada 2-3 laporan, hanya laporan paling akhir yang dihapus.\n*#cancel-all* — Hapus semua laporan hari ini dan hitung ulang progresmu.\nHanya bisa digunakan pada hari yang sama dengan laporan.",
 	},
 	{
 		emoji:   "🏆",
@@ -63,8 +63,10 @@ func NewGetHelpUsecase() *GetHelpUsecase {
 func (uc *GetHelpUsecase) Execute() string {
 	return `🤖 *Command Lapor Bot*
 
-📝 #lapor — laporan aktivitas harian
+📝 #lapor — laporan aktivitas harian (max 3x/hari)
+📌 #lapor-kemarin — laporan khusus hari kemarin (max 3x/hari)
 ❌ #cancel — batalkan laporan hari ini
+🧹 #cancel-all — batalkan semua laporan hari ini
 📊 #mystats — statistik personal
 🏆 #leaderboard — leaderboard lifetime
 📅 #leaderboard-weekly — leaderboard minggu ini
@@ -91,7 +93,7 @@ func (uc *GetHelpUsecase) ExecuteTutorial() string {
 	}
 
 	msg += "⚔️ *Level Numerik*\n"
-	msg += "Level lifetime dimulai dari Lv.0 dan naik dari total points/EXP. Semakin tinggi level, EXP yang dibutuhkan makin besar: `5×level² + 50×level + 100`. Season boleh reset, tapi level lifetime tetap lanjut.\n\n"
+	msg += "Level lifetime dimulai dari Lv.0 dan naik dari total points/EXP. Semakin tinggi level, semakin banyak EXP yang dibutuhkan untuk naik level. Season boleh reset, tapi level lifetime tetap lanjut.\n\n"
 	msg += "🏅 *Badge*\n"
 	msg += "Notifikasi #lapor hanya menampilkan badge terbaru supaya ringkas. Untuk syarat, poin, dan cerita unlock lengkap, buka #achievements.\n\n"
 	msg += "_Catatan: Bot hanya merespon di grup yang sudah dikonfigurasi. Semangat terus! 💪_"

--- a/internal/app/usecase/get_leaderboard_usecase.go
+++ b/internal/app/usecase/get_leaderboard_usecase.go
@@ -63,7 +63,8 @@ func (uc *GetLeaderboardUsecase) Execute(ctx context.Context) (string, error) {
 	// Header
 	sb := strings.Builder{}
 	dateStr := displayDate.Format("02-01-2006")
-	sb.WriteString(fmt.Sprintf("30 Days of Sweat Challenge – Day %d (%s)\n\n", challengeDay, dateStr))
+	seasonNumber, _ := GetCurrentSessionInfo(now)
+	sb.WriteString(fmt.Sprintf("Season %d Hidup Sehat SWE Growth – Day %d (%s)\n\n", seasonNumber, challengeDay, dateStr))
 
 	// Recap
 	sb.WriteString(fmt.Sprintf("Recap day %d:\n", challengeDay))

--- a/internal/app/usecase/get_motivation_usecase.go
+++ b/internal/app/usecase/get_motivation_usecase.go
@@ -338,6 +338,27 @@ var (
 	"📚 \"Kamu adalah rata-rata dari 5 orang yang paling sering kamu habiskan waktumu. Pilih yang gerak, bukan yang malas.\" — Jim Rohn",
 	"📚 \"Apa yang kita lakukan berulang-ulang membentuk siapa kita. Karena itu, keunggulan bukan tindakan, tapi kebiasaan.\" — Aristoteles",
 	"📚 \"Tubuh yang sehat adalah tamu pelayan; jiwa yang jernih adalah tuan rumah. Rawat keduanya, dan hidupmu akan lengkap.\" — Anonim",
+
+	"🌾 \"Padi tidak tumbuh karena ditarik, tapi karena dirawat tiap hari. Begitu juga tubuhmu.\" — Pepatah Timur",
+	"🫖 \"Kesehatan adalah teh hangat kehidupan: sederhana, sering diabaikan, tapi paling terasa saat hilang.\" — Anonim",
+	"🧘 \"Pikiran yang tenang lebih mudah lahir dari tubuh yang dirawat daripada tubuh yang terus diabaikan.\" — Anonim",
+	"🪷 \"Sehat bukan proyek 30 hari. Sehat adalah cara kita menghormati hari-hari yang masih diberi.\" — Anonim",
+	"🌙 \"Orang bijak tidur sebelum tubuhnya memohon, makan sebelum rakus, dan bergerak sebelum sakit memaksa.\" — Pepatah",
+	"🧱 \"Tubuh sehat dibangun seperti rumah tua yang kuat: satu bata kebiasaan kecil setiap hari.\" — Anonim",
+	"🌊 \"Air yang mengalir jarang membusuk. Tubuh yang bergerak jarang menyerah pada kaku.\" — Pepatah Kuno",
+	"🕯️ \"Rawat energimu seperti api kecil: beri udara, beri bahan bakar, jangan biarkan padam.\" — Anonim",
+	"🍃 \"Makanan baik, tidur cukup, dan langkah kecil adalah doa yang ditulis tubuh untuk masa depanmu.\" — Anonim",
+	"🧭 \"Jangan tunggu dokter menjadi alarm. Jadikan kebiasaan sehat sebagai kompas sebelum tubuh tersesat.\" — Anonim",
+	"🏡 \"Tubuhmu adalah rumah pertama. Sebelum mengejar dunia, rapikan rumahmu sendiri.\" — Anonim",
+	"🪙 \"Kesehatan adalah tabungan yang bunganya dibayar di usia tua. Setor sedikit hari ini.\" — Anonim",
+	"🦉 \"Orang kuat tahu kapan berlatih. Orang bijak tahu kapan istirahat. Orang sehat belajar keduanya.\" — Anonim",
+	"🌻 \"Sinar matahari, air putih, napas panjang, dan jalan kaki: obat lama yang masih bekerja.\" — Anonim",
+	"🧵 \"Kebiasaan sehat adalah benang halus. Sendiri tampak kecil, bersama-sama menjadi kain hidup yang kuat.\" — Anonim",
+	"🗿 \"Bangsa kuno membangun monumen dengan kesabaran. Bangun kesehatanmu dengan cara yang sama.\" — Anonim",
+	"🥣 \"Makanlah untuk merawat, bukan melampiaskan. Bergeraklah untuk bersyukur, bukan menghukum.\" — Anonim",
+	"🪨 \"Disiplin sehat bukan rantai. Ia adalah pagar yang menjaga hidupmu tetap bebas.\" — Anonim",
+	"🌱 \"Hari tanpa gerak bukan kegagalan, tapi sinyal lembut untuk kembali menyiram akar.\" — Anonim",
+	"🫀 \"Detak jantungmu bekerja tanpa cuti. Beri dia alasan untuk terus kuat.\" — Anonim",
 	}
 )
 

--- a/internal/app/usecase/get_mystats_usecase_test.go
+++ b/internal/app/usecase/get_mystats_usecase_test.go
@@ -64,6 +64,10 @@ func (r *myStatsRepoStub) DeleteActivityLog(ctx context.Context, userID string, 
 	return nil
 }
 
+func (r *myStatsRepoStub) DeleteLatestActivityLog(ctx context.Context, userID string, activityDate time.Time) (int, error) {
+	return 0, nil
+}
+
 func (r *myStatsRepoStub) DeleteReport(ctx context.Context, userID string) error {
 	return nil
 }
@@ -78,6 +82,10 @@ func (r *myStatsRepoStub) GetStravaAccountByAthleteID(ctx context.Context, athle
 
 func (r *myStatsRepoStub) GetStravaAccountByUserID(ctx context.Context, userID string) (*domain.StravaAccount, error) {
 	return nil, nil
+}
+
+func (r *myStatsRepoStub) GetDailyActivityCount(ctx context.Context, userID string, date time.Time) (int, error) {
+	return 0, nil
 }
 
 func TestGetMyStatsUsecase_IncludesSeasonAndWeeklyCounts(t *testing.T) {

--- a/internal/app/usecase/get_weekly_leaderboard_usecase_test.go
+++ b/internal/app/usecase/get_weekly_leaderboard_usecase_test.go
@@ -64,6 +64,10 @@ func (r *weeklyLeaderboardRepoStub) DeleteActivityLog(ctx context.Context, userI
 	return nil
 }
 
+func (r *weeklyLeaderboardRepoStub) DeleteLatestActivityLog(ctx context.Context, userID string, activityDate time.Time) (int, error) {
+	return 0, nil
+}
+
 func (r *weeklyLeaderboardRepoStub) DeleteReport(ctx context.Context, userID string) error {
 	return nil
 }
@@ -78,6 +82,10 @@ func (r *weeklyLeaderboardRepoStub) GetStravaAccountByAthleteID(ctx context.Cont
 
 func (r *weeklyLeaderboardRepoStub) GetStravaAccountByUserID(ctx context.Context, userID string) (*domain.StravaAccount, error) {
 	return nil, nil
+}
+
+func (r *weeklyLeaderboardRepoStub) GetDailyActivityCount(ctx context.Context, userID string, date time.Time) (int, error) {
+	return 0, nil
 }
 
 func TestGetWeeklyLeaderboardUsecase_UsesSundayWeekRange(t *testing.T) {

--- a/internal/app/usecase/handle_message_usecase.go
+++ b/internal/app/usecase/handle_message_usecase.go
@@ -72,9 +72,20 @@ func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, messa
 		return MessageResponse{Text: text}, nil
 	}
 
+	if strings.Contains(msg, "#lapor-kemarin") {
+		workout := domain.ParseHevy(message)
+		text, err := uc.reportUC.ExecuteYesterday(ctx, userID, name, workout)
+		return MessageResponse{Text: text}, err
+	}
+
 	if strings.Contains(msg, "#lapor") {
 		workout := domain.ParseHevy(message)
 		text, err := uc.reportUC.Execute(ctx, userID, name, workout)
+		return MessageResponse{Text: text}, err
+	}
+
+	if strings.Contains(msg, "#cancel-all") {
+		text, err := uc.cancelUC.ExecuteAll(ctx, userID, name)
 		return MessageResponse{Text: text}, err
 	}
 

--- a/internal/app/usecase/handle_message_usecase_test.go
+++ b/internal/app/usecase/handle_message_usecase_test.go
@@ -113,6 +113,10 @@ func (m *mockReportRepo) DeleteActivityLog(ctx context.Context, userID string, a
 	return nil
 }
 
+func (m *mockReportRepo) DeleteLatestActivityLog(ctx context.Context, userID string, activityDate time.Time) (int, error) {
+	return 0, nil
+}
+
 func (m *mockReportRepo) GetUserActivityDates(ctx context.Context, userID string) ([]time.Time, error) {
 	return nil, nil
 }
@@ -120,6 +124,10 @@ func (m *mockReportRepo) GetUserActivityDates(ctx context.Context, userID string
 func (m *mockReportRepo) DeleteReport(ctx context.Context, userID string) error {
 	delete(m.reports, userID)
 	return nil
+}
+
+func (m *mockReportRepo) GetDailyActivityCount(ctx context.Context, userID string, date time.Time) (int, error) {
+	return 0, nil
 }
 
 func TestHandleMessage_LaporCommand(t *testing.T) {
@@ -234,8 +242,8 @@ func TestHandleMessage_LeaderboardCommand(t *testing.T) {
 	if msg.Text == "" {
 		t.Error("#leaderboard should return a response")
 	}
-	if !containsSubstring(msg.Text, "30 Days of Sweat Challenge") {
-		t.Errorf("Response should contain '30 Days of Sweat Challenge', got '%s'", msg.Text)
+	if !containsSubstring(msg.Text, "Hidup Sehat SWE Growth") {
+		t.Errorf("Response should contain 'Hidup Sehat SWE Growth', got '%s'", msg.Text)
 	}
 }
 

--- a/internal/app/usecase/report_activity_usecase.go
+++ b/internal/app/usecase/report_activity_usecase.go
@@ -11,6 +11,8 @@ import (
 	"github.com/fardannozami/whatsapp-gateway/internal/domain"
 )
 
+const MaxDailyReports = 3
+
 type ReportActivityUsecase struct {
 	repo  domain.ReportRepository
 	locks sync.Map
@@ -38,6 +40,23 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 	now := time.Now()
 	today := domain.GetToday(now)
 
+	var dailyCount int
+	if report != nil && domain.GetToday(report.LastReportDate).Equal(today) {
+		dailyCount, err = uc.repo.GetDailyActivityCount(ctx, userID, today)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if dailyCount >= MaxDailyReports {
+		msg := fmt.Sprintf("%s sudah laporan %dx hari ini, ayo jangan curang! 😉\n\nBatas harian adalah %d laporan: laporan pertama untuk progres utama, laporan ke-2 dan ke-3 hanya bonus ½ XP. Kalau tadi salah input, pakai #cancel untuk hapus laporan terakhir atau #cancel-all untuk hapus semua laporan hari ini. 🙏", report.Name, MaxDailyReports, MaxDailyReports)
+		msg += fmt.Sprintf("\n\n💬 _\"%s\"_", RandomQuote())
+		return msg, nil
+	}
+
+	isRepeatReport := dailyCount > 0
+	isFullReport := !isRepeatReport
+
 	streakFreezeUsed := false
 
 	if report != nil {
@@ -57,61 +76,44 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 					return "", err
 				}
 			}
-
-			duplicateMsg := fmt.Sprintf("%s sudah laporan hari ini, ayo jangan curang! 😉", name)
-			if workout != nil {
-				duplicateMsg += "\n" + uc.formatWorkout(workout)
-			}
-			duplicateMsg += "\n\nKalau tadi salah lapor, ketik #cancel untuk membatalkan laporan hari ini. 🙏"
-			duplicateMsg += fmt.Sprintf("\n\n💬 _\"%s\"_", RandomQuote())
-			return duplicateMsg, nil
-		}
-
-		daysSinceLastReport := int(math.Round(today.Sub(lastReportDate).Hours() / 24))
-
-		currentWeekStart := domain.GetStartOfISOWeek(today)
-		lastWeekStart := domain.GetStartOfISOWeek(lastReportDate)
-		weeksSinceLastReport := int(math.Round(currentWeekStart.Sub(lastWeekStart).Hours() / (24 * 7)))
-
-		if currentWeekStart.Equal(lastWeekStart) {
-			// Same week — streak stays the same, nothing to increment
-		} else if weeksSinceLastReport == 1 {
-			// Consecutive week — streak continues
-			report.Streak++
-			report.ComebackStreak++ // also increment comeback streak if active
-		} else if weeksSinceLastReport == 2 && report.StreakFreezes > 0 {
-			// Exactly 1 week missed — auto-consume streak freeze to protect streak
-			report.StreakFreezes--
-			report.Streak++
-			report.ComebackStreak++
-			streakFreezeUsed = true
+			report.LastReportDate = now
+			name = report.Name
 		} else {
-			// Missed week(s) — streak resets
-			report.InactiveDays = daysSinceLastReport
-			report.ComebackStreak = 1
-			report.Streak = 1
-		}
-		report.ActivityCount++
-		report.SeasonalActivityCount++
-		if report.Streak > report.SeasonalMaxStreak {
-			report.SeasonalMaxStreak = report.Streak
-		}
+			daysSinceLastReport := int(math.Round(today.Sub(lastReportDate).Hours() / 24))
 
-		// Handle Centurion Cycle Transition
-		isNewCycle := false
-		if report.ActivityCount > 100 {
-			report.ActivityCount = 1
-			report.CenturionCycles++
-			isNewCycle = true
-		}
+			currentWeekStart := domain.GetStartOfISOWeek(today)
+			lastWeekStart := domain.GetStartOfISOWeek(lastReportDate)
+			weeksSinceLastReport := int(math.Round(currentWeekStart.Sub(lastWeekStart).Hours() / (24 * 7)))
 
-		// Keep manually configured names stable. Placeholder names were healed above
-		// when WhatsApp later provided a real push/contact name.
-		report.LastReportDate = now
-		name = report.Name // Use the stored name for the response message
+			if isFullReport {
+				if currentWeekStart.Equal(lastWeekStart) {
+				} else if weeksSinceLastReport == 1 {
+					report.Streak++
+					report.ComebackStreak++
+				} else if weeksSinceLastReport == 2 && report.StreakFreezes > 0 {
+					report.StreakFreezes--
+					report.Streak++
+					report.ComebackStreak++
+					streakFreezeUsed = true
+				} else {
+					report.InactiveDays = daysSinceLastReport
+					report.ComebackStreak = 1
+					report.Streak = 1
+				}
+				report.ActivityCount++
+				report.SeasonalActivityCount++
+				if report.Streak > report.SeasonalMaxStreak {
+					report.SeasonalMaxStreak = report.Streak
+				}
 
-		if isNewCycle {
-			// Special handling for new cycle can be added here or in the response construction
+				if report.ActivityCount > 100 {
+					report.ActivityCount = 1
+					report.CenturionCycles++
+				}
+			}
+
+			report.LastReportDate = now
+			name = report.Name
 		}
 	} else {
 		name = reportName("", name)
@@ -134,68 +136,72 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 		}
 	}
 
-	// Logic for MaxStreak: it should be at least 1 if they reported once
 	if report.MaxStreak == 0 {
 		report.MaxStreak = 1
 	}
 	oldNumericLevel := domain.NumericLevelFromTotalPoints(report.TotalPoints)
 
-	// 1. Update Max Streak
 	newRecord := false
-	if report.Streak > report.MaxStreak {
+	if isFullReport && report.Streak > report.MaxStreak {
 		report.MaxStreak = report.Streak
 		if report.Streak > 1 {
 			newRecord = true
 		}
 	}
 
-	// 2. Calculate base EXP + bonuses
 	basePoints := 10
-	streakBonus := 2 * (report.Streak - 1)
-	if streakBonus < 0 {
-		streakBonus = 0
-	}
+	streakBonus := 0
 	seasonalFirstBonus := 0
-	if report.SeasonalActivityCount == 1 {
-		seasonalFirstBonus = 5
+	if isFullReport {
+		streakBonus = 2 * (report.Streak - 1)
+		if streakBonus < 0 {
+			streakBonus = 0
+		}
+		if report.SeasonalActivityCount == 1 {
+			seasonalFirstBonus = 5
+		}
 	}
 	reportPoints := basePoints + streakBonus + seasonalFirstBonus
+	if isRepeatReport {
+		reportPoints = reportPoints / 2
+	}
 	report.TotalPoints += reportPoints
 	report.SeasonalPoints += reportPoints
 
-	// 3. Check for new season badges. Badge progress resets every season, but
-	// lifetime EXP/level remains preserved.
-	newAchievements := domain.CheckNewSeasonAchievements(report)
+	var newAchievements []domain.Achievement
+	var comebackAchievements []domain.ComebackAchievement
 	pointsGained := 0
 
-	for _, ach := range newAchievements {
-		report.SeasonalAchievements = domain.AddAchievement(report.SeasonalAchievements, ach.ID)
-		if !domain.HasAchievement(report.Achievements, ach.ID) {
-			report.Achievements = domain.AddAchievement(report.Achievements, ach.ID)
+	if isFullReport {
+		newAchievements = domain.CheckNewSeasonAchievements(report)
+		for _, ach := range newAchievements {
+			report.SeasonalAchievements = domain.AddAchievement(report.SeasonalAchievements, ach.ID)
+			if !domain.HasAchievement(report.Achievements, ach.ID) {
+				report.Achievements = domain.AddAchievement(report.Achievements, ach.ID)
+			}
+			report.TotalPoints += ach.Points
+			report.SeasonalPoints += ach.Points
+			pointsGained += ach.Points
 		}
-		report.TotalPoints += ach.Points
-		report.SeasonalPoints += ach.Points
-		pointsGained += ach.Points
-	}
 
-	// 4. Check for new comeback achievements
-	comebackAchievements := domain.CheckComebackAchievements(report)
-	for _, ach := range comebackAchievements {
-		report.Achievements = domain.AddAchievement(report.Achievements, ach.ID)
-		report.TotalPoints += ach.Points
-		pointsGained += ach.Points
+		comebackAchievements = domain.CheckComebackAchievements(report)
+		for _, ach := range comebackAchievements {
+			report.Achievements = domain.AddAchievement(report.Achievements, ach.ID)
+			report.TotalPoints += ach.Points
+			pointsGained += ach.Points
+		}
 	}
 
 	freezeAwarded := false
-	for _, ach := range newAchievements {
-		if ach.ID == "streak_4" && report.StreakFreezes < 2 {
-			report.StreakFreezes++
-			freezeAwarded = true
+	if isFullReport {
+		for _, ach := range newAchievements {
+			if ach.ID == "streak_4" && report.StreakFreezes < 2 {
+				report.StreakFreezes++
+				freezeAwarded = true
+			}
 		}
 	}
 
-	// 5. Persist numeric RPG level. It is derived from lifetime EXP, then stored
-	// so the value remains available across season resets and deployments.
 	report.Level = domain.NumericLevelFromTotalPoints(report.TotalPoints)
 	leveledUp := report.Level > oldNumericLevel
 
@@ -203,12 +209,10 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 		return "", err
 	}
 
-	// 6. Construct Response
-	isComeback := report.InactiveDays > 3 && report.Streak == 1
+	isComeback := isFullReport && report.InactiveDays > 3 && report.Streak == 1
 	var response string
 
 	if isComeback {
-		// Special comeback message
 		response = fmt.Sprintf("🎉 WELCOME BACK, %s! 🎉\n", name)
 		response += fmt.Sprintf("Kamu kembali setelah %d hari absen. Itu butuh keberanian! 💪\n", report.InactiveDays)
 		response += "Streak kamu direset, tapi totalmu tetap tersimpan.\n"
@@ -218,7 +222,6 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 		response += fmt.Sprintf("\n📊 Level: Lv.%d • %s (Total: %d pts)\n", report.Level, domain.FormatLevel(report.TotalPoints), report.TotalPoints)
 		response += fmt.Sprintf("📅 Total hari aktif: %d\n", report.ActivityCount)
 
-		// Show comeback challenge info
 		nextComebackAch := uc.getNextComebackTarget(report)
 		if nextComebackAch != nil {
 			response += fmt.Sprintf("\n🔥 Comeback Challenge dimulai! Raih %d minggu berturut-turut untuk unlock \"%s\"!", nextComebackAch.MinComebackStreak, nextComebackAch.Name)
@@ -226,7 +229,6 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 			response += "\n🔥 Comeback Challenge dimulai! Ayo bangun streak-mu kembali!"
 		}
 	} else {
-		// Normal report message with EXP breakdown
 		cyclePrefix := ""
 		if report.CenturionCycles > 0 {
 			cyclePrefix = fmt.Sprintf("[C%d] ", report.CenturionCycles+1)
@@ -239,39 +241,44 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 		if seasonalFirstBonus > 0 {
 			expBreakdown += " (first season report +5)"
 		}
+		if isRepeatReport {
+			expBreakdown += " (repeat report, ½ XP)"
+		}
 
-		response = fmt.Sprintf("Laporan diterima, %s%s sudah berkeringat %d hari. Lanjutkan 🔥 (streak %d minggu)\n%s",
-			cyclePrefix, name, report.ActivityCount, report.Streak, expBreakdown)
+		if isRepeatReport {
+			response = fmt.Sprintf("Laporan diterima (laporan ke-%d hari ini), %s%s sudah berkeringat %d hari. Lanjutkan 🔥 (streak %d minggu)\n%s",
+				dailyCount+1, cyclePrefix, name, report.ActivityCount, report.Streak, expBreakdown)
+		} else {
+			response = fmt.Sprintf("Laporan diterima, %s%s sudah berkeringat %d hari. Lanjutkan 🔥 (streak %d minggu)\n%s",
+				cyclePrefix, name, report.ActivityCount, report.Streak, expBreakdown)
+		}
 		if report.JobClass != "" {
 			response += fmt.Sprintf("\n🧭 Job: %s", domain.FormatJobClass(report.JobClass))
 		}
 	}
 
-	// 7. Add Centurion Milestone Message
-	if report.ActivityCount == 1 && report.CenturionCycles > 0 && !isComeback {
+	if isFullReport && report.ActivityCount == 1 && report.CenturionCycles > 0 && !isComeback {
 		response = "🔥 *ERA BARU DIMULAI!* 🔥\n" +
 			fmt.Sprintf("Selamat %s, Anda telah menyelesaikan 100 hari sebelumnya.\n", name) +
 			fmt.Sprintf("Sekarang Anda memulai *Siklus %d (Hari ke-1)*. Terus jaga konsistensi! 💪\n\n", report.CenturionCycles+1) +
 			response
-	} else if report.ActivityCount == 100 {
+	} else if isFullReport && report.ActivityCount == 100 {
 		response = "🎊 *LUAR BIASA!* 🎊\n" +
 			fmt.Sprintf("Selamat %s, Anda mencapai *HARI KE-100*! 💯\n", name) +
 			"Anda sekarang resmi menyandang gelar *CENTURION 🛡️*. Nama Anda telah diabdikan dalam jajaran legenda grup!\n\n" +
 			response
 	}
 
-	// Append Workout Details if present
 	if workout != nil {
 		response += "\n" + uc.formatWorkout(workout)
 	}
 
-	// Append Gamification Notifications
 	if streakFreezeUsed {
 		response += fmt.Sprintf("\n\n❄️ *Streak Freeze terpakai!* Streak kamu aman. (Sisa freeze: %d)", report.StreakFreezes)
 	}
 
 	if newRecord {
-		response += fmt.Sprintf("\n\n🏆 New Personal Best Streak: %d minggu!", report.Streak)
+		response += fmt.Sprintf("\n\n🏆 New Personal Best Streak: %d minggu!", report.MaxStreak)
 	}
 
 	if leveledUp {
@@ -301,7 +308,265 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 		response += fmt.Sprintf("\n\n💰 Total: +%d points (Lifetime: %d | Season: %d)", totalPointsGained, report.TotalPoints, report.SeasonalPoints)
 	}
 
-	// Show progress bar
+	response += fmt.Sprintf("\n%s", domain.FormatNumericLevelProgressBar(report.TotalPoints))
+	response += fmt.Sprintf("\n%s", domain.FormatProgressBar(report.TotalPoints))
+
+	return response, nil
+}
+
+func (uc *ReportActivityUsecase) ExecuteYesterday(ctx context.Context, userID, name string, workout *domain.HevyWorkout) (string, error) {
+	lock := uc.userLock(userID)
+	lock.Lock()
+	defer lock.Unlock()
+
+	report, err := uc.repo.GetReport(ctx, userID)
+	if err != nil {
+		return "", err
+	}
+
+	now := time.Now()
+	today := domain.GetToday(now)
+	yesterday := today.AddDate(0, 0, -1)
+
+	dailyCount, err := uc.repo.GetDailyActivityCount(ctx, userID, yesterday)
+	if err != nil {
+		return "", err
+	}
+	if dailyCount >= MaxDailyReports {
+		return fmt.Sprintf("%s sudah mencapai batas maksimal %dx laporan untuk hari kemarin. 🙏", report.Name, MaxDailyReports), nil
+	}
+
+	if report != nil && domain.GetToday(report.LastReportDate).Equal(today) {
+		return fmt.Sprintf("%s sudah laporan hari ini. Gunakan #lapor untuk laporan tambahan hari ini. 💪", report.Name), nil
+	}
+
+	if report != nil {
+		lastReportDate := domain.GetToday(report.LastReportDate)
+		daysSinceLastReport := int(math.Round(today.Sub(lastReportDate).Hours() / 24))
+		if daysSinceLastReport < 2 {
+			return fmt.Sprintf("%s sudah laporan dalam 2 hari terakhir. Tidak perlu lapor ulang untuk hari kemarin. 🙏", report.Name), nil
+		}
+	}
+
+	streakFreezeUsed := false
+
+	if report != nil {
+		storedName := report.Name
+		name = reportName(storedName, name)
+		shouldUpdateStoredName := isUnknownName(storedName) && strings.TrimSpace(storedName) != name
+		if shouldUpdateStoredName {
+			report.Name = name
+		}
+
+		lastReportDate := domain.GetToday(report.LastReportDate)
+		currentWeekStart := domain.GetStartOfISOWeek(yesterday)
+		lastWeekStart := domain.GetStartOfISOWeek(lastReportDate)
+		weeksSinceLastReport := int(math.Round(currentWeekStart.Sub(lastWeekStart).Hours() / (24 * 7)))
+
+		if currentWeekStart.Equal(lastWeekStart) {
+		} else if weeksSinceLastReport == 1 {
+			report.Streak++
+			report.ComebackStreak++
+		} else if weeksSinceLastReport == 2 && report.StreakFreezes > 0 {
+			report.StreakFreezes--
+			report.Streak++
+			report.ComebackStreak++
+			streakFreezeUsed = true
+		} else {
+			report.InactiveDays = int(math.Round(today.Sub(lastReportDate).Hours()/24)) - 1
+			report.ComebackStreak = 1
+			report.Streak = 1
+		}
+		report.ActivityCount++
+		report.SeasonalActivityCount++
+		if report.Streak > report.SeasonalMaxStreak {
+			report.SeasonalMaxStreak = report.Streak
+		}
+
+		if report.ActivityCount > 100 {
+			report.ActivityCount = 1
+			report.CenturionCycles++
+		}
+
+		report.LastReportDate = now.AddDate(0, 0, -1)
+		name = report.Name
+	} else {
+		name = reportName("", name)
+		report = &domain.Report{
+			UserID:                userID,
+			Name:                  name,
+			Streak:                1,
+			ActivityCount:         1,
+			SeasonalActivityCount: 1,
+			SeasonalMaxStreak:     1,
+			LastReportDate:        now.AddDate(0, 0, -1),
+			MaxStreak:             0,
+			TotalPoints:           0,
+			SeasonalPoints:        0,
+			Achievements:          "",
+			SeasonalAchievements:  "",
+			ComebackStreak:        1,
+			InactiveDays:          0,
+			StreakFreezes:         1,
+		}
+	}
+
+	if report.MaxStreak == 0 {
+		report.MaxStreak = 1
+	}
+	oldNumericLevel := domain.NumericLevelFromTotalPoints(report.TotalPoints)
+
+	newRecord := false
+	if report.Streak > report.MaxStreak {
+		report.MaxStreak = report.Streak
+		if report.Streak > 1 {
+			newRecord = true
+		}
+	}
+
+	basePoints := 5
+	streakBonus := 0
+	seasonalFirstBonus := 0
+	if report.Streak > 1 {
+		streakBonus = (2 * (report.Streak - 1)) / 2
+		if streakBonus < 0 {
+			streakBonus = 0
+		}
+	}
+	if report.SeasonalActivityCount == 1 {
+		seasonalFirstBonus = 2
+	}
+	reportPoints := basePoints + streakBonus + seasonalFirstBonus
+	report.TotalPoints += reportPoints
+	report.SeasonalPoints += reportPoints
+
+	newAchievements := domain.CheckNewSeasonAchievements(report)
+	pointsGained := 0
+
+	for _, ach := range newAchievements {
+		report.SeasonalAchievements = domain.AddAchievement(report.SeasonalAchievements, ach.ID)
+		if !domain.HasAchievement(report.Achievements, ach.ID) {
+			report.Achievements = domain.AddAchievement(report.Achievements, ach.ID)
+		}
+		report.TotalPoints += ach.Points
+		report.SeasonalPoints += ach.Points
+		pointsGained += ach.Points
+	}
+
+	comebackAchievements := domain.CheckComebackAchievements(report)
+	for _, ach := range comebackAchievements {
+		report.Achievements = domain.AddAchievement(report.Achievements, ach.ID)
+		report.TotalPoints += ach.Points
+		pointsGained += ach.Points
+	}
+
+	freezeAwarded := false
+	for _, ach := range newAchievements {
+		if ach.ID == "streak_4" && report.StreakFreezes < 2 {
+			report.StreakFreezes++
+			freezeAwarded = true
+		}
+	}
+
+	report.Level = domain.NumericLevelFromTotalPoints(report.TotalPoints)
+	leveledUp := report.Level > oldNumericLevel
+
+	if err := uc.repo.UpsertReportWithActivity(ctx, report, yesterday); err != nil {
+		return "", err
+	}
+
+	isComeback := report.InactiveDays > 3 && report.Streak == 1
+	var response string
+
+	if isComeback {
+		response = fmt.Sprintf("🎉 WELCOME BACK, %s! 🎉\n", name)
+		response += fmt.Sprintf("Kamu kembali setelah %d hari absen. Itu butuh keberanian! 💪\n", report.InactiveDays)
+		response += "Streak kamu direset, tapi totalmu tetap tersimpan.\n"
+		if report.JobClass != "" {
+			response += fmt.Sprintf("🧭 Job: %s\n", domain.FormatJobClass(report.JobClass))
+		}
+		response += fmt.Sprintf("\n📊 Level: Lv.%d • %s (Total: %d pts)\n", report.Level, domain.FormatLevel(report.TotalPoints), report.TotalPoints)
+		response += fmt.Sprintf("📅 Total hari aktif: %d\n", report.ActivityCount)
+
+		nextComebackAch := uc.getNextComebackTarget(report)
+		if nextComebackAch != nil {
+			response += fmt.Sprintf("\n🔥 Comeback Challenge dimulai! Raih %d minggu berturut-turut untuk unlock \"%s\"!", nextComebackAch.MinComebackStreak, nextComebackAch.Name)
+		} else {
+			response += "\n🔥 Comeback Challenge dimulai! Ayo bangun streak-mu kembali!"
+		}
+	} else {
+		cyclePrefix := ""
+		if report.CenturionCycles > 0 {
+			cyclePrefix = fmt.Sprintf("[C%d] ", report.CenturionCycles+1)
+		}
+
+		expBreakdown := fmt.Sprintf("⭐ +%d pts", basePoints)
+		if streakBonus > 0 {
+			expBreakdown += fmt.Sprintf(" (streak bonus +%d)", streakBonus)
+		}
+		if seasonalFirstBonus > 0 {
+			expBreakdown += " (first season report +2)"
+		}
+		expBreakdown += " (lapor kemarin, ½ XP)"
+
+		response = fmt.Sprintf("Laporan kemarin diterima, %s%s sudah berkeringat %d hari. Lanjutkan 🔥 (streak %d minggu)\n%s",
+			cyclePrefix, name, report.ActivityCount, report.Streak, expBreakdown)
+		if report.JobClass != "" {
+			response += fmt.Sprintf("\n🧭 Job: %s", domain.FormatJobClass(report.JobClass))
+		}
+	}
+
+	if report.ActivityCount == 1 && report.CenturionCycles > 0 && !isComeback {
+		response = "🔥 *ERA BARU DIMULAI!* 🔥\n" +
+			fmt.Sprintf("Selamat %s, Anda telah menyelesaikan 100 hari sebelumnya.\n", name) +
+			fmt.Sprintf("Sekarang Anda memulai *Siklus %d (Hari ke-1)*. Terus jaga konsistensi! 💪\n\n", report.CenturionCycles+1) +
+			response
+	} else if report.ActivityCount == 100 {
+		response = "🎊 *LUAR BIASA!* 🎊\n" +
+			fmt.Sprintf("Selamat %s, Anda mencapai *HARI KE-100*! 💯\n", name) +
+			"Anda sekarang resmi menyandang gelar *CENTURION 🛡️*. Nama Anda telah diabdikan dalam jajaran legenda grup!\n\n" +
+			response
+	}
+
+	if workout != nil {
+		response += "\n" + uc.formatWorkout(workout)
+	}
+
+	if streakFreezeUsed {
+		response += fmt.Sprintf("\n\n❄️ *Streak Freeze terpakai!* Streak kamu aman. (Sisa freeze: %d)", report.StreakFreezes)
+	}
+
+	if newRecord {
+		response += fmt.Sprintf("\n\n🏆 New Personal Best Streak: %d minggu!", report.MaxStreak)
+	}
+
+	if leveledUp {
+		response += fmt.Sprintf("\n\n⚔️ *LEVEL UP!* Lv.%d → Lv.%d", oldNumericLevel, report.Level)
+	}
+
+	if len(newAchievements)+len(comebackAchievements) > 0 {
+		response += "\n\n🏅 *Badge baru:*"
+		for _, ach := range newAchievements {
+			response += fmt.Sprintf("\n%s %s (+%d pts)", ach.DisplayEmoji, ach.Name, ach.Points)
+		}
+		for _, ach := range comebackAchievements {
+			response += fmt.Sprintf("\n%s %s (+%d pts)", ach.DisplayEmoji, ach.Name, ach.Points)
+		}
+
+		if freezeAwarded {
+			response += fmt.Sprintf("\n\n❄️ Bonus: +1 Streak Freeze! (Total: %d)", report.StreakFreezes)
+		}
+
+		response += "\nDetail badge & cerita unlock: #achievements"
+	}
+
+	response += fmt.Sprintf("\n\n💬 _\"%s\"_", RandomQuote())
+
+	totalPointsGained := reportPoints + pointsGained
+	if totalPointsGained > 0 {
+		response += fmt.Sprintf("\n\n💰 Total: +%d points (Lifetime: %d | Season: %d)", totalPointsGained, report.TotalPoints, report.SeasonalPoints)
+	}
+
 	response += fmt.Sprintf("\n%s", domain.FormatNumericLevelProgressBar(report.TotalPoints))
 	response += fmt.Sprintf("\n%s", domain.FormatProgressBar(report.TotalPoints))
 
@@ -348,7 +613,6 @@ func (uc *ReportActivityUsecase) formatWorkout(workout *domain.HevyWorkout) stri
 	return res
 }
 
-// getNextComebackTarget finds the next comeback achievement the user can target.
 func (uc *ReportActivityUsecase) getNextComebackTarget(report *domain.Report) *domain.ComebackAchievement {
 	for i := range domain.AllComebackAchievements {
 		a := &domain.AllComebackAchievements[i]

--- a/internal/app/usecase/report_activity_usecase_test.go
+++ b/internal/app/usecase/report_activity_usecase_test.go
@@ -12,6 +12,7 @@ import (
 type mockRepo struct {
 	reports        map[string]*domain.Report
 	activityCounts []domain.ActivityLeaderboardEntry
+	dailyCounts    map[string]int
 }
 
 func (m *mockRepo) GetReport(ctx context.Context, userID string) (*domain.Report, error) {
@@ -25,6 +26,11 @@ func (m *mockRepo) UpsertReport(ctx context.Context, report *domain.Report) erro
 
 func (m *mockRepo) UpsertReportWithActivity(ctx context.Context, report *domain.Report, activityDate time.Time) error {
 	m.reports[report.UserID] = report
+	key := report.UserID + "|" + activityDate.Format(time.DateOnly)
+	if m.dailyCounts == nil {
+		m.dailyCounts = make(map[string]int)
+	}
+	m.dailyCounts[key]++
 	return nil
 }
 
@@ -81,8 +87,20 @@ func (m *mockRepo) DeleteActivityLog(ctx context.Context, userID string, activit
 	return nil
 }
 
+func (m *mockRepo) DeleteLatestActivityLog(ctx context.Context, userID string, activityDate time.Time) (int, error) {
+	return 0, nil
+}
+
 func (m *mockRepo) DeleteReport(ctx context.Context, userID string) error {
 	return nil
+}
+
+func (m *mockRepo) GetDailyActivityCount(ctx context.Context, userID string, date time.Time) (int, error) {
+	key := userID + "|" + date.Format(time.DateOnly)
+	if m.dailyCounts == nil {
+		return 0, nil
+	}
+	return m.dailyCounts[key], nil
 }
 
 // =============================================================================
@@ -101,7 +119,7 @@ func (m *mockRepo) DeleteReport(ctx context.Context, userID string) error {
 // =============================================================================
 
 func TestStreak_FirstReport(t *testing.T) {
-	repo := &mockRepo{reports: make(map[string]*domain.Report)}
+	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
 	uc := usecase.NewReportActivityUsecase(repo)
 	ctx := context.Background()
 
@@ -144,7 +162,7 @@ func TestStreak_FirstReport(t *testing.T) {
 }
 
 func TestStreak_ConsecutiveDay_StreakIncreases(t *testing.T) {
-	repo := &mockRepo{reports: make(map[string]*domain.Report)}
+	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
 	uc := usecase.NewReportActivityUsecase(repo)
 	ctx := context.Background()
 
@@ -174,7 +192,7 @@ func TestStreak_ConsecutiveDay_StreakIncreases(t *testing.T) {
 }
 
 func TestStreak_MissedDay_StreakResets(t *testing.T) {
-	repo := &mockRepo{reports: make(map[string]*domain.Report)}
+	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
 	uc := usecase.NewReportActivityUsecase(repo)
 	ctx := context.Background()
 
@@ -203,8 +221,8 @@ func TestStreak_MissedDay_StreakResets(t *testing.T) {
 	}
 }
 
-func TestStreak_SameDay_Rejected(t *testing.T) {
-	repo := &mockRepo{reports: make(map[string]*domain.Report)}
+func TestStreak_SameDay_SecondReport(t *testing.T) {
+	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
 	uc := usecase.NewReportActivityUsecase(repo)
 	ctx := context.Background()
 
@@ -217,25 +235,24 @@ func TestStreak_SameDay_Rejected(t *testing.T) {
 		ActivityCount:  15,
 		LastReportDate: now,
 	}
+	// Simulate that the user already has 1 activity logged today
+	repo.dailyCounts["user1|"+domain.GetToday(now).Format(time.DateOnly)] = 1
 
-	// Try to report again same day
+	// Report again same day (second report)
 	msg, err := uc.Execute(ctx, "user1", "Diana", nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// Should be rejected with warning, cancel guidance, and motivation.
-	if !containsSubstring(msg, "Diana sudah laporan hari ini, ayo jangan curang! 😉") {
-		t.Errorf("Same day: expected rejection message, got '%s'", msg)
+	// Should accept but with halved XP
+	if !containsSubstring(msg, "Laporan diterima (laporan ke-2 hari ini)") {
+		t.Errorf("Same day: expected repeat report message, got '%s'", msg)
 	}
-	if !containsSubstring(msg, "#cancel") {
-		t.Errorf("Same day: expected #cancel guidance, got '%s'", msg)
-	}
-	if !containsSubstring(msg, "💬 _\"") {
-		t.Errorf("Same day: expected motivation, got '%s'", msg)
+	if !containsSubstring(msg, "repeat report, ½ XP") {
+		t.Errorf("Same day: expected halved XP note, got '%s'", msg)
 	}
 
-	// Values should NOT change
+	// Values should NOT change (streak and activity count stay same)
 	r := repo.reports["user1"]
 	if r.Streak != 7 {
 		t.Errorf("Same day: Streak should remain 7, got %d", r.Streak)
@@ -245,8 +262,35 @@ func TestStreak_SameDay_Rejected(t *testing.T) {
 	}
 }
 
+func TestStreak_SameDay_MaxReportsReached(t *testing.T) {
+	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
+	uc := usecase.NewReportActivityUsecase(repo)
+	ctx := context.Background()
+
+	now := time.Now()
+	repo.reports["user1"] = &domain.Report{
+		UserID:         "user1",
+		Name:           "Diana",
+		Streak:         7,
+		ActivityCount:  15,
+		LastReportDate: now,
+	}
+	// Simulate that the user already has 3 activities logged today (max)
+	repo.dailyCounts["user1|"+domain.GetToday(now).Format(time.DateOnly)] = 3
+
+	// Fourth report should be rejected
+	msg, err := uc.Execute(ctx, "user1", "Diana", nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !containsSubstring(msg, "sudah laporan 3x hari ini") {
+		t.Errorf("Expected max limit message, got '%s'", msg)
+	}
+}
+
 func TestStreak_SameDay_UsesStoredNameWhenIncomingNameUnknown(t *testing.T) {
-	repo := &mockRepo{reports: make(map[string]*domain.Report)}
+	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
 	uc := usecase.NewReportActivityUsecase(repo)
 	ctx := context.Background()
 
@@ -263,16 +307,16 @@ func TestStreak_SameDay_UsesStoredNameWhenIncomingNameUnknown(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	if !containsSubstring(msg, "Budi sudah laporan hari ini") {
-		t.Fatalf("Duplicate #lapor should use stored name instead of incoming Unknown, got %q", msg)
+	if !containsSubstring(msg, "Budi") {
+		t.Fatalf("Duplicate #lapor should use stored name, got %q", msg)
 	}
-	if containsSubstring(msg, "Unknown sudah laporan hari ini") {
-		t.Fatalf("Duplicate #lapor should not show Unknown when stored name exists, got %q", msg)
+	if containsSubstring(msg, "Unknown") {
+		t.Fatalf("Duplicate #lapor should not show Unknown, got %q", msg)
 	}
 }
 
 func TestStreak_SameDay_HealsUnknownStoredName(t *testing.T) {
-	repo := &mockRepo{reports: make(map[string]*domain.Report)}
+	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
 	uc := usecase.NewReportActivityUsecase(repo)
 	ctx := context.Background()
 
@@ -289,8 +333,8 @@ func TestStreak_SameDay_HealsUnknownStoredName(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	if !containsSubstring(msg, "Budi sudah laporan hari ini") {
-		t.Fatalf("Duplicate #lapor should use incoming valid name when stored name is Unknown, got %q", msg)
+	if !containsSubstring(msg, "Budi") {
+		t.Fatalf("Duplicate #lapor should use incoming valid name, got %q", msg)
 	}
 	if repo.reports["user1"].Name != "Budi" {
 		t.Fatalf("Duplicate #lapor should persist healed name, got %q", repo.reports["user1"].Name)
@@ -301,7 +345,7 @@ func TestStreak_SameDay_HealsUnknownStoredName(t *testing.T) {
 }
 
 func TestStreak_FirstReport_DoesNotPersistUnknownName(t *testing.T) {
-	repo := &mockRepo{reports: make(map[string]*domain.Report)}
+	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
 	uc := usecase.NewReportActivityUsecase(repo)
 	ctx := context.Background()
 
@@ -319,7 +363,7 @@ func TestStreak_FirstReport_DoesNotPersistUnknownName(t *testing.T) {
 }
 
 func TestStreak_ExistingUnknownStoredNameWithUnknownIncomingNormalizesToTeman(t *testing.T) {
-	repo := &mockRepo{reports: make(map[string]*domain.Report)}
+	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
 	uc := usecase.NewReportActivityUsecase(repo)
 	ctx := context.Background()
 
@@ -345,7 +389,7 @@ func TestStreak_ExistingUnknownStoredNameWithUnknownIncomingNormalizesToTeman(t 
 }
 
 func TestStreak_LongGap_StreakResets(t *testing.T) {
-	repo := &mockRepo{reports: make(map[string]*domain.Report)}
+	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
 	uc := usecase.NewReportActivityUsecase(repo)
 	ctx := context.Background()
 
@@ -387,7 +431,7 @@ func TestStreak_LongGap_StreakResets(t *testing.T) {
 // =============================================================================
 
 func TestLeaderboard_RanksByActivityCount(t *testing.T) {
-	repo := &mockRepo{reports: make(map[string]*domain.Report)}
+	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
 	uc := usecase.NewGetLeaderboardUsecase(repo)
 	ctx := context.Background()
 
@@ -448,7 +492,7 @@ func TestLeaderboard_RanksByActivityCount(t *testing.T) {
 // =============================================================================
 
 func TestCenturion_PrestigeTransition(t *testing.T) {
-	repo := &mockRepo{reports: make(map[string]*domain.Report)}
+	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
 	uc := usecase.NewReportActivityUsecase(repo)
 	ctx := context.Background()
 
@@ -502,7 +546,7 @@ func TestCenturion_PrestigeTransition(t *testing.T) {
 }
 
 func TestLeaderboard_CenturionSorting(t *testing.T) {
-	repo := &mockRepo{reports: make(map[string]*domain.Report)}
+	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
 	uc := usecase.NewGetLeaderboardUsecase(repo)
 	ctx := context.Background()
 

--- a/internal/domain/report.go
+++ b/internal/domain/report.go
@@ -75,8 +75,11 @@ type ReportRepository interface {
 	ResolveLIDToPhone(ctx context.Context, lid string) string
 
 	DeleteActivityLog(ctx context.Context, userID string, activityDate time.Time) error
+	DeleteLatestActivityLog(ctx context.Context, userID string, activityDate time.Time) (int, error)
 	GetUserActivityDates(ctx context.Context, userID string) ([]time.Time, error)
 	DeleteReport(ctx context.Context, userID string) error
+
+	GetDailyActivityCount(ctx context.Context, userID string, date time.Time) (int, error)
 
 	// Strava Integration
 	UpsertStravaAccount(ctx context.Context, account *StravaAccount) error

--- a/internal/infra/sqlite/report_repository.go
+++ b/internal/infra/sqlite/report_repository.go
@@ -98,8 +98,11 @@ func (r *ReportRepository) UpsertReport(ctx context.Context, report *domain.Repo
 
 func logActivity(ctx context.Context, execer execContexter, userID string, activityDate time.Time) error {
 	query := `
-		INSERT OR IGNORE INTO activity_logs (user_id, activity_date, created_at)
-		VALUES (?, ?, ?)
+		INSERT INTO activity_logs (user_id, activity_date, created_at, report_count)
+		VALUES (?, ?, ?, 1)
+		ON CONFLICT(user_id, activity_date) DO UPDATE SET
+			report_count = report_count + 1,
+			created_at = excluded.created_at
 	`
 	_, err := execer.ExecContext(ctx, query, userID, activityDate.Format(time.DateOnly), time.Now().UTC().Format(time.RFC3339))
 	return err
@@ -227,6 +230,7 @@ func (r *ReportRepository) InitTable(ctx context.Context) error {
 			user_id TEXT NOT NULL,
 			activity_date TEXT NOT NULL,
 			created_at TEXT NOT NULL,
+			report_count INTEGER NOT NULL DEFAULT 1,
 			PRIMARY KEY (user_id, activity_date),
 			FOREIGN KEY (user_id) REFERENCES user_reports(user_id) ON DELETE CASCADE
 		);
@@ -274,6 +278,7 @@ func (r *ReportRepository) InitTable(ctx context.Context) error {
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN seasonal_max_streak INTEGER DEFAULT 0")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN seasonal_achievements TEXT DEFAULT ''")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN streak_freezes INTEGER DEFAULT 1")
+	_, _ = r.db.ExecContext(ctx, "ALTER TABLE activity_logs ADD COLUMN report_count INTEGER NOT NULL DEFAULT 1")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE strava_accounts ADD COLUMN name TEXT")
 
 	// Run data migrations
@@ -498,12 +503,59 @@ func (r *ReportRepository) DeleteActivityLog(ctx context.Context, userID string,
 	return err
 }
 
+func (r *ReportRepository) DeleteLatestActivityLog(ctx context.Context, userID string, activityDate time.Time) (int, error) {
+	date := activityDate.Format(time.DateOnly)
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	var count int
+	err = tx.QueryRowContext(ctx, `SELECT COALESCE(report_count, 1) FROM activity_logs WHERE user_id = ? AND activity_date = ?`, userID, date).Scan(&count)
+	if err == sql.ErrNoRows {
+		_ = tx.Rollback()
+		return 0, nil
+	}
+	if err != nil {
+		_ = tx.Rollback()
+		return 0, err
+	}
+
+	remaining := count - 1
+	if remaining > 0 {
+		if _, err := tx.ExecContext(ctx, `UPDATE activity_logs SET report_count = ? WHERE user_id = ? AND activity_date = ?`, remaining, userID, date); err != nil {
+			_ = tx.Rollback()
+			return 0, err
+		}
+	} else {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM activity_logs WHERE user_id = ? AND activity_date = ?`, userID, date); err != nil {
+			_ = tx.Rollback()
+			return 0, err
+		}
+	}
+
+	return remaining, tx.Commit()
+}
+
 func (r *ReportRepository) DeleteReport(ctx context.Context, userID string) error {
 	if _, err := r.db.ExecContext(ctx, `DELETE FROM activity_logs WHERE user_id = ?`, userID); err != nil {
 		return err
 	}
 	_, err := r.db.ExecContext(ctx, `DELETE FROM user_reports WHERE user_id = ?`, userID)
 	return err
+}
+
+func (r *ReportRepository) GetDailyActivityCount(ctx context.Context, userID string, date time.Time) (int, error) {
+	query := `SELECT COALESCE(report_count, 1) FROM activity_logs WHERE user_id = ? AND activity_date = ?`
+	var count int
+	err := r.db.QueryRowContext(ctx, query, userID, date.Format(time.DateOnly)).Scan(&count)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func (r *ReportRepository) GetStravaAccountByUserID(ctx context.Context, userID string) (*domain.StravaAccount, error) {


### PR DESCRIPTION
- Add ExecuteAll in CancelReportUsecase with shared helper
- Enforce daily limit of 3 reports per user via GetDailyActivityCount
- Delete latest daily log when cancelling a single report
- Extend repository with GetDailyActivityCount and DeleteLatestActivityLog
- Persist per-day report_count in activity_logs and increment on log
- Wire #cancel-all support in message handler