### PR TITLE
feat(goal): add weekly goal usecase and persistence

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -52,6 +52,7 @@ func main() {
 	resetSessionUC := usecase.NewResetSessionUsecase(repo)
 	motivationUC := usecase.NewGetMotivationUsecase()
 	helpUC := usecase.NewGetHelpUsecase()
+	goalUC := usecase.NewGoalUsecase(repo)
 
 	// Strava Integration
 	stravaClient := strava.NewClient(cfg)
@@ -253,7 +254,29 @@ func main() {
 		log.Fatalf("Invalid NOTIFY_LEADERBOARD_TIME %q: %v", cfg.NotifyLeaderboardTime, err)
 	}
 
+	goalCleanupSchedule, err := scheduler.ParseDaily("00:10", jakartaLoc)
+	if err != nil {
+		log.Fatalf("Invalid goal cleanup schedule: %v", err)
+	}
+
 	sched := scheduler.NewScheduler(appCtx)
+
+	sched.AddJob(&scheduler.Job{
+		Name:    "goal-cleanup",
+		Freq:    goalCleanupSchedule,
+		Recover: false,
+		Fn: func(ctx context.Context) error {
+			deleted, err := goalUC.CleanupExpired(ctx, time.Now().In(jakartaLoc))
+			if err != nil {
+				log.Printf("[SCHEDULER] Goal cleanup failed: %v", err)
+				return err
+			}
+			if deleted > 0 {
+				log.Printf("[SCHEDULER] Goal cleanup deleted %d expired goal(s)", deleted)
+			}
+			return nil
+		},
+	})
 
 	sched.AddJob(&scheduler.Job{
 		Name:    "morning-workout-checkpoint",

--- a/internal/app/usecase/cancel_report_usecase_test.go
+++ b/internal/app/usecase/cancel_report_usecase_test.go
@@ -103,6 +103,30 @@ func (r *cancelReportRepoStub) GetDailyActivityCount(ctx context.Context, userID
 	return r.dailyCount, nil
 }
 
+func (r *cancelReportRepoStub) SetGoal(ctx context.Context, goal *domain.WeeklyGoal) error {
+	return nil
+}
+
+func (r *cancelReportRepoStub) GetActiveGoal(ctx context.Context, userID string, now time.Time) (*domain.WeeklyGoal, error) {
+	return nil, nil
+}
+
+func (r *cancelReportRepoStub) DeleteActiveGoal(ctx context.Context, userID string, now time.Time) error {
+	return nil
+}
+
+func (r *cancelReportRepoStub) DeleteExpiredGoals(ctx context.Context, now time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (r *cancelReportRepoStub) GetGoalActivities(ctx context.Context, userID string, startDate, endDate time.Time) ([]domain.GoalActivity, error) {
+	return nil, nil
+}
+
+func (r *cancelReportRepoStub) RecordGoalActivity(ctx context.Context, userID string, activityDate time.Time, activityText string) (bool, error) {
+	return false, nil
+}
+
 func TestCancelReport_NoReport(t *testing.T) {
 	repo := &cancelReportRepoStub{report: nil}
 	uc := NewCancelReportUsecase(repo)

--- a/internal/app/usecase/get_achievements_usecase.go
+++ b/internal/app/usecase/get_achievements_usecase.go
@@ -31,6 +31,7 @@ func (uc *GetAchievementsUsecase) Execute(ctx context.Context) (string, error) {
 	// Calculate season badge stats. Lifetime achievements are preserved in the
 	// database, but the visible badge race resets every season.
 	stats := make(map[string]int)
+	goalTotal := 0
 	for _, r := range reports {
 		if r.SeasonalAchievements != "" {
 			ids := strings.Split(r.SeasonalAchievements, ",")
@@ -38,6 +39,7 @@ func (uc *GetAchievementsUsecase) Execute(ctx context.Context) (string, error) {
 				stats[strings.TrimSpace(id)]++
 			}
 		}
+		goalTotal += r.GoalsCompleted
 	}
 
 	seasonNumber, _ := GetCurrentSessionInfo(time.Now())
@@ -73,6 +75,11 @@ func (uc *GetAchievementsUsecase) Execute(ctx context.Context) (string, error) {
 		}
 		sb.WriteString("\n")
 	}
+
+	sb.WriteString("🎯 *Goal Mingguan*\n")
+	sb.WriteString(fmt.Sprintf("🏆 Total goal tercapai grup: %d\n", goalTotal))
+	sb.WriteString("   Syarat: set #goal, lalu penuhi target hari aktif dalam 7 hari sejak goal dibuat. Laporan dobel di hari yang sama tetap dihitung 1.\n")
+	sb.WriteString("   _Goal adalah quest mingguan: kecil, jelas, dan selesai lewat aksi harian._\n\n")
 
 	sb.WriteString("⚔️ Level numerik naik dari total EXP lifetime. Semakin tinggi level, semakin banyak EXP yang dibutuhkan.")
 

--- a/internal/app/usecase/get_help_usecase.go
+++ b/internal/app/usecase/get_help_usecase.go
@@ -20,7 +20,12 @@ var helpSections = []struct {
 	{
 		emoji:   "🏆",
 		title:   "Leaderboard & Statistik",
-		content: "*#leaderboard* — Lihat klasemen lifetime (total hari aktif).\n*#leaderboard-weekly* — Lihat klasemen total hari aktif minggu ini.\n*#leaderboard-seasonal* — Lihat klasemen seasonal points.\n*#ranks* — Lihat ranking hunter selama season ini.\n*#mystats* — Cek statistik personal ringkas.",
+		content: "*#leaderboard* — Lihat klasemen lifetime (total hari aktif).\n*#leaderboard-weekly* — Lihat klasemen total hari aktif minggu ini (Senin—Minggu).\n*#leaderboard-seasonal* — Lihat klasemen seasonal points.\n*#ranks* — Lihat ranking hunter selama season ini.\n*#mystats* — Cek statistik personal ringkas.",
+	},
+	{
+		emoji:   "🎯",
+		title:   "Goal Mingguan",
+		content: "*#goal set [1-7] [aktivitas]* — Tetapkan target hari aktif untuk 7 hari ke depan sejak command dikirim. Contoh: `#goal set 3 Olahraga`.\n*#goal* — Lihat progress, waktu mulai, dan waktu berakhir goal aktif.\n*#goal reset* — Hapus goal aktif kalau ingin set ulang.\n\nAlur: set goal → lapor aktivitas dengan #lapor → cek progress dengan #goal → jika target tercapai, total goals di #mystats bertambah.\nLaporan dobel di hari yang sama tetap dihitung 1. Data goal yang sudah lewat dibersihkan otomatis setiap 00:10.",
 	},
 	{
 		emoji:   "🎖️",
@@ -68,6 +73,9 @@ func (uc *GetHelpUsecase) Execute() string {
 ❌ #cancel — batalkan laporan hari ini
 🧹 #cancel-all — batalkan semua laporan hari ini
 📊 #mystats — statistik personal
+🎯 #goal set [1-7] [aktivitas] — set goal 7 hari sejak sekarang
+🎯 #goal — progress goal aktif
+🔄 #goal reset — reset goal aktif
 🏆 #leaderboard — leaderboard lifetime
 📅 #leaderboard-weekly — leaderboard minggu ini
 🏹 #leaderboard-seasonal — leaderboard season
@@ -96,6 +104,12 @@ func (uc *GetHelpUsecase) ExecuteTutorial() string {
 	msg += "Level lifetime dimulai dari Lv.0 dan naik dari total points/EXP. Semakin tinggi level, semakin banyak EXP yang dibutuhkan untuk naik level. Season boleh reset, tapi level lifetime tetap lanjut.\n\n"
 	msg += "🏅 *Badge*\n"
 	msg += "Notifikasi #lapor hanya menampilkan badge terbaru supaya ringkas. Untuk syarat, poin, dan cerita unlock lengkap, buka #achievements.\n\n"
+	msg += "🎯 *Flow Goal Mingguan*\n"
+	msg += "1. Set target: `#goal set 3 Olahraga` (maksimal 7).\n"
+	msg += "2. Window goal berjalan 7 hari dari waktu kamu set, bukan kalender Senin—Minggu.\n"
+	msg += "3. Lapor aktivitas dengan `#lapor`; laporan dobel di hari yang sama tetap dihitung 1 untuk goal.\n"
+	msg += "4. Cek progress kapan saja dengan `#goal`. Jika ingin ganti target saat masih aktif, pakai `#goal reset` dulu.\n"
+	msg += "5. Saat target tercapai, total goals di `#mystats` dan `#achievements` bertambah.\n\n"
 	msg += "_Catatan: Bot hanya merespon di grup yang sudah dikonfigurasi. Semangat terus! 💪_"
 	return msg
 }

--- a/internal/app/usecase/get_mystats_usecase.go
+++ b/internal/app/usecase/get_mystats_usecase.go
@@ -32,7 +32,7 @@ func (uc *GetMyStatsUsecase) Execute(ctx context.Context, userID, name string) (
 	}
 
 	now := uc.now()
-	weekStart := domain.GetStartOfSundayWeek(now)
+	weekStart := domain.GetStartOfISOWeekStrict(now)
 	weekEnd := weekStart.AddDate(0, 0, 7)
 	weeklyEntries, err := uc.repo.GetActivityCountsByDateRange(ctx, weekStart, weekEnd)
 	if err != nil {
@@ -81,6 +81,7 @@ func (uc *GetMyStatsUsecase) Execute(ctx context.Context, userID, name string) (
 	sb.WriteString(fmt.Sprintf("🏅 Badge season: %d/%d\n", seasonBadgeCount, len(domain.AllSeasonAchievements)))
 	sb.WriteString(fmt.Sprintf("🗓️ Hari season: %d\n", seasonCount))
 	sb.WriteString(fmt.Sprintf("📆 Hari minggu ini: %d\n\n", weeklyCount))
+	sb.WriteString(fmt.Sprintf("🎯 Goals tercapai: %d\n\n", report.GoalsCompleted))
 
 	sb.WriteString(fmt.Sprintf("🔥 Streak saat ini: %d minggu\n", report.Streak))
 	sb.WriteString(fmt.Sprintf("🏆 Streak tertinggi: %d minggu\n", report.MaxStreak))

--- a/internal/app/usecase/get_mystats_usecase_test.go
+++ b/internal/app/usecase/get_mystats_usecase_test.go
@@ -88,21 +88,46 @@ func (r *myStatsRepoStub) GetDailyActivityCount(ctx context.Context, userID stri
 	return 0, nil
 }
 
+func (r *myStatsRepoStub) SetGoal(ctx context.Context, goal *domain.WeeklyGoal) error {
+	return nil
+}
+
+func (r *myStatsRepoStub) GetActiveGoal(ctx context.Context, userID string, now time.Time) (*domain.WeeklyGoal, error) {
+	return nil, nil
+}
+
+func (r *myStatsRepoStub) DeleteActiveGoal(ctx context.Context, userID string, now time.Time) error {
+	return nil
+}
+
+func (r *myStatsRepoStub) DeleteExpiredGoals(ctx context.Context, now time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (r *myStatsRepoStub) GetGoalActivities(ctx context.Context, userID string, startDate, endDate time.Time) ([]domain.GoalActivity, error) {
+	return nil, nil
+}
+
+func (r *myStatsRepoStub) RecordGoalActivity(ctx context.Context, userID string, activityDate time.Time, activityText string) (bool, error) {
+	return false, nil
+}
+
 func TestGetMyStatsUsecase_IncludesSeasonAndWeeklyCounts(t *testing.T) {
 	fixedNow := time.Date(2026, time.June, 10, 9, 0, 0, 0, time.UTC)
-	weekStart := time.Date(2026, time.June, 7, 0, 0, 0, 0, time.UTC)
-	weekEnd := time.Date(2026, time.June, 14, 0, 0, 0, 0, time.UTC)
+	weekStart := time.Date(2026, time.June, 8, 0, 0, 0, 0, time.UTC)
+	weekEnd := time.Date(2026, time.June, 15, 0, 0, 0, 0, time.UTC)
 	seasonStart := time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC)
 	seasonEnd := time.Date(2026, time.September, 1, 0, 0, 0, 0, time.FixedZone("WIB", 7*3600))
 
 	repo := &myStatsRepoStub{
 		report: &domain.Report{
-			UserID:        "user1",
-			Name:          "Gamer",
-			Streak:        10,
-			ActivityCount: 10,
-			MaxStreak:     12,
-			TotalPoints:   50,
+			UserID:         "user1",
+			Name:           "Gamer",
+			Streak:         10,
+			ActivityCount:  10,
+			MaxStreak:      12,
+			TotalPoints:    50,
+			GoalsCompleted: 2,
 		},
 		entries: map[string][]domain.ActivityLeaderboardEntry{
 			weekStart.Format(time.DateOnly) + "|" + weekEnd.Format(time.DateOnly): {
@@ -136,5 +161,8 @@ func TestGetMyStatsUsecase_IncludesSeasonAndWeeklyCounts(t *testing.T) {
 	}
 	if !contains(result, "📆 Hari minggu ini: 3") {
 		t.Fatalf("expected weekly count in response, got %q", result)
+	}
+	if !contains(result, "🎯 Goals tercapai: 2") {
+		t.Fatalf("expected goal count in response, got %q", result)
 	}
 }

--- a/internal/app/usecase/get_weekly_leaderboard_usecase.go
+++ b/internal/app/usecase/get_weekly_leaderboard_usecase.go
@@ -24,7 +24,7 @@ func NewGetWeeklyLeaderboardUsecase(repo domain.ReportRepository) *GetWeeklyLead
 
 func (uc *GetWeeklyLeaderboardUsecase) Execute(ctx context.Context) (string, error) {
 	now := uc.now()
-	weekStart := domain.GetStartOfSundayWeek(now)
+	weekStart := domain.GetStartOfISOWeekStrict(now)
 	weekEnd := weekStart.AddDate(0, 0, 7)
 
 	entries, err := uc.repo.GetActivityCountsByDateRange(ctx, weekStart, weekEnd)

--- a/internal/app/usecase/get_weekly_leaderboard_usecase_test.go
+++ b/internal/app/usecase/get_weekly_leaderboard_usecase_test.go
@@ -88,7 +88,31 @@ func (r *weeklyLeaderboardRepoStub) GetDailyActivityCount(ctx context.Context, u
 	return 0, nil
 }
 
-func TestGetWeeklyLeaderboardUsecase_UsesSundayWeekRange(t *testing.T) {
+func (r *weeklyLeaderboardRepoStub) SetGoal(ctx context.Context, goal *domain.WeeklyGoal) error {
+	return nil
+}
+
+func (r *weeklyLeaderboardRepoStub) GetActiveGoal(ctx context.Context, userID string, now time.Time) (*domain.WeeklyGoal, error) {
+	return nil, nil
+}
+
+func (r *weeklyLeaderboardRepoStub) DeleteActiveGoal(ctx context.Context, userID string, now time.Time) error {
+	return nil
+}
+
+func (r *weeklyLeaderboardRepoStub) DeleteExpiredGoals(ctx context.Context, now time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (r *weeklyLeaderboardRepoStub) GetGoalActivities(ctx context.Context, userID string, startDate, endDate time.Time) ([]domain.GoalActivity, error) {
+	return nil, nil
+}
+
+func (r *weeklyLeaderboardRepoStub) RecordGoalActivity(ctx context.Context, userID string, activityDate time.Time, activityText string) (bool, error) {
+	return false, nil
+}
+
+func TestGetWeeklyLeaderboardUsecase_UsesISOWeekRange(t *testing.T) {
 	repo := &weeklyLeaderboardRepoStub{
 		entries: []domain.ActivityLeaderboardEntry{
 			{Name: "Cici", ActivityCount: 2},
@@ -105,8 +129,8 @@ func TestGetWeeklyLeaderboardUsecase_UsesSundayWeekRange(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	expectedStart := time.Date(2026, time.April, 26, 0, 0, 0, 0, time.UTC)
-	expectedEnd := time.Date(2026, time.May, 3, 0, 0, 0, 0, time.UTC)
+	expectedStart := time.Date(2026, time.April, 27, 0, 0, 0, 0, time.UTC)
+	expectedEnd := time.Date(2026, time.May, 4, 0, 0, 0, 0, time.UTC)
 	if !repo.start.Equal(expectedStart) {
 		t.Fatalf("expected start %v, got %v", expectedStart, repo.start)
 	}
@@ -114,7 +138,7 @@ func TestGetWeeklyLeaderboardUsecase_UsesSundayWeekRange(t *testing.T) {
 		t.Fatalf("expected end %v, got %v", expectedEnd, repo.end)
 	}
 
-	if !contains(result, "Periode: 26-04-2026 s/d sebelum 03-05-2026") {
+	if !contains(result, "Periode: 27-04-2026 s/d sebelum 04-05-2026") {
 		t.Fatalf("expected weekly period in response, got %q", result)
 	}
 	if !contains(result, "1. Budi: 4 hari") {

--- a/internal/app/usecase/goal_usecase.go
+++ b/internal/app/usecase/goal_usecase.go
@@ -1,0 +1,207 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/fardannozami/whatsapp-gateway/internal/domain"
+)
+
+const (
+	maxWeeklyGoalDays = 7
+	goalWindowDays    = 7
+)
+
+var shortIndonesianDays = []string{"Min", "Sen", "Sel", "Rab", "Kam", "Jum", "Sab"}
+var indonesianMonths = []string{"", "Januari", "Februari", "Maret", "April", "Mei", "Juni", "Juli", "Agustus", "September", "Oktober", "November", "Desember"}
+var goalLocation = time.FixedZone("WIB", 7*60*60)
+
+type GoalUsecase struct {
+	repo domain.ReportRepository
+	now  func() time.Time
+}
+
+func NewGoalUsecase(repo domain.ReportRepository) *GoalUsecase {
+	return &GoalUsecase{repo: repo, now: time.Now}
+}
+
+func (uc *GoalUsecase) Execute(ctx context.Context, userID, name, message string) (string, error) {
+	args := strings.Fields(strings.TrimSpace(message))
+	if len(args) >= 2 {
+		switch strings.ToLower(args[1]) {
+		case "set":
+			return uc.set(ctx, userID, args[2:])
+		case "reset":
+			return uc.reset(ctx, userID)
+		}
+	}
+
+	return uc.status(ctx, userID)
+}
+
+func (uc *GoalUsecase) set(ctx context.Context, userID string, args []string) (string, error) {
+	if len(args) == 0 {
+		return "Format goal: #goal set <1-7> [aktivitas]\nContoh: #goal set 3 Olahraga", nil
+	}
+
+	targetDays, err := strconv.Atoi(args[0])
+	if err != nil || targetDays < 1 {
+		return "Target goal harus angka 1 sampai 7. Contoh: #goal set 3 Olahraga", nil
+	}
+	if targetDays > maxWeeklyGoalDays {
+		return "Target goal maksimal 7 hari. 1 minggu = 7 hari ya 🙏", nil
+	}
+
+	now := uc.now()
+	existing, err := uc.repo.GetActiveGoal(ctx, userID, now)
+	if err != nil {
+		return "", err
+	}
+	if existing != nil {
+		return "Kamu masih punya goal aktif. Pakai #goal reset dulu kalau mau menggantinya. 🎯", nil
+	}
+
+	activity := strings.TrimSpace(strings.Join(args[1:], " "))
+	if activity == "" {
+		activity = "Olahraga"
+	}
+
+	goal := &domain.WeeklyGoal{
+		UserID:     userID,
+		TargetDays: targetDays,
+		Activity:   activity,
+		StartAt:    now,
+		EndAt:      now.AddDate(0, 0, goalWindowDays),
+		CreatedAt:  now,
+	}
+	if err := uc.repo.SetGoal(ctx, goal); errors.Is(err, domain.ErrActiveGoalExists) {
+		return "Kamu masih punya goal aktif. Pakai #goal reset dulu kalau mau menggantinya. 🎯", nil
+	} else if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("🎯 Goal aktif diset: %dx %s\n%s\n\nLaporkan aktivitas dengan #lapor. Laporan lebih dari 1x di hari yang sama tetap dihitung 1 untuk goal.", targetDays, activity, formatGoalPeriod(goal.StartAt, goal.EndAt)), nil
+}
+
+func (uc *GoalUsecase) reset(ctx context.Context, userID string) (string, error) {
+	now := uc.now()
+	goal, err := uc.repo.GetActiveGoal(ctx, userID, now)
+	if err != nil {
+		return "", err
+	}
+	if goal == nil {
+		return "Belum ada goal aktif untuk di-reset. Buat dengan #goal set <1-7> [aktivitas].", nil
+	}
+	if err := uc.repo.DeleteActiveGoal(ctx, userID, now); err != nil {
+		return "", err
+	}
+	return "Goal aktif sudah dihapus. Kamu bisa set ulang dengan #goal set <1-7> [aktivitas]. 🔄", nil
+}
+
+func (uc *GoalUsecase) status(ctx context.Context, userID string) (string, error) {
+	now := uc.now()
+	goal, err := uc.repo.GetActiveGoal(ctx, userID, now)
+	if err != nil {
+		return "", err
+	}
+	if goal == nil {
+		return "Belum ada goal aktif. Buat dengan #goal set <1-7> [aktivitas].\nContoh: #goal set 3 Olahraga", nil
+	}
+
+	activities, err := uc.repo.GetGoalActivities(ctx, userID, goal.StartAt, goal.EndAt)
+	if err != nil {
+		return "", err
+	}
+
+	return formatGoalStatus(goal, activities, now), nil
+}
+
+func (uc *GoalUsecase) RecordActivity(ctx context.Context, userID string, activityAt time.Time, activityText string) (bool, error) {
+	return uc.repo.RecordGoalActivity(ctx, userID, activityAt, activityText)
+}
+
+func (uc *GoalUsecase) CleanupExpired(ctx context.Context, now time.Time) (int64, error) {
+	return uc.repo.DeleteExpiredGoals(ctx, now)
+}
+
+func formatGoalStatus(goal *domain.WeeklyGoal, activities []domain.GoalActivity, now time.Time) string {
+	activityByDate := make(map[string]string, len(activities))
+	for _, activity := range activities {
+		activityByDate[activity.Date.Format(time.DateOnly)] = strings.TrimSpace(activity.Activity)
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("🎯 GOAL AKTIF: %dx %s\n", goal.TargetDays, goal.Activity))
+	sb.WriteString(formatGoalPeriod(goal.StartAt, goal.EndAt))
+	sb.WriteString("\n>\n")
+	sb.WriteString("| Hari | Status | Aktivitas |\n")
+	sb.WriteString("|:---|:---:|---:|\n")
+
+	completedDays := len(activityByDate)
+	startDate := goalReportDate(goal.StartAt)
+	endDate := goalReportDate(goal.EndAt.Add(-time.Nanosecond))
+	for date := startDate; !date.After(endDate); date = date.AddDate(0, 0, 1) {
+		activity, ok := activityByDate[date.Format(time.DateOnly)]
+		status := "⬜"
+		if ok {
+			status = "✅"
+		}
+		if activity == "" {
+			activity = "—"
+		}
+		sb.WriteString(fmt.Sprintf("| %s | %s | %s |\n", shortIndonesianDays[date.Weekday()], status, activity))
+	}
+
+	if completedDays > goal.TargetDays {
+		completedDays = goal.TargetDays
+	}
+	remaining := goal.TargetDays - completedDays
+	sb.WriteString(">\n")
+	sb.WriteString(fmt.Sprintf("Progress: %s %d/%d\n>\n", formatGoalProgressBar(completedDays), completedDays, goal.TargetDays))
+	if remaining <= 0 {
+		sb.WriteString("🏆 Goal tercapai! Disiplinmu naik level — pertahankan momentumnya. 🎯")
+	} else {
+		sb.WriteString(fmt.Sprintf("🚀 Kurang %d hari lagi buat capai goal!", remaining))
+	}
+
+	if now.Before(goal.EndAt) {
+		remainingDuration := goal.EndAt.Sub(now).Round(time.Minute)
+		sb.WriteString(fmt.Sprintf("\n⏳ Sisa waktu: %s", remainingDuration))
+	}
+
+	return sb.String()
+}
+
+func formatGoalProgressBar(done int) string {
+	if done < 0 {
+		done = 0
+	}
+	if done > 7 {
+		done = 7
+	}
+	return strings.Repeat("▓", done) + strings.Repeat("░", 7-done)
+}
+
+func formatGoalPeriod(startAt, endAt time.Time) string {
+	return fmt.Sprintf("📅 Mulai: %s\n🏁 Berakhir: %s", formatGoalTime(startAt), formatGoalTime(endAt))
+}
+
+func formatGoalTime(t time.Time) string {
+	t = t.In(goalLocation)
+	return fmt.Sprintf("%02d %s %d %02d:%02d", t.Day(), indonesianMonths[int(t.Month())], t.Year(), t.Hour(), t.Minute())
+}
+
+func goalReportDate(t time.Time) time.Time {
+	return domain.GetToday(t.UTC())
+}
+
+func goalActivityText(workout *domain.HevyWorkout) string {
+	if workout == nil || strings.TrimSpace(workout.Title) == "" {
+		return "Olahraga"
+	}
+	return strings.TrimSpace(workout.Title)
+}

--- a/internal/app/usecase/handle_message_usecase.go
+++ b/internal/app/usecase/handle_message_usecase.go
@@ -27,6 +27,7 @@ type HandleMessageUsecase struct {
 	motivationUC        *GetMotivationUsecase
 	helpUC              *GetHelpUsecase
 	jobUC               *JobUsecase
+	goalUC              *GoalUsecase
 }
 
 func NewHandleMessageUsecase(
@@ -56,6 +57,7 @@ func NewHandleMessageUsecase(
 		motivationUC:        motivationUC,
 		helpUC:              helpUC,
 		jobUC:               NewJobUsecase(leaderboardUC.repo),
+		goalUC:              NewGoalUsecase(leaderboardUC.repo),
 	}
 }
 
@@ -101,6 +103,11 @@ func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, messa
 
 	if strings.Contains(msg, "#jobs") {
 		return MessageResponse{Text: uc.jobUC.List()}, nil
+	}
+
+	if strings.Contains(msg, "#goal") {
+		text, err := uc.goalUC.Execute(ctx, userID, name, message)
+		return MessageResponse{Text: text}, err
 	}
 
 	if strings.Contains(msg, "#job") {

--- a/internal/app/usecase/handle_message_usecase_test.go
+++ b/internal/app/usecase/handle_message_usecase_test.go
@@ -48,6 +48,7 @@ func (m *mockLeaderboardUsecase) Execute(ctx context.Context) (string, error) {
 type mockReportRepo struct {
 	reports        map[string]*domain.Report
 	activityCounts []domain.ActivityLeaderboardEntry
+	goals          map[string]*domain.WeeklyGoal
 }
 
 func (m *mockReportRepo) GetReport(ctx context.Context, userID string) (*domain.Report, error) {
@@ -128,6 +129,51 @@ func (m *mockReportRepo) DeleteReport(ctx context.Context, userID string) error 
 
 func (m *mockReportRepo) GetDailyActivityCount(ctx context.Context, userID string, date time.Time) (int, error) {
 	return 0, nil
+}
+
+func (m *mockReportRepo) SetGoal(ctx context.Context, goal *domain.WeeklyGoal) error {
+	if m.goals == nil {
+		m.goals = make(map[string]*domain.WeeklyGoal)
+	}
+	m.goals[goal.UserID+"|"+goal.StartAt.Format(time.RFC3339)] = goal
+	return nil
+}
+
+func (m *mockReportRepo) GetActiveGoal(ctx context.Context, userID string, now time.Time) (*domain.WeeklyGoal, error) {
+	for _, goal := range m.goals {
+		if goal.UserID == userID && !now.Before(goal.StartAt) && now.Before(goal.EndAt) {
+			return goal, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *mockReportRepo) DeleteActiveGoal(ctx context.Context, userID string, now time.Time) error {
+	for key, goal := range m.goals {
+		if goal.UserID == userID && !now.Before(goal.StartAt) && now.Before(goal.EndAt) {
+			delete(m.goals, key)
+		}
+	}
+	return nil
+}
+
+func (m *mockReportRepo) DeleteExpiredGoals(ctx context.Context, now time.Time) (int64, error) {
+	var deleted int64
+	for key, goal := range m.goals {
+		if !goal.EndAt.After(now) {
+			delete(m.goals, key)
+			deleted++
+		}
+	}
+	return deleted, nil
+}
+
+func (m *mockReportRepo) GetGoalActivities(ctx context.Context, userID string, startDate, endDate time.Time) ([]domain.GoalActivity, error) {
+	return nil, nil
+}
+
+func (m *mockReportRepo) RecordGoalActivity(ctx context.Context, userID string, activityDate time.Time, activityText string) (bool, error) {
+	return false, nil
 }
 
 func TestHandleMessage_LaporCommand(t *testing.T) {

--- a/internal/app/usecase/report_activity_usecase.go
+++ b/internal/app/usecase/report_activity_usecase.go
@@ -208,6 +208,10 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 	if err := uc.repo.UpsertReportWithActivity(ctx, report, today); err != nil {
 		return "", err
 	}
+	goalCompleted, err := NewGoalUsecase(uc.repo).RecordActivity(ctx, userID, now, goalActivityText(workout))
+	if err != nil {
+		return "", err
+	}
 
 	isComeback := isFullReport && report.InactiveDays > 3 && report.Streak == 1
 	var response string
@@ -279,6 +283,10 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 
 	if newRecord {
 		response += fmt.Sprintf("\n\n🏆 New Personal Best Streak: %d minggu!", report.MaxStreak)
+	}
+
+	if goalCompleted {
+		response += "\n\n🎯 *Goal minggu ini tercapai!* Konsistensi harianmu sudah sesuai target. Mantap, champ! 🏆"
 	}
 
 	if leveledUp {
@@ -474,6 +482,10 @@ func (uc *ReportActivityUsecase) ExecuteYesterday(ctx context.Context, userID, n
 	if err := uc.repo.UpsertReportWithActivity(ctx, report, yesterday); err != nil {
 		return "", err
 	}
+	goalCompleted, err := NewGoalUsecase(uc.repo).RecordActivity(ctx, userID, yesterday, goalActivityText(workout))
+	if err != nil {
+		return "", err
+	}
 
 	isComeback := report.InactiveDays > 3 && report.Streak == 1
 	var response string
@@ -538,6 +550,10 @@ func (uc *ReportActivityUsecase) ExecuteYesterday(ctx context.Context, userID, n
 
 	if newRecord {
 		response += fmt.Sprintf("\n\n🏆 New Personal Best Streak: %d minggu!", report.MaxStreak)
+	}
+
+	if goalCompleted {
+		response += "\n\n🎯 *Goal minggu ini tercapai!* Konsistensi harianmu sudah sesuai target. Mantap, champ! 🏆"
 	}
 
 	if leveledUp {

--- a/internal/app/usecase/report_activity_usecase_test.go
+++ b/internal/app/usecase/report_activity_usecase_test.go
@@ -103,6 +103,30 @@ func (m *mockRepo) GetDailyActivityCount(ctx context.Context, userID string, dat
 	return m.dailyCounts[key], nil
 }
 
+func (m *mockRepo) SetGoal(ctx context.Context, goal *domain.WeeklyGoal) error {
+	return nil
+}
+
+func (m *mockRepo) GetActiveGoal(ctx context.Context, userID string, now time.Time) (*domain.WeeklyGoal, error) {
+	return nil, nil
+}
+
+func (m *mockRepo) DeleteActiveGoal(ctx context.Context, userID string, now time.Time) error {
+	return nil
+}
+
+func (m *mockRepo) DeleteExpiredGoals(ctx context.Context, now time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (m *mockRepo) GetGoalActivities(ctx context.Context, userID string, startDate, endDate time.Time) ([]domain.GoalActivity, error) {
+	return nil, nil
+}
+
+func (m *mockRepo) RecordGoalActivity(ctx context.Context, userID string, activityDate time.Time, activityText string) (bool, error) {
+	return false, nil
+}
+
 // =============================================================================
 // STREAK LOGIC TESTS
 // =============================================================================

--- a/internal/domain/report.go
+++ b/internal/domain/report.go
@@ -2,8 +2,11 @@ package domain
 
 import (
 	"context"
+	"errors"
 	"time"
 )
+
+var ErrActiveGoalExists = errors.New("active goal exists")
 
 type Report struct {
 	UserID                string    `json:"user_id" db:"user_id"`
@@ -24,12 +27,28 @@ type Report struct {
 	SeasonalMaxStreak     int       `json:"seasonal_max_streak" db:"seasonal_max_streak"`
 	SeasonalAchievements  string    `json:"seasonal_achievements" db:"seasonal_achievements"`
 	StreakFreezes         int       `json:"streak_freezes" db:"streak_freezes"`
+	GoalsCompleted        int       `json:"goals_completed" db:"goals_completed"`
 }
 
 type ActivityLeaderboardEntry struct {
 	UserID        string
 	Name          string
 	ActivityCount int
+}
+
+type WeeklyGoal struct {
+	UserID      string
+	TargetDays  int
+	Activity    string
+	StartAt     time.Time
+	EndAt       time.Time
+	CreatedAt   time.Time
+	CompletedAt *time.Time
+}
+
+type GoalActivity struct {
+	Date     time.Time
+	Activity string
 }
 
 // ReportCutoffOffset is the spare time allowed for late-night reporting.
@@ -48,6 +67,19 @@ func GetStartOfISOWeek(t time.Time) time.Time {
 	t = GetToday(t)
 	// ISO week starts on Monday. Go's Weekday() returns 0 for Sunday, 1 for Monday, etc.
 	// We want to shift back to the most recent Monday.
+	weekday := int(t.Weekday())
+	if weekday == 0 { // Sunday
+		weekday = 7
+	}
+	daysToSubtract := weekday - 1
+	return t.AddDate(0, 0, -daysToSubtract)
+}
+
+// GetStartOfISOWeekStrict returns the Monday of the ISO week containing t
+// without applying the daily report cutoff. Use this for weekly windows that
+// must roll over exactly at Monday 00:00.
+func GetStartOfISOWeekStrict(t time.Time) time.Time {
+	t = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
 	weekday := int(t.Weekday())
 	if weekday == 0 { // Sunday
 		weekday = 7
@@ -80,6 +112,13 @@ type ReportRepository interface {
 	DeleteReport(ctx context.Context, userID string) error
 
 	GetDailyActivityCount(ctx context.Context, userID string, date time.Time) (int, error)
+
+	SetGoal(ctx context.Context, goal *WeeklyGoal) error
+	GetActiveGoal(ctx context.Context, userID string, now time.Time) (*WeeklyGoal, error)
+	DeleteActiveGoal(ctx context.Context, userID string, now time.Time) error
+	DeleteExpiredGoals(ctx context.Context, now time.Time) (int64, error)
+	GetGoalActivities(ctx context.Context, userID string, startDate, endDate time.Time) ([]GoalActivity, error)
+	RecordGoalActivity(ctx context.Context, userID string, activityDate time.Time, activityText string) (bool, error)
 
 	// Strava Integration
 	UpsertStravaAccount(ctx context.Context, account *StravaAccount) error

--- a/internal/domain/report_test.go
+++ b/internal/domain/report_test.go
@@ -33,3 +33,36 @@ func TestGetToday(t *testing.T) {
 		t.Errorf("For 23:59, expected %v, got %v", expected3, got3)
 	}
 }
+
+func TestGetStartOfISOWeekStrict_UsesMondayMidnightBoundary(t *testing.T) {
+	tests := []struct {
+		name string
+		now  time.Time
+		want time.Time
+	}{
+		{
+			name: "Monday midnight starts new week",
+			now:  time.Date(2026, time.June, 15, 0, 0, 0, 0, time.UTC),
+			want: time.Date(2026, time.June, 15, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "Monday within report cutoff still starts new week",
+			now:  time.Date(2026, time.June, 15, 0, 29, 0, 0, time.UTC),
+			want: time.Date(2026, time.June, 15, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "Sunday belongs to previous Monday",
+			now:  time.Date(2026, time.June, 14, 23, 59, 0, 0, time.UTC),
+			want: time.Date(2026, time.June, 8, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetStartOfISOWeekStrict(tt.now)
+			if !got.Equal(tt.want) {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}

--- a/internal/infra/sqlite/report_repository.go
+++ b/internal/infra/sqlite/report_repository.go
@@ -25,7 +25,7 @@ const selectColumns = `user_id, name, COALESCE(job_class, ''), streak, activity_
 	COALESCE(comeback_streak, 0), COALESCE(inactive_days, 0), COALESCE(centurion_cycles, 0),
 	COALESCE(seasonal_points, 0), COALESCE(seasonal_activity_count, 0),
 	COALESCE(seasonal_max_streak, 0), COALESCE(seasonal_achievements, ''),
-	COALESCE(streak_freezes, 0)`
+	COALESCE(streak_freezes, 0), COALESCE(goals_completed, 0)`
 
 func scanReport(scanner interface{ Scan(dest ...any) error }) (*domain.Report, error) {
 	var report domain.Report
@@ -36,7 +36,7 @@ func scanReport(scanner interface{ Scan(dest ...any) error }) (*domain.Report, e
 		&report.ComebackStreak, &report.InactiveDays, &report.CenturionCycles,
 		&report.SeasonalPoints, &report.SeasonalActivityCount,
 		&report.SeasonalMaxStreak, &report.SeasonalAchievements,
-		&report.StreakFreezes,
+		&report.StreakFreezes, &report.GoalsCompleted,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -61,8 +61,8 @@ func (r *ReportRepository) GetReport(ctx context.Context, userID string) (*domai
 
 func upsertReport(ctx context.Context, execer execContexter, report *domain.Report) error {
 	query := `
-		INSERT INTO user_reports (user_id, name, job_class, streak, activity_count, last_report_date, max_streak, total_points, level, achievements, comeback_streak, inactive_days, centurion_cycles, seasonal_points, seasonal_activity_count, seasonal_max_streak, seasonal_achievements, streak_freezes)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO user_reports (user_id, name, job_class, streak, activity_count, last_report_date, max_streak, total_points, level, achievements, comeback_streak, inactive_days, centurion_cycles, seasonal_points, seasonal_activity_count, seasonal_max_streak, seasonal_achievements, streak_freezes, goals_completed)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(user_id) DO UPDATE SET
 			name = excluded.name,
 			job_class = excluded.job_class,
@@ -87,7 +87,7 @@ func upsertReport(ctx context.Context, execer execContexter, report *domain.Repo
 		report.LastReportDate.Format(time.RFC3339), report.MaxStreak, report.TotalPoints,
 		report.Level, report.Achievements, report.ComebackStreak, report.InactiveDays, report.CenturionCycles,
 		report.SeasonalPoints, report.SeasonalActivityCount, report.SeasonalMaxStreak,
-		report.SeasonalAchievements, report.StreakFreezes,
+		report.SeasonalAchievements, report.StreakFreezes, report.GoalsCompleted,
 	)
 	return err
 }
@@ -231,6 +231,7 @@ func (r *ReportRepository) InitTable(ctx context.Context) error {
 			activity_date TEXT NOT NULL,
 			created_at TEXT NOT NULL,
 			report_count INTEGER NOT NULL DEFAULT 1,
+			activity_text TEXT DEFAULT '',
 			PRIMARY KEY (user_id, activity_date),
 			FOREIGN KEY (user_id) REFERENCES user_reports(user_id) ON DELETE CASCADE
 		);
@@ -278,8 +279,62 @@ func (r *ReportRepository) InitTable(ctx context.Context) error {
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN seasonal_max_streak INTEGER DEFAULT 0")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN seasonal_achievements TEXT DEFAULT ''")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN streak_freezes INTEGER DEFAULT 1")
+	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN goals_completed INTEGER DEFAULT 0")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE activity_logs ADD COLUMN report_count INTEGER NOT NULL DEFAULT 1")
+	_, _ = r.db.ExecContext(ctx, "ALTER TABLE activity_logs ADD COLUMN activity_text TEXT DEFAULT ''")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE strava_accounts ADD COLUMN name TEXT")
+
+	goalQuery := `
+		CREATE TABLE IF NOT EXISTS weekly_goals (
+			user_id TEXT NOT NULL,
+			target_days INTEGER NOT NULL,
+			activity TEXT NOT NULL,
+			week_start TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			completed_at TEXT DEFAULT '',
+			PRIMARY KEY (user_id, week_start)
+		);
+	`
+	_, err = r.db.ExecContext(ctx, goalQuery)
+	if err != nil {
+		return err
+	}
+
+	rollingGoalQuery := `
+		CREATE TABLE IF NOT EXISTS goals (
+			user_id TEXT NOT NULL,
+			target_days INTEGER NOT NULL,
+			activity TEXT NOT NULL,
+			start_at TEXT NOT NULL,
+			end_at TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			completed_at TEXT DEFAULT '',
+			PRIMARY KEY (user_id, start_at)
+		);
+	`
+	_, err = r.db.ExecContext(ctx, rollingGoalQuery)
+	if err != nil {
+		return err
+	}
+
+	goalActivityQuery := `
+		CREATE TABLE IF NOT EXISTS goal_activity_logs (
+			user_id TEXT NOT NULL,
+			goal_start_at TEXT NOT NULL,
+			activity_date TEXT NOT NULL,
+			activity_text TEXT DEFAULT '',
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (user_id, goal_start_at, activity_date)
+		);
+	`
+	_, err = r.db.ExecContext(ctx, goalActivityQuery)
+	if err != nil {
+		return err
+	}
+	_, err = r.db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_goals_end_at ON goals (end_at)`)
+	if err != nil {
+		return err
+	}
 
 	// Run data migrations
 	if err := r.MigrateDayToWeekStreaks(ctx); err != nil {
@@ -498,9 +553,19 @@ func (r *ReportRepository) GetUserActivityDates(ctx context.Context, userID stri
 }
 
 func (r *ReportRepository) DeleteActivityLog(ctx context.Context, userID string, activityDate time.Time) error {
-	query := `DELETE FROM activity_logs WHERE user_id = ? AND activity_date = ?`
-	_, err := r.db.ExecContext(ctx, query, userID, activityDate.Format(time.DateOnly))
-	return err
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM activity_logs WHERE user_id = ? AND activity_date = ?`, userID, activityDate.Format(time.DateOnly)); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := reconcileGoalAfterActivityDelete(ctx, tx, userID, activityDate); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	return tx.Commit()
 }
 
 func (r *ReportRepository) DeleteLatestActivityLog(ctx context.Context, userID string, activityDate time.Time) (int, error) {
@@ -532,13 +597,95 @@ func (r *ReportRepository) DeleteLatestActivityLog(ctx context.Context, userID s
 			_ = tx.Rollback()
 			return 0, err
 		}
+		if err := reconcileGoalAfterActivityDelete(ctx, tx, userID, activityDate); err != nil {
+			_ = tx.Rollback()
+			return 0, err
+		}
 	}
 
 	return remaining, tx.Commit()
 }
 
+func reconcileGoalAfterActivityDelete(ctx context.Context, tx *sql.Tx, userID string, activityDate time.Time) error {
+	activityDateStr := activityDate.Format(time.DateOnly)
+	rows, err := tx.QueryContext(ctx, `
+		SELECT g.start_at, g.target_days, COALESCE(g.completed_at, '')
+		FROM goals g
+		JOIN goal_activity_logs gal ON gal.user_id = g.user_id AND gal.goal_start_at = g.start_at
+		WHERE g.user_id = ? AND gal.activity_date = ?
+	`, userID, activityDateStr)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	type affectedGoal struct {
+		startAt     string
+		targetDays  int
+		completedAt string
+	}
+	var goals []affectedGoal
+	for rows.Next() {
+		var goal affectedGoal
+		if err := rows.Scan(&goal.startAt, &goal.targetDays, &goal.completedAt); err != nil {
+			return err
+		}
+		goals = append(goals, goal)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM goal_activity_logs WHERE user_id = ? AND activity_date = ?`, userID, activityDateStr); err != nil {
+		return err
+	}
+
+	for _, goal := range goals {
+		if goal.completedAt == "" {
+			continue
+		}
+		var activeDays int
+		if err := tx.QueryRowContext(ctx, `
+			SELECT COUNT(*)
+			FROM goal_activity_logs
+			WHERE user_id = ? AND goal_start_at = ?
+		`, userID, goal.startAt).Scan(&activeDays); err != nil {
+			return err
+		}
+		if activeDays >= goal.targetDays {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE goals
+			SET completed_at = ''
+			WHERE user_id = ? AND start_at = ?
+		`, userID, goal.startAt); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+		UPDATE user_reports
+		SET goals_completed = CASE
+			WHEN COALESCE(goals_completed, 0) > 0 THEN goals_completed - 1
+			ELSE 0
+		END
+		WHERE user_id = ?
+	`, userID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (r *ReportRepository) DeleteReport(ctx context.Context, userID string) error {
 	if _, err := r.db.ExecContext(ctx, `DELETE FROM activity_logs WHERE user_id = ?`, userID); err != nil {
+		return err
+	}
+	if _, err := r.db.ExecContext(ctx, `DELETE FROM weekly_goals WHERE user_id = ?`, userID); err != nil {
+		return err
+	}
+	if _, err := r.db.ExecContext(ctx, `DELETE FROM goal_activity_logs WHERE user_id = ?`, userID); err != nil {
+		return err
+	}
+	if _, err := r.db.ExecContext(ctx, `DELETE FROM goals WHERE user_id = ?`, userID); err != nil {
 		return err
 	}
 	_, err := r.db.ExecContext(ctx, `DELETE FROM user_reports WHERE user_id = ?`, userID)
@@ -556,6 +703,275 @@ func (r *ReportRepository) GetDailyActivityCount(ctx context.Context, userID str
 		return 0, err
 	}
 	return count, nil
+}
+
+func (r *ReportRepository) SetGoal(ctx context.Context, goal *domain.WeeklyGoal) error {
+	query := `
+		INSERT INTO goals (user_id, target_days, activity, start_at, end_at, created_at, completed_at)
+		SELECT ?, ?, ?, ?, ?, ?, ''
+		WHERE NOT EXISTS (
+			SELECT 1 FROM goals
+			WHERE user_id = ? AND start_at <= ? AND end_at > ?
+		)
+	`
+	startAt := goal.StartAt.UTC().Format(time.RFC3339)
+	endAt := goal.EndAt.UTC().Format(time.RFC3339)
+	createdAt := goal.CreatedAt.UTC().Format(time.RFC3339)
+	res, err := r.db.ExecContext(ctx, query,
+		goal.UserID,
+		goal.TargetDays,
+		goal.Activity,
+		startAt,
+		endAt,
+		createdAt,
+		goal.UserID,
+		startAt,
+		startAt,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return domain.ErrActiveGoalExists
+	}
+	return nil
+}
+
+func (r *ReportRepository) GetActiveGoal(ctx context.Context, userID string, now time.Time) (*domain.WeeklyGoal, error) {
+	query := `
+		SELECT user_id, target_days, activity, start_at, end_at, created_at, COALESCE(completed_at, '')
+		FROM goals
+		WHERE user_id = ? AND start_at <= ? AND end_at > ?
+		ORDER BY start_at DESC
+		LIMIT 1
+	`
+	nowStr := now.UTC().Format(time.RFC3339)
+	row := r.db.QueryRowContext(ctx, query, userID, nowStr, nowStr)
+	return scanGoal(row)
+}
+
+func scanGoal(scanner interface{ Scan(dest ...any) error }) (*domain.WeeklyGoal, error) {
+	var goal domain.WeeklyGoal
+	var startAtStr, endAtStr, createdAtStr, completedAtStr string
+	err := scanner.Scan(&goal.UserID, &goal.TargetDays, &goal.Activity, &startAtStr, &endAtStr, &createdAtStr, &completedAtStr)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	goal.StartAt, err = time.Parse(time.RFC3339, startAtStr)
+	if err != nil {
+		return nil, err
+	}
+	goal.EndAt, err = time.Parse(time.RFC3339, endAtStr)
+	if err != nil {
+		return nil, err
+	}
+	goal.CreatedAt, err = time.Parse(time.RFC3339, createdAtStr)
+	if err != nil {
+		return nil, err
+	}
+	if completedAtStr != "" {
+		completedAt, err := time.Parse(time.RFC3339, completedAtStr)
+		if err != nil {
+			return nil, err
+		}
+		goal.CompletedAt = &completedAt
+	}
+	return &goal, nil
+}
+
+func (r *ReportRepository) DeleteActiveGoal(ctx context.Context, userID string, now time.Time) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	nowStr := now.UTC().Format(time.RFC3339)
+	var startAt, completedAt string
+	err = tx.QueryRowContext(ctx, `
+		SELECT start_at, COALESCE(completed_at, '')
+		FROM goals
+		WHERE user_id = ? AND start_at <= ? AND end_at > ?
+		ORDER BY start_at DESC
+		LIMIT 1
+	`, userID, nowStr, nowStr).Scan(&startAt, &completedAt)
+	if err == sql.ErrNoRows {
+		return tx.Commit()
+	}
+	if err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM goal_activity_logs WHERE user_id = ? AND goal_start_at = ?`, userID, startAt); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM goals WHERE user_id = ? AND start_at = ?`, userID, startAt); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if completedAt != "" {
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE user_reports
+			SET goals_completed = CASE
+				WHEN COALESCE(goals_completed, 0) > 0 THEN goals_completed - 1
+				ELSE 0
+			END
+			WHERE user_id = ?
+		`, userID); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (r *ReportRepository) DeleteExpiredGoals(ctx context.Context, now time.Time) (int64, error) {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	nowStr := now.UTC().Format(time.RFC3339)
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM goal_activity_logs
+		WHERE (user_id, goal_start_at) IN (
+			SELECT user_id, start_at FROM goals WHERE end_at <= ?
+		)
+	`, nowStr); err != nil {
+		_ = tx.Rollback()
+		return 0, err
+	}
+	res, err := tx.ExecContext(ctx, `DELETE FROM goals WHERE end_at <= ?`, nowStr)
+	if err != nil {
+		_ = tx.Rollback()
+		return 0, err
+	}
+	deleted, err := res.RowsAffected()
+	if err != nil {
+		_ = tx.Rollback()
+		return 0, err
+	}
+	return deleted, tx.Commit()
+}
+
+func (r *ReportRepository) GetGoalActivities(ctx context.Context, userID string, startAt, endAt time.Time) ([]domain.GoalActivity, error) {
+	query := `
+		SELECT activity_date, COALESCE(activity_text, '')
+		FROM goal_activity_logs
+		WHERE user_id = ? AND goal_start_at = ?
+		ORDER BY activity_date ASC
+	`
+	rows, err := r.db.QueryContext(ctx, query, userID, startAt.UTC().Format(time.RFC3339))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	activities := []domain.GoalActivity{}
+	for rows.Next() {
+		var activity domain.GoalActivity
+		var dateStr string
+		if err := rows.Scan(&dateStr, &activity.Activity); err != nil {
+			return nil, err
+		}
+		activity.Date, err = time.Parse(time.DateOnly, dateStr)
+		if err != nil {
+			return nil, err
+		}
+		activities = append(activities, activity)
+	}
+	return activities, rows.Err()
+}
+
+func (r *ReportRepository) RecordGoalActivity(ctx context.Context, userID string, activityAt time.Time, activityText string) (bool, error) {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+
+	activityAtUTC := activityAt.UTC()
+	activityAtStr := activityAtUTC.Format(time.RFC3339)
+	var goalStartAt, completedAt string
+	var targetDays int
+	err = tx.QueryRowContext(ctx, `
+		SELECT start_at, target_days, COALESCE(completed_at, '')
+		FROM goals
+		WHERE user_id = ? AND start_at <= ? AND end_at > ?
+		ORDER BY start_at DESC
+		LIMIT 1
+	`, userID, activityAtStr, activityAtStr).Scan(&goalStartAt, &targetDays, &completedAt)
+	if err == sql.ErrNoRows {
+		return false, tx.Commit()
+	}
+	if err != nil {
+		_ = tx.Rollback()
+		return false, err
+	}
+
+	activityDate := domain.GetToday(activityAtUTC)
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO goal_activity_logs (user_id, goal_start_at, activity_date, activity_text, created_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(user_id, goal_start_at, activity_date) DO UPDATE SET
+			activity_text = CASE WHEN COALESCE(activity_text, '') = '' THEN excluded.activity_text ELSE activity_text END
+	`, userID, goalStartAt, activityDate.Format(time.DateOnly), activityText, activityAtStr); err != nil {
+		_ = tx.Rollback()
+		return false, err
+	}
+
+	if completedAt != "" {
+		return false, tx.Commit()
+	}
+
+	var activeDays int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM goal_activity_logs
+		WHERE user_id = ? AND goal_start_at = ?
+	`, userID, goalStartAt).Scan(&activeDays); err != nil {
+		_ = tx.Rollback()
+		return false, err
+	}
+	if activeDays < targetDays {
+		return false, tx.Commit()
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := tx.ExecContext(ctx, `
+		UPDATE goals
+		SET completed_at = ?
+		WHERE user_id = ? AND start_at = ? AND COALESCE(completed_at, '') = ''
+	`, now, userID, goalStartAt)
+	if err != nil {
+		_ = tx.Rollback()
+		return false, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		_ = tx.Rollback()
+		return false, err
+	}
+	if affected == 0 {
+		return false, tx.Commit()
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE user_reports
+		SET goals_completed = COALESCE(goals_completed, 0) + 1
+		WHERE user_id = ?
+	`, userID); err != nil {
+		_ = tx.Rollback()
+		return false, err
+	}
+
+	return true, tx.Commit()
 }
 
 func (r *ReportRepository) GetStravaAccountByUserID(ctx context.Context, userID string) (*domain.StravaAccount, error) {

--- a/internal/infra/sqlite/report_repository_test.go
+++ b/internal/infra/sqlite/report_repository_test.go
@@ -393,3 +393,291 @@ func TestReportRepository_ConcurrentAccess(t *testing.T) {
 		t.Errorf("Expected ActivityCount=10, got %d", final.ActivityCount)
 	}
 }
+
+func TestReportRepository_RecordGoalActivity_CompletesOncePerRollingWindow(t *testing.T) {
+	_, repo, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	startAt := time.Date(2026, time.June, 8, 16, 30, 0, 0, time.UTC)
+	endAt := startAt.AddDate(0, 0, 7)
+	report := &domain.Report{
+		UserID:         "user1",
+		Name:           "Budi",
+		LastReportDate: startAt,
+		StreakFreezes:  1,
+	}
+	if err := repo.UpsertReport(ctx, report); err != nil {
+		t.Fatalf("upsert report: %v", err)
+	}
+	if err := repo.SetGoal(ctx, &domain.WeeklyGoal{
+		UserID:     "user1",
+		TargetDays: 2,
+		Activity:   "Olahraga",
+		StartAt:    startAt,
+		EndAt:      endAt,
+		CreatedAt:  startAt,
+	}); err != nil {
+		t.Fatalf("set goal: %v", err)
+	}
+
+	if err := repo.LogActivity(ctx, "user1", domain.GetToday(startAt)); err != nil {
+		t.Fatalf("log day 1: %v", err)
+	}
+	completed, err := repo.RecordGoalActivity(ctx, "user1", startAt, "Lari 5km")
+	if err != nil {
+		t.Fatalf("record day 1: %v", err)
+	}
+	if completed {
+		t.Fatal("goal should not complete after one active day")
+	}
+
+	secondDay := startAt.AddDate(0, 0, 1)
+	if err := repo.LogActivity(ctx, "user1", domain.GetToday(secondDay)); err != nil {
+		t.Fatalf("log day 2: %v", err)
+	}
+	completed, err = repo.RecordGoalActivity(ctx, "user1", secondDay, "Gym 45min")
+	if err != nil {
+		t.Fatalf("record day 2: %v", err)
+	}
+	if !completed {
+		t.Fatal("goal should complete after two unique active days")
+	}
+
+	completed, err = repo.RecordGoalActivity(ctx, "user1", secondDay.Add(10*time.Minute), "Laporan kedua")
+	if err != nil {
+		t.Fatalf("record repeat: %v", err)
+	}
+	if completed {
+		t.Fatal("goal completion should only be counted once")
+	}
+
+	updated, err := repo.GetReport(ctx, "user1")
+	if err != nil {
+		t.Fatalf("get report: %v", err)
+	}
+	if updated.GoalsCompleted != 1 {
+		t.Fatalf("expected GoalsCompleted=1, got %d", updated.GoalsCompleted)
+	}
+
+	activities, err := repo.GetGoalActivities(ctx, "user1", startAt, endAt)
+	if err != nil {
+		t.Fatalf("get goal activities: %v", err)
+	}
+	if len(activities) != 2 {
+		t.Fatalf("expected 2 goal activity days, got %d", len(activities))
+	}
+	if activities[0].Activity != "Lari 5km" || activities[1].Activity != "Gym 45min" {
+		t.Fatalf("unexpected activities: %+v", activities)
+	}
+}
+
+func TestReportRepository_SetGoal_RejectsSecondActiveGoal(t *testing.T) {
+	_, repo, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	startAt := time.Date(2026, time.June, 8, 16, 30, 0, 0, time.UTC)
+	first := &domain.WeeklyGoal{
+		UserID:     "user1",
+		TargetDays: 2,
+		Activity:   "Olahraga",
+		StartAt:    startAt,
+		EndAt:      startAt.AddDate(0, 0, 7),
+		CreatedAt:  startAt,
+	}
+	if err := repo.SetGoal(ctx, first); err != nil {
+		t.Fatalf("set first goal: %v", err)
+	}
+
+	secondStart := startAt.Add(time.Minute)
+	err := repo.SetGoal(ctx, &domain.WeeklyGoal{
+		UserID:     "user1",
+		TargetDays: 3,
+		Activity:   "Gym",
+		StartAt:    secondStart,
+		EndAt:      secondStart.AddDate(0, 0, 7),
+		CreatedAt:  secondStart,
+	})
+	if err != domain.ErrActiveGoalExists {
+		t.Fatalf("expected ErrActiveGoalExists, got %v", err)
+	}
+}
+
+func TestReportRepository_RecordGoalActivity_UsesUTCReportDate(t *testing.T) {
+	_, repo, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	wib := time.FixedZone("WIB", 7*60*60)
+	startAt := time.Date(2026, time.June, 8, 20, 0, 0, 0, wib)
+	activityAt := time.Date(2026, time.June, 9, 1, 0, 0, 0, wib)
+	if err := repo.SetGoal(ctx, &domain.WeeklyGoal{
+		UserID:     "user1",
+		TargetDays: 1,
+		Activity:   "Olahraga",
+		StartAt:    startAt,
+		EndAt:      startAt.AddDate(0, 0, 7),
+		CreatedAt:  startAt,
+	}); err != nil {
+		t.Fatalf("set goal: %v", err)
+	}
+	completed, err := repo.RecordGoalActivity(ctx, "user1", activityAt, "Lari malam")
+	if err != nil || !completed {
+		t.Fatalf("expected completion, completed=%v err=%v", completed, err)
+	}
+
+	activities, err := repo.GetGoalActivities(ctx, "user1", startAt, startAt.AddDate(0, 0, 7))
+	if err != nil {
+		t.Fatalf("get goal activities: %v", err)
+	}
+	if len(activities) != 1 {
+		t.Fatalf("expected 1 activity, got %d", len(activities))
+	}
+	want := time.Date(2026, time.June, 8, 0, 0, 0, 0, time.UTC)
+	if !activities[0].Date.Equal(want) {
+		t.Fatalf("expected UTC report date %v, got %v", want, activities[0].Date)
+	}
+}
+
+func TestReportRepository_RecordGoalActivity_CountsFinalPartialDayBeforeEnd(t *testing.T) {
+	_, repo, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	wib := time.FixedZone("WIB", 7*60*60)
+	startAt := time.Date(2026, time.June, 8, 16, 30, 0, 0, wib)
+	endAt := startAt.AddDate(0, 0, 7)
+	if err := repo.SetGoal(ctx, &domain.WeeklyGoal{
+		UserID:     "user1",
+		TargetDays: 1,
+		Activity:   "Olahraga",
+		StartAt:    startAt,
+		EndAt:      endAt,
+		CreatedAt:  startAt,
+	}); err != nil {
+		t.Fatalf("set goal: %v", err)
+	}
+
+	completed, err := repo.RecordGoalActivity(ctx, "user1", endAt.Add(-time.Hour), "Lari final")
+	if err != nil || !completed {
+		t.Fatalf("expected final partial day to count, completed=%v err=%v", completed, err)
+	}
+	completed, err = repo.RecordGoalActivity(ctx, "user1", endAt, "Terlambat")
+	if err != nil {
+		t.Fatalf("record at end: %v", err)
+	}
+	if completed {
+		t.Fatal("activity exactly at end_at should not count as a new completion")
+	}
+}
+
+func TestReportRepository_DeleteActiveGoal_DecrementsCompletedGoal(t *testing.T) {
+	_, repo, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	startAt := time.Date(2026, time.June, 8, 16, 30, 0, 0, time.UTC)
+	endAt := startAt.AddDate(0, 0, 7)
+	report := &domain.Report{
+		UserID:         "user1",
+		Name:           "Budi",
+		LastReportDate: startAt,
+		StreakFreezes:  1,
+	}
+	if err := repo.UpsertReport(ctx, report); err != nil {
+		t.Fatalf("upsert report: %v", err)
+	}
+	if err := repo.SetGoal(ctx, &domain.WeeklyGoal{
+		UserID:     "user1",
+		TargetDays: 1,
+		Activity:   "Olahraga",
+		StartAt:    startAt,
+		EndAt:      endAt,
+		CreatedAt:  startAt,
+	}); err != nil {
+		t.Fatalf("set goal: %v", err)
+	}
+	completed, err := repo.RecordGoalActivity(ctx, "user1", startAt.Add(time.Minute), "Lari")
+	if err != nil || !completed {
+		t.Fatalf("expected completion, completed=%v err=%v", completed, err)
+	}
+
+	if err := repo.DeleteActiveGoal(ctx, "user1", startAt.Add(time.Hour)); err != nil {
+		t.Fatalf("delete active goal: %v", err)
+	}
+	goal, err := repo.GetActiveGoal(ctx, "user1", startAt.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("get active goal: %v", err)
+	}
+	if goal != nil {
+		t.Fatalf("expected goal deleted, got %+v", goal)
+	}
+	updated, err := repo.GetReport(ctx, "user1")
+	if err != nil {
+		t.Fatalf("get report: %v", err)
+	}
+	if updated.GoalsCompleted != 0 {
+		t.Fatalf("expected GoalsCompleted=0 after reset, got %d", updated.GoalsCompleted)
+	}
+}
+
+func TestReportRepository_DeleteActivityLog_ReopensCompletedGoalWhenBelowTarget(t *testing.T) {
+	_, repo, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	startAt := time.Date(2026, time.June, 8, 16, 30, 0, 0, time.UTC)
+	endAt := startAt.AddDate(0, 0, 7)
+	report := &domain.Report{
+		UserID:         "user1",
+		Name:           "Budi",
+		LastReportDate: startAt,
+		StreakFreezes:  1,
+	}
+	if err := repo.UpsertReport(ctx, report); err != nil {
+		t.Fatalf("upsert report: %v", err)
+	}
+	if err := repo.SetGoal(ctx, &domain.WeeklyGoal{
+		UserID:     "user1",
+		TargetDays: 2,
+		Activity:   "Olahraga",
+		StartAt:    startAt,
+		EndAt:      endAt,
+		CreatedAt:  startAt,
+	}); err != nil {
+		t.Fatalf("set goal: %v", err)
+	}
+	if err := repo.LogActivity(ctx, "user1", domain.GetToday(startAt)); err != nil {
+		t.Fatalf("log day 1: %v", err)
+	}
+	if _, err := repo.RecordGoalActivity(ctx, "user1", startAt, "Lari"); err != nil {
+		t.Fatalf("record day 1: %v", err)
+	}
+	secondDay := startAt.AddDate(0, 0, 1)
+	if err := repo.LogActivity(ctx, "user1", domain.GetToday(secondDay)); err != nil {
+		t.Fatalf("log day 2: %v", err)
+	}
+	completed, err := repo.RecordGoalActivity(ctx, "user1", secondDay, "Gym")
+	if err != nil || !completed {
+		t.Fatalf("expected goal completion, completed=%v err=%v", completed, err)
+	}
+
+	if err := repo.DeleteActivityLog(ctx, "user1", domain.GetToday(secondDay)); err != nil {
+		t.Fatalf("delete activity: %v", err)
+	}
+	goal, err := repo.GetActiveGoal(ctx, "user1", startAt.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("get active goal: %v", err)
+	}
+	if goal == nil || goal.CompletedAt != nil {
+		t.Fatalf("expected goal reopened after falling below target, got %+v", goal)
+	}
+	updated, err := repo.GetReport(ctx, "user1")
+	if err != nil {
+		t.Fatalf("get report: %v", err)
+	}
+	if updated.GoalsCompleted != 0 {
+		t.Fatalf("expected GoalsCompleted=0 after cancel, got %d", updated.GoalsCompleted)
+	}
+}


### PR DESCRIPTION
- Introduce GoalUsecase to manage weekly goals, including set, reset, and status flows
- Extend domain and repository with goal-related operations (Set/GetActiveGoal, DeleteActiveGoal, GetGoalActivities, RecordGoalActivity, DeleteExpiredGoals)
- Wire goal usecase into handler and repository interactions to track progress
- Persist goal state in the SQLite repository and expose completion counts
- Add ErrActiveGoalExists to signal concurrent goal creation attempts
- Add tests covering goal lifecycle, activity recording, and edge cases
- Align ISO week calculations across stats and leaderboards for consistency