### PR TITLE
feat(sidequest): implement daily side quests and reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Bot hanya merespon perintah berikut di dalam grup yang telah dikonfigurasi (`GRO
 | Perintah | Fungsi |
 | --- | --- |
 | `#lapor` | Merekam aktivitas harian user. Menambah streak jika laporan hari ini/kemarin. |
+| `#mysidequest` | Menampilkan side quest harian untuk user yang sudah memilih job. |
+| `#lapor sidequest [kegiatan] [jumlah]` | Melaporkan side quest. Reward ½ XP, tetap dihitung ke streak, stats, leaderboard, dan goal. |
 | `#cancel` | Membatalkan laporan hari ini. Hanya bisa digunakan di hari yang sama. |
 | `#leaderboard` | Menampilkan klasemen streak, daftar yang "Keep Streak" 🔥 dan "Lose Streak" 💔. |
 | `#leaderboard-weekly` | Menampilkan klasemen total hari aktif minggu ini. |
@@ -103,6 +105,7 @@ Bot hanya merespon perintah berikut di dalam grup yang telah dikonfigurasi (`GRO
 ### Fitur Gamifikasi 🏅
 - **Season Ranks (`#ranks`)**: Rank ala hunter dihitung dari seasonal points dan reset setiap season.
 - **Hunter Jobs (`#jobs`, `#job [id]`)**: Pilih job profile seperti fighter, tanker, assassin, mage, ranger, healer, atau necromancer. Job tampil di `#mystats` dan laporan harian.
+- **Side Quest (`#mysidequest`)**: Bonus gerak harian easy/medium/hard untuk user yang sudah punya job. Lapor dengan `#lapor sidequest jalan 4000` atau `#lapor sidequest sepeda 5 km`.
 - **Season Badges**: Badge reset setiap season supaya semua member mulai berburu dari awal.
 - **Lifetime Level & EXP**: Total poin dan level numerik (`Lv.0+`) tetap tersimpan lintas season. EXP naik level memakai kurva `5×level² + 50×level + 100` agar makin tinggi level makin lama naiknya.
 - **Milestone Notification**: Dapat notifikasi khusus saat mencapai streak tertenu (7, 14, 30 hari, dst).

--- a/internal/app/usecase/daily_quest_usecase.go
+++ b/internal/app/usecase/daily_quest_usecase.go
@@ -53,8 +53,9 @@ func (u *DailyQuestUsecase) GetOrGenerateQuestList(ctx context.Context, userID, 
 	return tasks, nil
 }
 
-// SendDailyQuests sends the consolidated daily quest list to the configured group at 04:00.
+// SendDailyQuests prepares today's side quests and sends a group-only morning prompt at 04:00.
 func (u *DailyQuestUsecase) SendDailyQuests(ctx context.Context, now time.Time, client *whatsmeow.Client, sender *queue.MessageSender, groupID string) error {
+	_ = client
 	if groupID == "" {
 		return fmt.Errorf("group ID is not configured")
 	}
@@ -64,116 +65,37 @@ func (u *DailyQuestUsecase) SendDailyQuests(ctx context.Context, now time.Time, 
 		return fmt.Errorf("failed to get reports: %w", err)
 	}
 
-	dateStr := domain.GetToday(now).Format("02-01-2006")
-
-	var sb strings.Builder
-	sb.WriteString("⚔️ *DAILY QUEST HARIAN HUNTER* ⚔️\n")
-	sb.WriteString(fmt.Sprintf("Tanggal: %s\n\n", dateStr))
-	sb.WriteString("Berikut adalah quest harian untuk para Hunter hari ini:\n\n")
-
-	type questGroup struct {
-		jobDesc  string
-		tasksStr string
-		users    []*domain.Report
-	}
-
-	var groups []questGroup
-	hasQuests := false
+	eligibleCount := 0
 
 	for _, r := range reports {
-		if r == nil {
+		if r == nil || strings.TrimSpace(r.JobClass) == "" {
 			continue
 		}
 
 		tasks, err := u.GetOrGenerateQuestList(ctx, r.UserID, r.JobClass, r.Level, now)
 		if err != nil {
-			log.Printf("[DAILY-QUEST] Failed to generate quest for %s: %v", r.UserID, err)
+			log.Printf("[SIDE-QUEST] Failed to generate quest for %s: %v", r.UserID, err)
 			continue
 		}
-
-		hasQuests = true
-
-		jobDesc := ""
-		if r.JobClass == "" {
-			jobDesc = "Job: - (General Quest)"
-		} else {
-			jobDesc = fmt.Sprintf("Job: %s (Lv.%d)", domain.FormatJobClass(r.JobClass), r.Level)
-		}
-
-		var tasksSB strings.Builder
-		for i, t := range tasks {
-			tasksSB.WriteString(fmt.Sprintf("  %d. %s\n", i+1, domain.FormatQuestTask(t)))
-		}
-		tasksStr := strings.TrimSuffix(tasksSB.String(), "\n")
-
-		found := false
-		for i, g := range groups {
-			if g.jobDesc == jobDesc && g.tasksStr == tasksStr {
-				groups[i].users = append(groups[i].users, r)
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			groups = append(groups, questGroup{
-				jobDesc:  jobDesc,
-				tasksStr: tasksStr,
-				users:    []*domain.Report{r},
-			})
+		if len(tasks) > 0 {
+			eligibleCount++
 		}
 	}
 
-	if !hasQuests {
+	if eligibleCount == 0 {
 		return nil
 	}
 
-	var mentions []string
-	anyUserWithoutJob := false
-
-	for _, g := range groups {
-		var userTags []string
-		for _, r := range g.users {
-			userTags = append(userTags, "@"+r.UserID)
-			mentions = append(mentions, r.UserID+"@s.whatsapp.net")
-			if r.JobClass == "" {
-				anyUserWithoutJob = true
-			}
-		}
-
-		sb.WriteString(fmt.Sprintf("👤 %s\n", strings.Join(userTags, ", ")))
-		sb.WriteString(g.jobDesc + "\n")
-		sb.WriteString("📜 *Daftar Quest:*\n")
-		sb.WriteString(g.tasksStr + "\n\n")
-	}
-
-	sb.WriteString("━━━━━━━━━━━━━━━━━━━━━━━━━━\n")
-	sb.WriteString("Cara melapor:\n")
-	sb.WriteString("Kirim pesan di GRUP dengan format `#lapor-quest [nama-quest] [jumlah]`.\n")
-	sb.WriteString("Kamu juga bisa melaporkan beberapa quest sekaligus secara bersamaan:\n")
-	sb.WriteString("#lapor-quest\n")
-	sb.WriteString("- push up 10\n")
-	sb.WriteString("- squat 15\n")
-
-	if anyUserWithoutJob {
-		sb.WriteString("\n💡 *Tip:* Bagi Hunter yang belum memilih job, kumpulkan minimal 50 poin agar bisa memilih job khusus (Fighter, Tanker, Assassin, Mage, Ranger, Healer, Necromancer) untuk mendapatkan quest khusus dengan reward yang lebih besar!\n")
-	}
-
-	sb.WriteString("\nSemangat berlatih dan terus tingkatkan rank-mu! 🔥")
+	dateStr := domain.GetToday(now).Format("02 Jan 2006")
+	msgText := fmt.Sprintf("🌅 *Selamat pagi, Hunters!*\n\nSide quest hari ini sudah terbuka untuk %d hunter yang sudah memilih job. Buka `#mysidequest` untuk lihat pilihan easy, medium, dan hard hari ini.\n\nPilih yang ringan dulu juga boleh—jalan 4.000 langkah, sepeda 5 km, atau gerakan singkat di rumah/kantor. Side quest cuma bonus ½ XP; misi utama tetap konsisten olahraga dan lapor di grup. ✨\n\n📅 %s\n📝 Lapor side quest: `#lapor sidequest <kegiatan> <jumlah>`", eligibleCount, dateStr)
 
 	targetJID, err := types.ParseJID(groupID)
 	if err != nil {
 		return fmt.Errorf("invalid group ID: %w", err)
 	}
 
-	msgText := sb.String()
 	msg := &waE2E.Message{
-		ExtendedTextMessage: &waE2E.ExtendedTextMessage{
-			Text: &msgText,
-			ContextInfo: &waE2E.ContextInfo{
-				MentionedJID: mentions,
-			},
-		},
+		Conversation: &msgText,
 	}
 
 	// Send to group
@@ -194,6 +116,9 @@ func (u *DailyQuestUsecase) ViewQuest(ctx context.Context, userID, name string, 
 	if report == nil {
 		return fmt.Sprintf("Halo %s, kamu belum terdaftar di database. Silakan lakukan laporan pertama dengan `#lapor` terlebih dahulu! 💪", name), nil
 	}
+	if strings.TrimSpace(report.JobClass) == "" {
+		return "🔒 *Side quest belum terbuka.*\n\nKamu perlu memilih job dulu agar bisa mendapat side quest harian. Cek `#jobs`, lalu pilih dengan `#job <id>` setelah syarat poin terpenuhi.", nil
+	}
 
 	tasks, err := u.GetOrGenerateQuestList(ctx, userID, report.JobClass, report.Level, now)
 	if err != nil {
@@ -201,29 +126,27 @@ func (u *DailyQuestUsecase) ViewQuest(ctx context.Context, userID, name string, 
 	}
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("📜 *Quest Harian - %s* 🏹\n", report.Name))
-	if report.JobClass == "" {
-		sb.WriteString("Job: - (General Quest)\n\n")
-	} else {
-		sb.WriteString(fmt.Sprintf("Job: %s (Lv.%d)\n\n", domain.FormatJobClass(report.JobClass), report.Level))
-	}
+	sb.WriteString(fmt.Sprintf("📜 *Side Quest Hari Ini - %s* 🏹\n", report.Name))
+	sb.WriteString(fmt.Sprintf("Job: %s (Lv.%d)\n", domain.FormatJobClass(report.JobClass), report.Level))
+	sb.WriteString("Reward: ½ XP per side quest yang valid. #lapor utama tetap prioritas.\n\n")
 
+	completed := 0
 	for i, t := range tasks {
 		status := "⏳"
 		if t.Progress >= t.Target {
 			status = "✅"
+			completed++
 		}
 		sb.WriteString(fmt.Sprintf("%s %d. %s\n", status, i+1, domain.FormatQuestProgressTask(t)))
 	}
 
-	sb.WriteString(fmt.Sprintf("\nProgress: %s\n\n", formatQuestProgressBar(tasks)))
-	sb.WriteString("Ketik `#lapor-quest [nama] [jumlah]` untuk update progres!\n")
+	sb.WriteString(fmt.Sprintf("\nProgress hari ini: %s (%d/%d selesai)\n", formatQuestProgressBar(tasks), completed, len(tasks)))
+	sb.WriteString(fmt.Sprintf("Total side quest selesai: %d lifetime • %d season\n\n", report.TotalSideQuests, report.SeasonalSideQuests))
+	sb.WriteString("Cara lapor: `#lapor sidequest [nama kegiatan] [jumlah]`\n")
 	sb.WriteString("Contoh:\n")
-	sb.WriteString("#lapor-quest push-up 5\n\n")
-	sb.WriteString("Atau laporkan sekaligus:\n")
-	sb.WriteString("#lapor-quest\n")
-	sb.WriteString("- push up 10\n")
-	sb.WriteString("- squat 15")
+	sb.WriteString("#lapor sidequest jalan 4000\n")
+	sb.WriteString("#lapor sidequest sepeda 5 km\n")
+	sb.WriteString("#lapor sidequest plank 60 detik")
 
 	return sb.String(), nil
 }
@@ -238,15 +161,25 @@ func (u *DailyQuestUsecase) UpdateProgress(ctx context.Context, userID, name str
 	if report == nil {
 		return fmt.Sprintf("Halo %s, kamu belum terdaftar di database. Silakan lakukan laporan pertama dengan `#lapor` terlebih dahulu! 💪", name), nil
 	}
+	if strings.TrimSpace(report.JobClass) == "" {
+		return "🔒 Side quest hanya tersedia setelah kamu memilih job. Cek `#jobs`, lalu pilih dengan `#job <id>` saat syarat poin sudah terpenuhi.", nil
+	}
+	today := domain.GetToday(now)
+	dailyCount, err := u.repo.GetDailyActivityCount(ctx, userID, today)
+	if err != nil {
+		return "", err
+	}
+	if dailyCount >= MaxDailyReports {
+		return fmt.Sprintf("Batas laporan harian sudah penuh (%dx). Side quest belum diterima agar progres quest tidak kepisah dari stats. Kalau salah input, pakai #cancel dulu lalu lapor ulang. 🙏", MaxDailyReports), nil
+	}
 
 	tasks, err := u.GetOrGenerateQuestList(ctx, userID, report.JobClass, report.Level, now)
 	if err != nil {
 		return "", err
 	}
 
-	updated := false
-	pointsAwarded := 0
 	var completedTasks []string
+	var rejected []string
 
 	for _, line := range inputLines {
 		namePart, val := parseLineFloat(line)
@@ -254,8 +187,10 @@ func (u *DailyQuestUsecase) UpdateProgress(ctx context.Context, userID, name str
 			continue
 		}
 
+		matched := false
 		for idx, task := range tasks {
 			if domain.MatchTask(namePart, task.ID) {
+				matched = true
 				added := 0
 				if task.Unit == "100m" {
 					if val < 50.0 { // e.g. "lari 2.5" is 2.5 km -> 25 units of 100m
@@ -267,20 +202,28 @@ func (u *DailyQuestUsecase) UpdateProgress(ctx context.Context, userID, name str
 					added = int(val)
 				}
 
-				wasCompleted := task.Progress >= task.Target
-				tasks[idx].Progress += added
-				updated = true
-
-				if !wasCompleted && tasks[idx].Progress >= task.Target {
-					pointsAwarded += task.RewardPoints
-					completedTasks = append(completedTasks, task.Name)
+				if task.Progress >= task.Target {
+					return fmt.Sprintf("%s sudah selesai hari ini. Pilih side quest lain di `#mysidequest` kalau masih mau lanjut. ✅", task.Name), nil
 				}
+				if added < task.Target {
+					rejected = append(rejected, fmt.Sprintf("%s butuh minimal %s, laporanmu baru %s", task.Name, formatQuestTarget(task), formatQuestValue(task, added)))
+					continue
+				}
+
+				tasks[idx].Progress = task.Target
+				completedTasks = append(completedTasks, task.Name)
 			}
+		}
+		if !matched {
+			rejected = append(rejected, fmt.Sprintf("%q tidak cocok dengan side quest hari ini", namePart))
 		}
 	}
 
-	if !updated {
-		return "Gagal memperbarui progres. Pastikan format penulisan benar.\nContoh: `#lapor-quest push-up 5`", nil
+	if len(completedTasks) == 0 {
+		if len(rejected) > 0 {
+			return "Side quest belum diterima. Targetnya harus tercapai dulu ya. 💪\n\n- " + strings.Join(rejected, "\n- ") + "\n\nCek target hari ini dengan `#mysidequest`, lalu lapor ulang: `#lapor sidequest <kegiatan> <jumlah>`", nil
+		}
+		return "Gagal membaca laporan side quest. Contoh: `#lapor sidequest jalan 4000` atau `#lapor sidequest sepeda 5 km`", nil
 	}
 
 	// Save updated tasks list
@@ -288,44 +231,26 @@ func (u *DailyQuestUsecase) UpdateProgress(ctx context.Context, userID, name str
 	if err != nil {
 		return "", err
 	}
-	todayStr := domain.GetToday(now).Format("2006-01-02")
+	todayStr := today.Format("2006-01-02")
 	if err := u.repo.SaveDailyQuest(ctx, userID, todayStr, string(bytes)); err != nil {
 		return "", err
 	}
 
-	// Update user report points
-	if pointsAwarded > 0 {
-		report.TotalPoints += pointsAwarded
-		report.SeasonalPoints += pointsAwarded
-		report.Level = domain.NumericLevelFromTotalPoints(report.TotalPoints)
-		if err := u.repo.UpsertReport(ctx, report); err != nil {
-			return "", err
-		}
-	}
-
-	// Check if this is their first quest update of today to trigger auto-#lapor
-	var autoLaporResult string
-	today := domain.GetToday(now)
-	reportedToday := domain.GetToday(report.LastReportDate).Equal(today)
-
-	if !reportedToday {
-		autoLaporResult, err = reportUC.Execute(ctx, userID, name, nil)
-		if err != nil {
-			log.Printf("[DAILY-QUEST] Failed to auto-trigger #lapor: %v", err)
-		}
+	activityText := "Side quest: " + strings.Join(completedTasks, ", ")
+	reportResult, err := reportUC.ExecuteSideQuest(ctx, userID, name, activityText, len(completedTasks), now)
+	if err != nil {
+		return "", err
 	}
 
 	// Format response message
 	var sb strings.Builder
 	if len(completedTasks) > 0 {
-		sb.WriteString("🎉 *QUEST BERHASIL DISELESAIKAN!* 🏆\n\n")
+		sb.WriteString("🎉 *SIDE QUEST BERHASIL DISELESAIKAN!* 🏆\n\n")
 		sb.WriteString("Selamat, kamu menyelesaikan:\n")
 		for _, name := range completedTasks {
 			sb.WriteString(fmt.Sprintf("- %s\n", name))
 		}
-		sb.WriteString(fmt.Sprintf("\n💰 Reward: +%d poin ditambahkan ke profilmu!\n\n", pointsAwarded))
-	} else {
-		sb.WriteString("📈 *PROGRES QUEST HARIAN DIUPDATE*\n\n")
+		sb.WriteString("\n💰 Reward: ½ XP per side quest valid.\n\n")
 	}
 
 	sb.WriteString("📜 *Daftar Quest Saat Ini:*\n")
@@ -338,12 +263,8 @@ func (u *DailyQuestUsecase) UpdateProgress(ctx context.Context, userID, name str
 	}
 
 	sb.WriteString(fmt.Sprintf("\nProgress: %s\n", formatQuestProgressBar(tasks)))
-
-	if autoLaporResult != "" {
-		sb.WriteString("\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n")
-		sb.WriteString("🤖 *AUTO #LAPOR DETECTED:*\n")
-		sb.WriteString(autoLaporResult)
-	}
+	sb.WriteString("\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n")
+	sb.WriteString(reportResult)
 
 	return sb.String(), nil
 }
@@ -372,6 +293,17 @@ func parseLineFloat(line string) (string, float64) {
 	var val float64
 	fmt.Sscanf(numStr, "%f", &val)
 	return namePart, val
+}
+
+func formatQuestTarget(task domain.QuestTask) string {
+	return formatQuestValue(task, task.Target)
+}
+
+func formatQuestValue(task domain.QuestTask, value int) string {
+	if task.Unit == "100m" {
+		return fmt.Sprintf("%.1f km", float64(value)/10.0)
+	}
+	return fmt.Sprintf("%d %s", value, task.Unit)
 }
 
 func formatQuestProgressBar(tasks []domain.QuestTask) string {

--- a/internal/app/usecase/daily_quest_usecase_test.go
+++ b/internal/app/usecase/daily_quest_usecase_test.go
@@ -109,7 +109,7 @@ func TestDailyQuestViewAndComplete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected view quest error: %v", err)
 	}
-	if !strings.Contains(viewMsg, "Quest Harian - Alice") {
+	if !strings.Contains(viewMsg, "Side Quest Hari Ini - Alice") {
 		t.Errorf("expected view message to contain Alice, got %q", viewMsg)
 	}
 
@@ -122,48 +122,35 @@ func TestDailyQuestViewAndComplete(t *testing.T) {
 	if err := json.Unmarshal([]byte(qJSON), &tasks); err != nil {
 		t.Fatalf("failed to parse stored quest tasks: %v", err)
 	}
-	if len(tasks) != 3 {
-		t.Fatalf("expected 3 generated tasks, got %d", len(tasks))
+	if len(tasks) != 4 {
+		t.Fatalf("expected 4 generated tasks, got %d", len(tasks))
 	}
 
-	// First task is Push-up (Target: 10 + 5 = 15 x)
 	t.Logf("Generated tasks: %+v", tasks)
 
-	// 2. Report progress for Push-up
-	progressMsg, err := questUC.UpdateProgress(context.Background(), "user1", "Alice", []string{"pushup 5"}, reportUC, now)
+	// 2. Report below target should be rejected.
+	progressMsg, err := questUC.UpdateProgress(context.Background(), "user1", "Alice", []string{"jalan 3999"}, reportUC, now)
 	if err != nil {
 		t.Fatalf("unexpected update progress error: %v", err)
 	}
-
-	// Verify progress was updated
-	if !strings.Contains(progressMsg, "Push-up: 5/") {
-		t.Errorf("expected progress message to show updated reps, got %q", progressMsg)
+	if !strings.Contains(progressMsg, "Side quest belum diterima") {
+		t.Errorf("expected below-target side quest to be rejected, got %q", progressMsg)
 	}
 
-	// Verify auto-#lapor was triggered (as they hadn't reported yet today)
-	if !strings.Contains(progressMsg, "AUTO #LAPOR DETECTED") {
-		t.Errorf("expected response to show auto-#lapor trigger, got %q", progressMsg)
-	}
-
-	// Verify streak increased (last report date updated)
-	if repo.upsertedReport.LastReportDate.Sub(now) > time.Second {
-		t.Errorf("expected last report date to be now, got %v", repo.upsertedReport.LastReportDate)
-	}
-
-	// 3. Complete pushup task
-	compMsg, err := questUC.UpdateProgress(context.Background(), "user1", "Alice", []string{"pushup 15"}, reportUC, now)
+	// 3. Complete walking side quest.
+	compMsg, err := questUC.UpdateProgress(context.Background(), "user1", "Alice", []string{"jalan 4000"}, reportUC, now)
 	if err != nil {
 		t.Fatalf("unexpected complete task error: %v", err)
 	}
 
-	// Verify points awarded
-	if !strings.Contains(compMsg, "QUEST BERHASIL DISELESAIKAN") {
+	if !strings.Contains(compMsg, "SIDE QUEST BERHASIL DISELESAIKAN") {
 		t.Errorf("expected success notification, got %q", compMsg)
 	}
-
-	// Pushup reward is 3 + 5/5 = 4 points
-	if repo.upsertedReport.TotalPoints <= 200 {
-		t.Errorf("expected points to increase, got %d", repo.upsertedReport.TotalPoints)
+	if repo.upsertedReport.TotalSideQuests != 1 || repo.upsertedReport.SeasonalSideQuests != 1 {
+		t.Errorf("expected side quest counters to increase, got lifetime=%d season=%d", repo.upsertedReport.TotalSideQuests, repo.upsertedReport.SeasonalSideQuests)
+	}
+	if repo.upsertedReport.TotalPoints != 205 {
+		t.Errorf("expected side quest to add 5 points, got %d", repo.upsertedReport.TotalPoints)
 	}
 }
 
@@ -233,40 +220,21 @@ func TestSendDailyQuests(t *testing.T) {
 		t.Errorf("expected JID %s, got %s", groupJID.String(), fakeClient.sentJID.String())
 	}
 
-	if fakeClient.sentMsg == nil || fakeClient.sentMsg.ExtendedTextMessage == nil || fakeClient.sentMsg.ExtendedTextMessage.Text == nil {
-		t.Fatalf("sent message does not contain ExtendedTextMessage text")
+	if fakeClient.sentMsg == nil || fakeClient.sentMsg.Conversation == nil {
+		t.Fatalf("sent message does not contain conversation text")
 	}
 
-	text := *fakeClient.sentMsg.ExtendedTextMessage.Text
-	if !strings.Contains(text, "⚔️ *DAILY QUEST HARIAN HUNTER* ⚔️") {
+	text := *fakeClient.sentMsg.Conversation
+	if !strings.Contains(text, "Selamat pagi, Hunters") {
 		t.Errorf("expected text to contain title, got: %s", text)
 	}
-	if !strings.Contains(text, "👤 @628123456789, @628111222333") {
-		t.Errorf("expected text to group Alice and Charlie, got: %s", text)
+	if !strings.Contains(text, "#mysidequest") {
+		t.Errorf("expected text to prompt #mysidequest, got: %s", text)
 	}
-	if !strings.Contains(text, "👤 @628987654321") {
-		t.Errorf("expected text to mention Bob, got: %s", text)
+	if strings.Contains(text, "@") || strings.Contains(text, "Alice") || strings.Contains(text, "Bob") || strings.Contains(text, "Charlie") {
+		t.Errorf("daily side quest prompt should not mention or name users, got: %s", text)
 	}
-	if !strings.Contains(text, "Job: Fighter ⚔️ (Lv.5)") {
-		t.Errorf("expected text to show Alice job and level, got: %s", text)
-	}
-	if !strings.Contains(text, "Job: - (General Quest)") {
-		t.Errorf("expected text to show Bob general quest, got: %s", text)
-	}
-
-	// Verify mentions are populated correctly in ContextInfo
-	contextInfo := fakeClient.sentMsg.ExtendedTextMessage.ContextInfo
-	if contextInfo == nil {
-		t.Fatalf("expected ContextInfo in ExtendedTextMessage to be set")
-	}
-	expectedMentions := []string{"628123456789@s.whatsapp.net", "628111222333@s.whatsapp.net", "628987654321@s.whatsapp.net"}
-	if len(contextInfo.MentionedJID) != len(expectedMentions) {
-		t.Errorf("expected %d mentions, got %d", len(expectedMentions), len(contextInfo.MentionedJID))
-	} else {
-		for i, m := range contextInfo.MentionedJID {
-			if m != expectedMentions[i] {
-				t.Errorf("expected mention %q at index %d, got %q", expectedMentions[i], i, m)
-			}
-		}
+	if !strings.Contains(text, "2 hunter") {
+		t.Errorf("expected only users with job to be counted, got: %s", text)
 	}
 }

--- a/internal/app/usecase/get_achievements_usecase.go
+++ b/internal/app/usecase/get_achievements_usecase.go
@@ -32,6 +32,7 @@ func (uc *GetAchievementsUsecase) Execute(ctx context.Context) (string, error) {
 	// database, but the visible badge race resets every season.
 	stats := make(map[string]int)
 	goalTotal := 0
+	sideQuestTotal := 0
 	for _, r := range reports {
 		if r.SeasonalAchievements != "" {
 			ids := strings.Split(r.SeasonalAchievements, ",")
@@ -40,6 +41,7 @@ func (uc *GetAchievementsUsecase) Execute(ctx context.Context) (string, error) {
 			}
 		}
 		goalTotal += r.GoalsCompleted
+		sideQuestTotal += r.SeasonalSideQuests
 	}
 
 	seasonNumber, _ := GetCurrentSessionInfo(time.Now())
@@ -80,6 +82,11 @@ func (uc *GetAchievementsUsecase) Execute(ctx context.Context) (string, error) {
 	sb.WriteString(fmt.Sprintf("🏆 Total goal tercapai grup: %d\n", goalTotal))
 	sb.WriteString("   Syarat: set #goal, lalu penuhi target hari aktif dalam 7 hari sejak goal dibuat. Laporan dobel di hari yang sama tetap dihitung 1.\n")
 	sb.WriteString("   _Goal adalah quest mingguan: kecil, jelas, dan selesai lewat aksi harian._\n\n")
+
+	sb.WriteString("✨ *Side Quest Harian*\n")
+	sb.WriteString(fmt.Sprintf("🏹 Total side quest selesai season ini: %d\n", sideQuestTotal))
+	sb.WriteString("   Syarat: sudah memilih job, cek `#mysidequest`, lalu lapor dengan `#lapor sidequest <kegiatan> <jumlah>`.\n")
+	sb.WriteString("   Reward side quest hanya ½ XP, tapi tetap dihitung ke streak, stats, leaderboard, dan goal.\n\n")
 
 	sb.WriteString("⚔️ Level numerik naik dari total EXP lifetime. Semakin tinggi level, semakin banyak EXP yang dibutuhkan.")
 

--- a/internal/app/usecase/get_help_usecase.go
+++ b/internal/app/usecase/get_help_usecase.go
@@ -10,7 +10,12 @@ var helpSections = []struct {
 	{
 		emoji:   "📝",
 		title:   "Melaporkan Aktivitas",
-		content: "*#lapor* — Laporkan workout atau aktivitas harianmu.\nContoh: `#lapor` atau `#lapor Push Day`\n\n🔄 Setiap laporan yang valid akan menambah streak mingguanmu dan total hari aktif.\n❄️ *Streak Freeze* — kamu punya 1 freeze gratis per season. Freeze otomatis melindungi 1 minggu absen. Dapatkan +1 freeze lagi saat kamu mencapai 4 minggu streak!\n\n📌 *Max 3x laporan per hari*: Kamu bisa lapor maksimal 3x dalam sehari. Laporan ke-2 dan ke-3 tetap dihitung 1 hari tapi XP dibagi 2.\n📌 *#lapor-kemarin* — Laporan khusus untuk hari kemarin. Sama seperti #lapor, XP dibagi 2. Max 3x per hari.",
+		content: "*#lapor* — Laporkan workout atau aktivitas harianmu.\nContoh: `#lapor` atau `#lapor Push Day`\n\n*#lapor sidequest [kegiatan] [jumlah]* — Laporkan side quest dari `#mysidequest`. Contoh: `#lapor sidequest jalan 4000`. Side quest hanya ½ XP, tapi tetap dihitung untuk streak, stats, leaderboard, dan goal.\n\n🔄 Setiap laporan yang valid akan menambah streak mingguanmu dan total hari aktif.\n❄️ *Streak Freeze* — kamu punya 1 freeze gratis per season. Freeze otomatis melindungi 1 minggu absen. Dapatkan +1 freeze lagi saat kamu mencapai 4 minggu streak!\n\n📌 *Max 3x laporan per hari*: Kamu bisa lapor maksimal 3x dalam sehari. Laporan ke-2 dan ke-3 tetap dihitung 1 hari tapi XP dibagi 2.\n📌 *#lapor-kemarin* — Laporan khusus untuk hari kemarin. Sama seperti #lapor, XP dibagi 2. Max 3x per hari.",
+	},
+	{
+		emoji:   "✨",
+		title:   "Side Quest Harian",
+		content: "*#mysidequest* — Lihat side quest easy, medium, dan hard hari ini. Wajib pilih job dulu lewat `#job <id>` agar mendapat side quest.\n\nEasy selalu jalan kaki minimal 4.000 langkah atau sepeda 5 km. Medium/hard berisi latihan ringan yang bisa dilakukan di rumah/kantor, dan naik sedikit sesuai level job.\n\nLapor dengan `#lapor sidequest [kegiatan] [jumlah]`. Target harus tercapai dulu; kalau kurang, laporan ditolak dan kamu bisa ulang setelah menambah aktivitas.",
 	},
 	{
 		emoji:   "❌",
@@ -69,6 +74,8 @@ func (uc *GetHelpUsecase) Execute() string {
 	return `🤖 *Command Lapor Bot*
 
 📝 #lapor — laporan aktivitas harian (max 3x/hari)
+✨ #mysidequest — lihat side quest hari ini
+✨ #lapor sidequest [kegiatan] [jumlah] — lapor side quest ½ XP
 📌 #lapor-kemarin — laporan khusus hari kemarin (max 3x/hari)
 ❌ #cancel — batalkan laporan hari ini
 🧹 #cancel-all — batalkan semua laporan hari ini
@@ -110,6 +117,12 @@ func (uc *GetHelpUsecase) ExecuteTutorial() string {
 	msg += "3. Lapor aktivitas dengan `#lapor`; laporan dobel di hari yang sama tetap dihitung 1 untuk goal.\n"
 	msg += "4. Cek progress kapan saja dengan `#goal`. Jika ingin ganti target saat masih aktif, pakai `#goal reset` dulu.\n"
 	msg += "5. Saat target tercapai, total goals di `#mystats` dan `#achievements` bertambah.\n\n"
+	msg += "✨ *Flow Side Quest Harian*\n"
+	msg += "1. Pilih job dulu dengan `#job <id>` agar side quest terbuka.\n"
+	msg += "2. Setiap pagi bot memberi reminder di grup; cek detail quest kamu dengan `#mysidequest`.\n"
+	msg += "3. Pilih easy, medium, hard, atau beberapa sekaligus jika mau.\n"
+	msg += "4. Lapor dengan format `#lapor sidequest <kegiatan> <jumlah>`, contoh `#lapor sidequest jalan 4000` atau `#lapor sidequest sepeda 5 km`.\n"
+	msg += "5. Side quest memberi ½ XP, tetap masuk streak, stats, leaderboard, goal, dan total side quest di `#mystats`/`#achievements`.\n\n"
 	msg += "_Catatan: Bot hanya merespon di grup yang sudah dikonfigurasi. Semangat terus! 💪_"
 	return msg
 }

--- a/internal/app/usecase/get_mystats_usecase.go
+++ b/internal/app/usecase/get_mystats_usecase.go
@@ -82,6 +82,7 @@ func (uc *GetMyStatsUsecase) Execute(ctx context.Context, userID, name string) (
 	sb.WriteString(fmt.Sprintf("🗓️ Hari season: %d\n", seasonCount))
 	sb.WriteString(fmt.Sprintf("📆 Hari minggu ini: %d\n\n", weeklyCount))
 	sb.WriteString(fmt.Sprintf("🎯 Goals tercapai: %d\n\n", report.GoalsCompleted))
+	sb.WriteString(fmt.Sprintf("✨ Side quest selesai: %d lifetime • %d season\n\n", report.TotalSideQuests, report.SeasonalSideQuests))
 
 	sb.WriteString(fmt.Sprintf("🔥 Streak saat ini: %d minggu\n", report.Streak))
 	sb.WriteString(fmt.Sprintf("🏆 Streak tertinggi: %d minggu\n", report.MaxStreak))

--- a/internal/app/usecase/goal_usecase.go
+++ b/internal/app/usecase/goal_usecase.go
@@ -169,8 +169,7 @@ func formatGoalStatus(goal *domain.WeeklyGoal, activities []domain.GoalActivity,
 	}
 
 	if now.Before(goal.EndAt) {
-		remainingDuration := goal.EndAt.Sub(now).Round(time.Minute)
-		sb.WriteString(fmt.Sprintf("\n⏳ Sisa waktu: %s", remainingDuration))
+		sb.WriteString(fmt.Sprintf("\n⏳ Sisa waktu: %s", formatGoalRemaining(goal.EndAt.Sub(now))))
 	}
 
 	return sb.String()
@@ -195,12 +194,43 @@ func formatGoalTime(t time.Time) string {
 	return fmt.Sprintf("%02d %s %d %02d:%02d", t.Day(), indonesianMonths[int(t.Month())], t.Year(), t.Hour(), t.Minute())
 }
 
+func formatGoalRemaining(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	d = d.Round(time.Minute)
+	days := int(d / (24 * time.Hour))
+	d -= time.Duration(days) * 24 * time.Hour
+	hours := int(d / time.Hour)
+	d -= time.Duration(hours) * time.Hour
+	minutes := int(d / time.Minute)
+
+	parts := make([]string, 0, 3)
+	if days > 0 {
+		parts = append(parts, fmt.Sprintf("%d hari", days))
+	}
+	if hours > 0 {
+		parts = append(parts, fmt.Sprintf("%d jam", hours))
+	}
+	if minutes > 0 || len(parts) == 0 {
+		parts = append(parts, fmt.Sprintf("%d menit", minutes))
+	}
+	return strings.Join(parts, " ")
+}
+
 func goalReportDate(t time.Time) time.Time {
 	return domain.GetToday(t.UTC())
 }
 
 func goalActivityText(workout *domain.HevyWorkout) string {
+	return goalActivityTextWithFallback(workout, "")
+}
+
+func goalActivityTextWithFallback(workout *domain.HevyWorkout, fallback string) string {
 	if workout == nil || strings.TrimSpace(workout.Title) == "" {
+		if text := strings.TrimSpace(fallback); text != "" {
+			return text
+		}
 		return "Olahraga"
 	}
 	return strings.TrimSpace(workout.Title)

--- a/internal/app/usecase/handle_message_usecase.go
+++ b/internal/app/usecase/handle_message_usecase.go
@@ -83,42 +83,21 @@ func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, messa
 		return MessageResponse{Text: text}, err
 	}
 
-	if strings.Contains(msg, "#lapor-quest") || strings.Contains(msg, "#laporquest") {
-		lines := strings.Split(message, "\n")
-		var argLines []string
-
-		if len(lines) == 1 {
-			cmdIdx := strings.Index(msg, "#lapor-quest")
-			cmdLen := len("#lapor-quest")
-			if cmdIdx == -1 {
-				cmdIdx = strings.Index(msg, "#laporquest")
-				cmdLen = len("#laporquest")
-			}
-			var arg string
-			if cmdIdx != -1 {
-				arg = strings.TrimSpace(message[cmdIdx+cmdLen:])
-			}
-			if arg != "" {
-				argLines = append(argLines, arg)
-			}
-		} else {
-			for _, line := range lines[1:] {
-				if strings.TrimSpace(line) != "" {
-					argLines = append(argLines, line)
-				}
-			}
-		}
-
-		if len(argLines) > 0 {
-			text, err := uc.dailyQuestUC.UpdateProgress(ctx, userID, name, argLines, uc.reportUC, time.Now())
-			return MessageResponse{Text: text}, err
-		}
-
+	if strings.Contains(msg, "#mysidequest") {
 		text, err := uc.dailyQuestUC.ViewQuest(ctx, userID, name, time.Now())
 		return MessageResponse{Text: text}, err
 	}
 
-	if strings.Contains(msg, "#lapor") {
+	if arg, ok := extractSideQuestReport(message); ok {
+		if arg == "" {
+			text, err := uc.dailyQuestUC.ViewQuest(ctx, userID, name, time.Now())
+			return MessageResponse{Text: text}, err
+		}
+		text, err := uc.dailyQuestUC.UpdateProgress(ctx, userID, name, []string{arg}, uc.reportUC, time.Now())
+		return MessageResponse{Text: text}, err
+	}
+
+	if containsCommand(msg, "#lapor") {
 		workout := domain.ParseHevy(message)
 		text, err := uc.reportUC.Execute(ctx, userID, name, workout)
 		return MessageResponse{Text: text}, err
@@ -212,4 +191,25 @@ func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, messa
 	}
 
 	return MessageResponse{}, nil
+}
+
+func extractSideQuestReport(message string) (string, bool) {
+	lower := strings.ToLower(message)
+	for _, command := range []string{"#lapor sidequest", "#lapor-sidequest"} {
+		idx := strings.Index(lower, command)
+		if idx == -1 {
+			continue
+		}
+		return strings.TrimSpace(message[idx+len(command):]), true
+	}
+	return "", false
+}
+
+func containsCommand(message, command string) bool {
+	idx := strings.Index(message, command)
+	if idx == -1 {
+		return false
+	}
+	end := idx + len(command)
+	return end == len(message) || message[end] == ' ' || message[end] == '\n' || message[end] == '\t'
 }

--- a/internal/app/usecase/handle_message_usecase_test.go
+++ b/internal/app/usecase/handle_message_usecase_test.go
@@ -614,7 +614,7 @@ func TestHandleMessage_LaporDoesNotUpdateName(t *testing.T) {
 	}
 }
 
-func TestHandleMessage_LaporQuestCommand(t *testing.T) {
+func TestHandleMessage_MySideQuestCommand(t *testing.T) {
 	repo := &mockReportRepo{reports: make(map[string]*domain.Report)}
 	reportUC := usecase.NewReportActivityUsecase(repo)
 	leaderboardUC := usecase.NewGetLeaderboardUsecase(repo)
@@ -630,29 +630,18 @@ func TestHandleMessage_LaporQuestCommand(t *testing.T) {
 	repo.reports["user123"] = &domain.Report{
 		UserID:      "user123",
 		Name:        "TestUser",
+		JobClass:    "fighter",
 		TotalPoints: 10,
 		Level:       1,
 	}
 
-	// 2. Test #lapor-quest command to view quests
-	msg, err := handleUC.Execute(ctx, "user123", "TestUser", "#lapor-quest")
+	msg, err := handleUC.Execute(ctx, "user123", "TestUser", "#mysidequest")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// Should route to daily quest view and return daily quest checklist
-	expected := "Quest Harian - TestUser"
-	if !containsSubstring(msg.Text, expected) {
-		t.Errorf("Expected message to contain '%s', got '%s'", expected, msg.Text)
-	}
-
-	// 3. Test #laporquest (without dash) to view quests
-	msg, err = handleUC.Execute(ctx, "user123", "TestUser", "#laporquest")
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	expected := "Side Quest Hari Ini - TestUser"
 	if !containsSubstring(msg.Text, expected) {
 		t.Errorf("Expected message to contain '%s', got '%s'", expected, msg.Text)
 	}
 }
-

--- a/internal/app/usecase/morning_workout_checkpoint_usecase.go
+++ b/internal/app/usecase/morning_workout_checkpoint_usecase.go
@@ -45,25 +45,23 @@ var morningWorkoutMotivations = []string{
 func BuildMorningWorkoutCheckpointMessage(activeToday, pendingToday []*domain.Report) string {
 	var sb strings.Builder
 
-	sb.WriteString("🌤️ *09:09 Workout Checkpoint*\n\n")
+	sb.WriteString("🌤️ *Selamat pagi! 09:09 Workout Checkpoint*\n\n")
 	sb.WriteString(morningWorkoutMotivations[rand.Intn(len(morningWorkoutMotivations))])
 	sb.WriteString("\n\n")
 
 	if len(activeToday) > 0 {
-		sb.WriteString(fmt.Sprintf("👏 *Sudah olahraga pagi ini (%d):*\n", len(activeToday)))
-		sb.WriteString(formatReportNames(activeToday))
-		sb.WriteString("\nKeren! Kalian sudah buka jalan dan jadi pemantik semangat buat grup. Respect! 🔥\n\n")
+		sb.WriteString(fmt.Sprintf("👏 Sebelum jam ini sudah ada %d laporan olahraga. Keren—terima kasih sudah jadi pemantik energi pagi buat grup! 🔥\n\n", len(activeToday)))
 	} else {
-		sb.WriteString("Belum ada yang laporan olahraga pagi ini. Siapa yang mau jadi pembuka dan nyalain semangat grup? 💪\n\n")
+		sb.WriteString("Belum ada laporan olahraga pagi ini. Tidak apa-apa—mulai dari 10 menit gerak ringan juga sudah menang dari nol. 💪\n\n")
 	}
 
 	if len(pendingToday) > 0 {
-		sb.WriteString(fmt.Sprintf("⏳ *Belum lapor hari ini (%d):*\n", len(pendingToday)))
-		sb.WriteString(formatReportNames(pendingToday))
-		sb.WriteString("\n\nMasih pagi — ambil 10–30 menit buat jalan kaki, stretching, bodyweight workout, atau olahraga favoritmu. Satu gerakan kecil hari ini tetap menang dari nol. 🚀")
+		sb.WriteString("Masih pagi — ambil 10–30 menit buat jalan kaki, stretching, bodyweight workout, atau olahraga favoritmu. Setelah itu lapor di grup dengan `#lapor`. 🚀")
 	} else {
 		sb.WriteString("Mantap, semua sudah lapor hari ini. Grup sehat full power! 🏆")
 	}
+
+	sb.WriteString("\n\n✨ Kalau sudah punya job, cek bonus gerak harian dengan `#mysidequest`.")
 
 	return sb.String()
 }

--- a/internal/app/usecase/morning_workout_checkpoint_usecase_test.go
+++ b/internal/app/usecase/morning_workout_checkpoint_usecase_test.go
@@ -34,14 +34,16 @@ func TestBuildMorningWorkoutCheckpointMessage(t *testing.T) {
 
 	for _, want := range []string{
 		"09:09 Workout Checkpoint",
-		"Sudah olahraga pagi ini",
-		"Active One",
-		"Belum lapor hari ini",
-		"Pending Two",
+		"sudah ada 1 laporan olahraga",
+		"#lapor",
+		"#mysidequest",
 	} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("expected message to contain %q, got %q", want, msg)
 		}
+	}
+	if strings.Contains(msg, "Active One") || strings.Contains(msg, "Pending Two") {
+		t.Fatalf("morning checkpoint should not name users, got %q", msg)
 	}
 	if strings.Contains(msg, "@") {
 		t.Fatalf("morning checkpoint should use plain names without mentions, got %q", msg)

--- a/internal/app/usecase/remind_inactive_users_usecase.go
+++ b/internal/app/usecase/remind_inactive_users_usecase.go
@@ -60,8 +60,6 @@ type inactiveUserInfo struct {
 	daysInactive int
 }
 
-
-
 func (u *RemindInactiveUsersUsecase) Execute(ctx context.Context, client *whatsmeow.Client, groupID string) (string, error) {
 	return u.ExecuteAt(ctx, client, groupID, time.Now())
 }
@@ -194,6 +192,7 @@ func BuildReminderMessage(
 
 	// Append health pillar reminders (olahraga, makanan, istirahat, kelola stres)
 	sb.WriteString(BuildWellnessReminder())
+	sb.WriteString("\n\n✨ Sudah punya job? Cek side quest hari ini dengan `#mysidequest` untuk bonus gerak ringan sebelum hari selesai.")
 
 	mentions = deduplicateMentions(mentions)
 	return sb.String(), mentions

--- a/internal/app/usecase/remind_inactive_users_usecase_test.go
+++ b/internal/app/usecase/remind_inactive_users_usecase_test.go
@@ -144,6 +144,9 @@ func TestBuildReminderMessage(t *testing.T) {
 	if !strings.Contains(msg, "Ada *2 orang* yang sudah bergerak") {
 		t.Error("expected reminder to appreciate active users collectively")
 	}
+	if !strings.Contains(msg, "#mysidequest") {
+		t.Error("expected 15:15 reminder to include #mysidequest info")
+	}
 	for _, active := range activeToday {
 		if strings.Contains(msg, active.Name) || strings.Contains(msg, active.UserID) {
 			t.Errorf("active user %s should be appreciated collectively without name or ID", active.UserID)

--- a/internal/app/usecase/report_activity_usecase.go
+++ b/internal/app/usecase/report_activity_usecase.go
@@ -18,6 +18,12 @@ type ReportActivityUsecase struct {
 	locks sync.Map
 }
 
+type reportActivityOptions struct {
+	sideQuestCount int
+	activityText   string
+	now            time.Time
+}
+
 func NewReportActivityUsecase(repo domain.ReportRepository) *ReportActivityUsecase {
 	return &ReportActivityUsecase{repo: repo}
 }
@@ -28,6 +34,21 @@ func (uc *ReportActivityUsecase) userLock(userID string) *sync.Mutex {
 }
 
 func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name string, workout *domain.HevyWorkout) (string, error) {
+	return uc.execute(ctx, userID, name, workout, reportActivityOptions{})
+}
+
+func (uc *ReportActivityUsecase) ExecuteSideQuest(ctx context.Context, userID, name, activityText string, completedCount int, now time.Time) (string, error) {
+	if completedCount < 1 {
+		completedCount = 1
+	}
+	return uc.execute(ctx, userID, name, nil, reportActivityOptions{
+		sideQuestCount: completedCount,
+		activityText:   activityText,
+		now:            now,
+	})
+}
+
+func (uc *ReportActivityUsecase) execute(ctx context.Context, userID, name string, workout *domain.HevyWorkout, opts reportActivityOptions) (string, error) {
 	lock := uc.userLock(userID)
 	lock.Lock()
 	defer lock.Unlock()
@@ -37,8 +58,12 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 		return "", err
 	}
 
-	now := time.Now()
+	now := opts.now
+	if now.IsZero() {
+		now = time.Now()
+	}
 	today := domain.GetToday(now)
+	isSideQuest := opts.sideQuestCount > 0
 
 	var dailyCount int
 	if report != nil && domain.GetToday(report.LastReportDate).Equal(today) {
@@ -161,8 +186,15 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 			seasonalFirstBonus = 5
 		}
 	}
+	if isSideQuest {
+		basePoints = 5
+		streakBonus = 0
+		seasonalFirstBonus = 0
+		report.TotalSideQuests += opts.sideQuestCount
+		report.SeasonalSideQuests += opts.sideQuestCount
+	}
 	reportPoints := basePoints + streakBonus + seasonalFirstBonus
-	if isRepeatReport {
+	if isRepeatReport && !isSideQuest {
 		reportPoints = reportPoints / 2
 	}
 	report.TotalPoints += reportPoints
@@ -172,7 +204,7 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 	var comebackAchievements []domain.ComebackAchievement
 	pointsGained := 0
 
-	if isFullReport {
+	if isFullReport && !isSideQuest {
 		newAchievements = domain.CheckNewSeasonAchievements(report)
 		for _, ach := range newAchievements {
 			report.SeasonalAchievements = domain.AddAchievement(report.SeasonalAchievements, ach.ID)
@@ -193,7 +225,7 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 	}
 
 	freezeAwarded := false
-	if isFullReport {
+	if isFullReport && !isSideQuest {
 		for _, ach := range newAchievements {
 			if ach.ID == "streak_4" && report.StreakFreezes < 2 {
 				report.StreakFreezes++
@@ -208,7 +240,7 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 	if err := uc.repo.UpsertReportWithActivity(ctx, report, today); err != nil {
 		return "", err
 	}
-	goalCompleted, err := NewGoalUsecase(uc.repo).RecordActivity(ctx, userID, now, goalActivityText(workout))
+	goalCompleted, err := NewGoalUsecase(uc.repo).RecordActivity(ctx, userID, now, goalActivityTextWithFallback(workout, opts.activityText))
 	if err != nil {
 		return "", err
 	}
@@ -245,11 +277,16 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 		if seasonalFirstBonus > 0 {
 			expBreakdown += " (first season report +5)"
 		}
-		if isRepeatReport {
+		if isSideQuest {
+			expBreakdown += " (side quest, ½ XP)"
+		} else if isRepeatReport {
 			expBreakdown += " (repeat report, ½ XP)"
 		}
 
-		if isRepeatReport {
+		if isSideQuest {
+			response = fmt.Sprintf("Side quest diterima, %s%s menyelesaikan %d side quest. Tetap dihitung untuk streak, stats, leaderboard, dan goal. 🔥\n%s",
+				cyclePrefix, name, opts.sideQuestCount, expBreakdown)
+		} else if isRepeatReport {
 			response = fmt.Sprintf("Laporan diterima (laporan ke-%d hari ini), %s%s sudah berkeringat %d hari. Lanjutkan 🔥 (streak %d minggu)\n%s",
 				dailyCount+1, cyclePrefix, name, report.ActivityCount, report.Streak, expBreakdown)
 		} else {

--- a/internal/domain/quest.go
+++ b/internal/domain/quest.go
@@ -10,205 +10,59 @@ import (
 type QuestTask struct {
 	ID           string `json:"id"`            // e.g. "pushup"
 	Name         string `json:"name"`          // e.g. "Push-up"
+	Difficulty   string `json:"difficulty"`    // "easy", "medium", or "hard"
 	Target       int    `json:"target"`        // numerical target quantity
 	Progress     int    `json:"progress"`      // current accumulated progress
 	Unit         string `json:"unit"`          // e.g. "x", "menit", "detik", "km", "langkah", "ml"
 	RewardPoints int    `json:"reward_points"` // points rewarded upon 100% completion
 }
 
-// GenerateDailyQuest deterministically generates a list of 3 tasks based on jobClass, level, and date.
+// GenerateDailyQuest deterministically generates daily side quest options.
+// A selected job is required; users without a job do not receive side quests.
 func GenerateDailyQuest(jobClass string, level int, date time.Time) []QuestTask {
+	if strings.TrimSpace(jobClass) == "" {
+		return nil
+	}
+
 	dateStr := date.Format("2006-01-02")
 	h := fnv.New32a()
 	h.Write([]byte(dateStr))
 	h.Write([]byte(jobClass))
 	hashValue := int(h.Sum32())
 
-	// Points scaling: base reward + (level/5), capped at base + 5
-	var baseReward int
-	if jobClass == "" {
-		baseReward = 2
-	} else {
-		baseReward = 3
+	// Medium/hard scale gently with hunter level so higher-ranked jobs get a
+	// little more challenge without turning side quests into the main #lapor.
+	if level < 0 {
+		level = 0
 	}
-	reward := baseReward + (level / 5)
-	if reward > baseReward+5 {
-		reward = baseReward + 5
+	mediumBonus := level / 5
+	if mediumBonus > 3 {
+		mediumBonus = 3
 	}
-
-	scale := func(base int, multiplier int) int {
-		return base + (level * multiplier)
+	hardBonus := level / 4
+	if hardBonus > 5 {
+		hardBonus = 5
 	}
 
-	var tasks []QuestTask
-
-	switch jobClass {
-	case "fighter":
-		templates := [][]QuestTask{
-			{
-				{ID: "pushup", Name: "Push-up", Target: scale(10, 1), Unit: "x", RewardPoints: reward},
-				{ID: "squat", Name: "Squat", Target: scale(15, 1), Unit: "x", RewardPoints: reward},
-				{ID: "plank", Name: "Plank", Target: scale(30, 3), Unit: "detik", RewardPoints: reward},
-			},
-			{
-				{ID: "burpee", Name: "Burpee", Target: scale(5, 1), Unit: "x", RewardPoints: reward},
-				{ID: "pushup", Name: "Push-up", Target: scale(12, 1), Unit: "x", RewardPoints: reward},
-				{ID: "squat", Name: "Squat", Target: scale(20, 1), Unit: "x", RewardPoints: reward},
-			},
-			{
-				{ID: "weight", Name: "Latihan Beban (Weight/Strength)", Target: scale(15, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "plank", Name: "Plank", Target: scale(40, 2), Unit: "detik", RewardPoints: reward},
-				{ID: "pushup", Name: "Push-up", Target: scale(8, 1), Unit: "x", RewardPoints: reward},
-			},
-		}
-		tasks = templates[hashValue%len(templates)]
-
-	case "tank":
-		templates := [][]QuestTask{
-			{
-				{ID: "air", Name: "Minum Air Putih", Target: scale(2000, 50), Unit: "ml", RewardPoints: reward},
-				{ID: "squat", Name: "Squat", Target: scale(10, 1), Unit: "x", RewardPoints: reward},
-				{ID: "stretching", Name: "Stretching Ringan", Target: scale(10, 1), Unit: "menit", RewardPoints: reward},
-			},
-			{
-				{ID: "stretching", Name: "Stretching Seluruh Tubuh", Target: scale(15, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "plank", Name: "Plank", Target: scale(20, 2), Unit: "detik", RewardPoints: reward},
-				{ID: "air", Name: "Minum Air Putih", Target: scale(2500, 50), Unit: "ml", RewardPoints: reward},
-			},
-			{
-				{ID: "deepbreathing", Name: "Latihan Pernapasan Dalam", Target: scale(5, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "plank", Name: "Plank", Target: scale(30, 2), Unit: "detik", RewardPoints: reward},
-				{ID: "squat", Name: "Squat", Target: scale(12, 1), Unit: "x", RewardPoints: reward},
-			},
-		}
-		tasks = templates[hashValue%len(templates)]
-
-	case "assassin":
-		templates := [][]QuestTask{
-			{
-				{ID: "hiit", Name: "HIIT Workout", Target: scale(10, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "jumpingjacks", Name: "Jumping Jacks", Target: scale(30, 2), Unit: "x", RewardPoints: reward},
-				{ID: "plank", Name: "Plank", Target: scale(30, 2), Unit: "detik", RewardPoints: reward},
-			},
-			{
-				{ID: "lari", Name: "Sprint Pendek", Target: scale(4, 1), Unit: "kali", RewardPoints: reward},
-				{ID: "jumpingjacks", Name: "Jumping Jacks", Target: scale(40, 2), Unit: "x", RewardPoints: reward},
-				{ID: "hiit", Name: "HIIT Workout", Target: scale(12, 1), Unit: "menit", RewardPoints: reward},
-			},
-			{
-				{ID: "burpee", Name: "Burpee", Target: scale(8, 1), Unit: "x", RewardPoints: reward},
-				{ID: "plank", Name: "Plank", Target: scale(45, 2), Unit: "detik", RewardPoints: reward},
-				{ID: "jumpingjacks", Name: "Jumping Jacks", Target: scale(25, 2), Unit: "x", RewardPoints: reward},
-			},
-		}
-		tasks = templates[hashValue%len(templates)]
-
-	case "mage":
-		templates := [][]QuestTask{
-			{
-				{ID: "cardio", Name: "Variasi Latihan Campuran", Target: scale(15, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "pushup", Name: "Push-up", Target: scale(8, 1), Unit: "x", RewardPoints: reward},
-				{ID: "squat", Name: "Squat", Target: scale(10, 1), Unit: "x", RewardPoints: reward},
-			},
-			{
-				{ID: "stretching", Name: "Coba Gerakan/Latihan Baru", Target: scale(10, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "plank", Name: "Plank", Target: scale(30, 2), Unit: "detik", RewardPoints: reward},
-				{ID: "shadowboxing", Name: "Shadow Boxing", Target: scale(10, 1), Unit: "menit", RewardPoints: reward},
-			},
-			{
-				{ID: "shadowboxing", Name: "Shadow Boxing", Target: scale(12, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "pushup", Name: "Push-up", Target: scale(10, 1), Unit: "x", RewardPoints: reward},
-				{ID: "squat", Name: "Squat", Target: scale(12, 1), Unit: "x", RewardPoints: reward},
-			},
-		}
-		tasks = templates[hashValue%len(templates)]
-
-	case "ranger":
-		templates := [][]QuestTask{
-			{
-				{ID: "lari", Name: "Lari / Jogging", Target: scale(20, 2), Unit: "100m", RewardPoints: reward}, // Target km: scale(20, 2) / 10 = 2.0 + 0.2*level km
-				{ID: "jalan", Name: "Jalan Kaki Harian", Target: scale(5000, 250), Unit: "langkah", RewardPoints: reward},
-				{ID: "squat", Name: "Squat", Target: scale(15, 1), Unit: "x", RewardPoints: reward},
-			},
-			{
-				{ID: "sepeda", Name: "Bersepeda", Target: scale(50, 5), Unit: "100m", RewardPoints: reward}, // scale(50, 5)/10 = 5.0 + 0.5*level km
-				{ID: "jalan", Name: "Jalan Kaki Harian", Target: scale(6000, 250), Unit: "langkah", RewardPoints: reward},
-				{ID: "plank", Name: "Plank", Target: scale(25, 2), Unit: "detik", RewardPoints: reward},
-			},
-			{
-				{ID: "lari", Name: "Lari / Jogging", Target: scale(30, 2), Unit: "100m", RewardPoints: reward},
-				{ID: "squat", Name: "Squat", Target: scale(12, 1), Unit: "x", RewardPoints: reward},
-				{ID: "jalan", Name: "Jalan Kaki Harian", Target: scale(4000, 250), Unit: "langkah", RewardPoints: reward},
-			},
-		}
-		// Adjust target values to readable units in description formatting
-		tasks = make([]QuestTask, len(templates[hashValue%len(templates)]))
-		copy(tasks, templates[hashValue%len(templates)])
-
-	case "healer":
-		templates := [][]QuestTask{
-			{
-				{ID: "yoga", Name: "Yoga / Mobility Flow", Target: scale(10, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "deepbreathing", Name: "Latihan Pernapasan & Meditasi", Target: scale(5, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "stretching", Name: "Peregangan Statis Pasca Bangun", Target: scale(5, 1), Unit: "menit", RewardPoints: reward},
-			},
-			{
-				{ID: "stretching", Name: "Pereda Ketegangan Leher & Punggung", Target: scale(10, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "yoga", Name: "Yoga / Mobility Flow", Target: scale(12, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "deepbreathing", Name: "Latihan Pernapasan & Meditasi", Target: scale(8, 1), Unit: "menit", RewardPoints: reward},
-			},
-			{
-				{ID: "meditasi", Name: "Mindfulness Meditation", Target: scale(10, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "stretching", Name: "Yoga / Mobility Flow", Target: scale(8, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "deepbreathing", Name: "Deep Breathing", Target: scale(5, 1), Unit: "menit", RewardPoints: reward},
-			},
-		}
-		tasks = templates[hashValue%len(templates)]
-
-	case "necromancer":
-		templates := [][]QuestTask{
-			{
-				{ID: "stretching", Name: "Pemanasan Sendi & Otot", Target: scale(5, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "situp", Name: "Sit-up", Target: scale(10, 1), Unit: "x", RewardPoints: reward},
-				{ID: "jalan", Name: "Jalan Kaki Ringan", Target: scale(15, 1), Unit: "menit", RewardPoints: reward},
-			},
-			{
-				{ID: "jalan", Name: "Jalan Kaki Ringan", Target: scale(20, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "squat", Name: "Squat", Target: scale(12, 1), Unit: "x", RewardPoints: reward},
-				{ID: "situp", Name: "Sit-up", Target: scale(12, 1), Unit: "x", RewardPoints: reward},
-			},
-			{
-				{ID: "stretching", Name: "Peregangan Pemulihan", Target: scale(10, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "situp", Name: "Sit-up", Target: scale(8, 1), Unit: "x", RewardPoints: reward},
-				{ID: "jalan", Name: "Jalan Kaki Ringan", Target: scale(15, 1), Unit: "menit", RewardPoints: reward},
-			},
-		}
-		tasks = templates[hashValue%len(templates)]
-
-	default: // general / no job
-		level = 1
-		reward = 2
-		templates := [][]QuestTask{
-			{
-				{ID: "jalan", Name: "Jalan Kaki Santai", Target: scale(15, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "pushup", Name: "Push-up / Wall Push-up", Target: scale(5, 1), Unit: "x", RewardPoints: reward},
-				{ID: "stretching", Name: "Peregangan Seluruh Tubuh", Target: scale(5, 1), Unit: "menit", RewardPoints: reward},
-			},
-			{
-				{ID: "stretching", Name: "Peregangan Seluruh Tubuh", Target: scale(8, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "squat", Name: "Squat Ringan", Target: scale(8, 1), Unit: "x", RewardPoints: reward},
-				{ID: "jalan", Name: "Jalan Kaki Santai", Target: scale(20, 1), Unit: "menit", RewardPoints: reward},
-			},
-			{
-				{ID: "jalan", Name: "Jalan Kaki Santai", Target: scale(10, 1), Unit: "menit", RewardPoints: reward},
-				{ID: "pushup", Name: "Push-up / Wall Push-up", Target: scale(6, 1), Unit: "x", RewardPoints: reward},
-				{ID: "squat", Name: "Squat Ringan", Target: scale(6, 1), Unit: "x", RewardPoints: reward},
-			},
-		}
-		tasks = templates[hashValue%len(templates)]
+	mediumOptions := []QuestTask{
+		{ID: "squat", Name: "Chair Squat / Sit-to-Stand", Difficulty: "medium", Target: 18 + mediumBonus*2, Unit: "x", RewardPoints: 5},
+		{ID: "pushup", Name: "Wall Push-up / Desk Push-up", Difficulty: "medium", Target: 15 + mediumBonus*2, Unit: "x", RewardPoints: 5},
+		{ID: "stretching", Name: "Office Stretching", Difficulty: "medium", Target: 8 + mediumBonus, Unit: "menit", RewardPoints: 5},
+		{ID: "shadowboxing", Name: "Shadow Boxing Ringan", Difficulty: "medium", Target: 6 + mediumBonus, Unit: "menit", RewardPoints: 5},
+	}
+	hardOptions := []QuestTask{
+		{ID: "plank", Name: "Plank", Difficulty: "hard", Target: 45 + hardBonus*5, Unit: "detik", RewardPoints: 5},
+		{ID: "jumpingjacks", Name: "Jumping Jacks", Difficulty: "hard", Target: 35 + hardBonus*3, Unit: "x", RewardPoints: 5},
+		{ID: "burpee", Name: "Burpee Ringan", Difficulty: "hard", Target: 8 + hardBonus, Unit: "x", RewardPoints: 5},
+		{ID: "yoga", Name: "Mobility Flow", Difficulty: "hard", Target: 12 + hardBonus, Unit: "menit", RewardPoints: 5},
 	}
 
-	return tasks
+	return []QuestTask{
+		{ID: "jalan", Name: "Jalan Kaki", Difficulty: "easy", Target: 4000, Unit: "langkah", RewardPoints: 5},
+		{ID: "sepeda", Name: "Bersepeda", Difficulty: "easy", Target: 50, Unit: "100m", RewardPoints: 5},
+		mediumOptions[hashValue%len(mediumOptions)],
+		hardOptions[(hashValue/len(mediumOptions))%len(hardOptions)],
+	}
 }
 
 // MatchTask checks if input contains keywords matching a specific task ID.
@@ -257,19 +111,34 @@ func MatchTask(input string, taskID string) bool {
 
 // FormatQuestProgressTask returns a descriptive string for a quest task, resolving Ranger 100m units to km.
 func FormatQuestProgressTask(task QuestTask) string {
+	difficulty := formatQuestDifficulty(task.Difficulty)
 	if task.Unit == "100m" {
 		targetKm := float64(task.Target) / 10.0
 		progressKm := float64(task.Progress) / 10.0
-		return fmt.Sprintf("%s: %.1f/%.1f km (+%d pts)", task.Name, progressKm, targetKm, task.RewardPoints)
+		return fmt.Sprintf("%s %s: %.1f/%.1f km (+½ XP)", difficulty, task.Name, progressKm, targetKm)
 	}
-	return fmt.Sprintf("%s: %d/%d %s (+%d pts)", task.Name, task.Progress, task.Target, task.Unit, task.RewardPoints)
+	return fmt.Sprintf("%s %s: %d/%d %s (+½ XP)", difficulty, task.Name, task.Progress, task.Target, task.Unit)
 }
 
 // FormatQuestTask returns a descriptive string for a quest task without showing progress (showing only target).
 func FormatQuestTask(task QuestTask) string {
+	difficulty := formatQuestDifficulty(task.Difficulty)
 	if task.Unit == "100m" {
 		targetKm := float64(task.Target) / 10.0
-		return fmt.Sprintf("%s: %.1f km (+%d pts)", task.Name, targetKm, task.RewardPoints)
+		return fmt.Sprintf("%s %s: %.1f km (+½ XP)", difficulty, task.Name, targetKm)
 	}
-	return fmt.Sprintf("%s: %d %s (+%d pts)", task.Name, task.Target, task.Unit, task.RewardPoints)
+	return fmt.Sprintf("%s %s: %d %s (+½ XP)", difficulty, task.Name, task.Target, task.Unit)
+}
+
+func formatQuestDifficulty(difficulty string) string {
+	switch strings.ToLower(strings.TrimSpace(difficulty)) {
+	case "easy":
+		return "🟢 Easy •"
+	case "medium":
+		return "🟡 Medium •"
+	case "hard":
+		return "🔴 Hard •"
+	default:
+		return ""
+	}
 }

--- a/internal/domain/quest_test.go
+++ b/internal/domain/quest_test.go
@@ -8,46 +8,31 @@ import (
 func TestGenerateDailyQuest(t *testing.T) {
 	now := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
 
-	// 1. General quest tests (no job)
+	// 1. No job means no side quest.
 	tasksGeneral := GenerateDailyQuest("", 0, now)
-	if len(tasksGeneral) != 3 {
-		t.Fatalf("expected 3 tasks, got %d", len(tasksGeneral))
-	}
-	if tasksGeneral[0].RewardPoints != 2 {
-		t.Errorf("expected reward points to be 2 for general level 0, got %d", tasksGeneral[0].RewardPoints)
+	if len(tasksGeneral) != 0 {
+		t.Fatalf("expected no tasks without job, got %d", len(tasksGeneral))
 	}
 
-	// 2. High level general quest tests
-	tasksGeneralLv20 := GenerateDailyQuest("", 20, now)
-	if tasksGeneralLv20[0].RewardPoints != 2 {
-		t.Errorf("expected reward points to be 2 for general level 20, got %d", tasksGeneralLv20[0].RewardPoints)
-	}
-
-	// 3. Job quest tests
+	// 2. Job quest tests
 	tasksFighter := GenerateDailyQuest("fighter", 0, now)
-	if len(tasksFighter) != 3 {
-		t.Fatalf("expected 3 tasks, got %d", len(tasksFighter))
+	if len(tasksFighter) != 4 {
+		t.Fatalf("expected 4 tasks, got %d", len(tasksFighter))
 	}
-	if tasksFighter[0].RewardPoints != 3 {
-		t.Errorf("expected reward points to be 3 for fighter level 0, got %d", tasksFighter[0].RewardPoints)
+	if tasksFighter[0].ID != "jalan" || tasksFighter[0].Target != 4000 || tasksFighter[0].Difficulty != "easy" {
+		t.Errorf("expected easy walk target, got %+v", tasksFighter[0])
+	}
+	if tasksFighter[1].ID != "sepeda" || tasksFighter[1].Target != 50 || tasksFighter[1].Difficulty != "easy" {
+		t.Errorf("expected easy bike target, got %+v", tasksFighter[1])
 	}
 
-	// 4. Verification of Ranger scaling and target conversion
-	tasksRanger := GenerateDailyQuest("ranger", 10, now)
-	foundLari := false
-	for _, task := range tasksRanger {
-		if task.ID == "lari" {
-			foundLari = true
-			expectedTarget := 30 + (10 * 2) // base 30 + 10 * 2 = 50 (50 * 100m = 5.0 km)
-			if task.Target != expectedTarget {
-				t.Errorf("expected target for lari ranger to be %d, got %d", expectedTarget, task.Target)
-			}
-		}
+	// 3. Medium/hard scale gently with level.
+	tasksLv20 := GenerateDailyQuest("fighter", 20, now)
+	if tasksLv20[2].Target <= tasksFighter[2].Target {
+		t.Errorf("expected medium target to scale up, got lv0=%d lv20=%d", tasksFighter[2].Target, tasksLv20[2].Target)
 	}
-	if !foundLari {
-		// Note: the template chosen is dependent on hashValue, so "lari" might not be in the current day's selected template. Let's force check a date or just check if any ranger templates scale.
-		// For June 15, 2026, "ranger" + "2026-06-15" hash will deterministicly select a template. Let's print to see what templates are generated.
-		t.Logf("Generated Ranger tasks: %+v", tasksRanger)
+	if tasksLv20[3].Target <= tasksFighter[3].Target {
+		t.Errorf("expected hard target to scale up, got lv0=%d lv20=%d", tasksFighter[3].Target, tasksLv20[3].Target)
 	}
 }
 

--- a/internal/domain/report.go
+++ b/internal/domain/report.go
@@ -28,6 +28,8 @@ type Report struct {
 	SeasonalAchievements  string    `json:"seasonal_achievements" db:"seasonal_achievements"`
 	StreakFreezes         int       `json:"streak_freezes" db:"streak_freezes"`
 	GoalsCompleted        int       `json:"goals_completed" db:"goals_completed"`
+	TotalSideQuests       int       `json:"total_side_quests" db:"total_side_quests"`
+	SeasonalSideQuests    int       `json:"seasonal_side_quests" db:"seasonal_side_quests"`
 }
 
 type ActivityLeaderboardEntry struct {

--- a/internal/infra/sqlite/report_repository.go
+++ b/internal/infra/sqlite/report_repository.go
@@ -25,7 +25,8 @@ const selectColumns = `user_id, name, COALESCE(job_class, ''), streak, activity_
 	COALESCE(comeback_streak, 0), COALESCE(inactive_days, 0), COALESCE(centurion_cycles, 0),
 	COALESCE(seasonal_points, 0), COALESCE(seasonal_activity_count, 0),
 	COALESCE(seasonal_max_streak, 0), COALESCE(seasonal_achievements, ''),
-	COALESCE(streak_freezes, 0), COALESCE(goals_completed, 0)`
+	COALESCE(streak_freezes, 0), COALESCE(goals_completed, 0),
+	COALESCE(total_side_quests, 0), COALESCE(seasonal_side_quests, 0)`
 
 func scanReport(scanner interface{ Scan(dest ...any) error }) (*domain.Report, error) {
 	var report domain.Report
@@ -37,6 +38,7 @@ func scanReport(scanner interface{ Scan(dest ...any) error }) (*domain.Report, e
 		&report.SeasonalPoints, &report.SeasonalActivityCount,
 		&report.SeasonalMaxStreak, &report.SeasonalAchievements,
 		&report.StreakFreezes, &report.GoalsCompleted,
+		&report.TotalSideQuests, &report.SeasonalSideQuests,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -61,8 +63,8 @@ func (r *ReportRepository) GetReport(ctx context.Context, userID string) (*domai
 
 func upsertReport(ctx context.Context, execer execContexter, report *domain.Report) error {
 	query := `
-		INSERT INTO user_reports (user_id, name, job_class, streak, activity_count, last_report_date, max_streak, total_points, level, achievements, comeback_streak, inactive_days, centurion_cycles, seasonal_points, seasonal_activity_count, seasonal_max_streak, seasonal_achievements, streak_freezes, goals_completed)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO user_reports (user_id, name, job_class, streak, activity_count, last_report_date, max_streak, total_points, level, achievements, comeback_streak, inactive_days, centurion_cycles, seasonal_points, seasonal_activity_count, seasonal_max_streak, seasonal_achievements, streak_freezes, goals_completed, total_side_quests, seasonal_side_quests)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(user_id) DO UPDATE SET
 			name = excluded.name,
 			job_class = excluded.job_class,
@@ -80,7 +82,9 @@ func upsertReport(ctx context.Context, execer execContexter, report *domain.Repo
 			seasonal_activity_count = excluded.seasonal_activity_count,
 			seasonal_max_streak = excluded.seasonal_max_streak,
 			seasonal_achievements = excluded.seasonal_achievements,
-			streak_freezes = excluded.streak_freezes
+			streak_freezes = excluded.streak_freezes,
+			total_side_quests = excluded.total_side_quests,
+			seasonal_side_quests = excluded.seasonal_side_quests
 	`
 	_, err := execer.ExecContext(ctx, query,
 		report.UserID, report.Name, report.JobClass, report.Streak, report.ActivityCount,
@@ -88,6 +92,7 @@ func upsertReport(ctx context.Context, execer execContexter, report *domain.Repo
 		report.Level, report.Achievements, report.ComebackStreak, report.InactiveDays, report.CenturionCycles,
 		report.SeasonalPoints, report.SeasonalActivityCount, report.SeasonalMaxStreak,
 		report.SeasonalAchievements, report.StreakFreezes, report.GoalsCompleted,
+		report.TotalSideQuests, report.SeasonalSideQuests,
 	)
 	return err
 }
@@ -205,6 +210,7 @@ func (r *ReportRepository) ResetAllReports(ctx context.Context) error {
 		    seasonal_activity_count = 0,
 		    seasonal_max_streak = 0,
 		    seasonal_achievements = '',
+		    seasonal_side_quests = 0,
 		    streak_freezes = 1
 	`)
 	return err
@@ -280,6 +286,8 @@ func (r *ReportRepository) InitTable(ctx context.Context) error {
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN seasonal_achievements TEXT DEFAULT ''")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN streak_freezes INTEGER DEFAULT 1")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN goals_completed INTEGER DEFAULT 0")
+	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN total_side_quests INTEGER DEFAULT 0")
+	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN seasonal_side_quests INTEGER DEFAULT 0")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE activity_logs ADD COLUMN report_count INTEGER NOT NULL DEFAULT 1")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE activity_logs ADD COLUMN activity_text TEXT DEFAULT ''")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE strava_accounts ADD COLUMN name TEXT")


### PR DESCRIPTION
- introduces  to view personalized daily side quests based on user's job.
- adds  for reporting side quest progress, granting 0.5x XP.
- updates morning and afternoon checkpoint messages to include info about side quests.
- refactors side quest generation to use a fixed pool of easy, medium, and hard quests, removing job-specific quest types.
- integrates side quest completions into user stats (), total, and seasonal counts.
- removes  command aliases to simplify reporting.