### PR TITLE
feat(daily-quest): enhance side quest content & reporting

### DIFF
--- a/internal/app/usecase/daily_quest_usecase.go
+++ b/internal/app/usecase/daily_quest_usecase.go
@@ -87,7 +87,7 @@ func (u *DailyQuestUsecase) SendDailyQuests(ctx context.Context, now time.Time, 
 	}
 
 	dateStr := domain.GetToday(now).Format("02 Jan 2006")
-	msgText := fmt.Sprintf("🌅 *Selamat pagi, Hunters!*\n\nSide quest hari ini sudah terbuka untuk %d hunter yang sudah memilih job. Buka `#mysidequest` untuk lihat pilihan easy, medium, dan hard hari ini.\n\nPilih yang ringan dulu juga boleh—jalan 4.000 langkah, sepeda 5 km, atau gerakan singkat di rumah/kantor. Side quest cuma bonus ½ XP; misi utama tetap konsisten olahraga dan lapor di grup. ✨\n\n📅 %s\n📝 Lapor side quest: `#lapor sidequest <kegiatan> <jumlah>`", eligibleCount, dateStr)
+	msgText := fmt.Sprintf("🌅 *Selamat pagi, Hunters!*\n\nSide quest hari ini sudah terbuka untuk %d hunter yang sudah memilih job. Buka `#mysidequest` untuk lihat pilihan easy, medium, dan hard hari ini.\n\nPilih yang ringan dulu juga boleh—minimal jalan kaki 4.000 langkah atau sepeda 5 km, atau gerakan singkat di rumah/kantor. Side quest cuma bonus kecil; misi utama tetap konsisten olahraga dan lapor di grup. ✨\n\n📅 %s\n📝 Lapor side quest: `#lapor sidequest <kegiatan> <jumlah>`", eligibleCount, dateStr)
 
 	targetJID, err := types.ParseJID(groupID)
 	if err != nil {
@@ -128,7 +128,7 @@ func (u *DailyQuestUsecase) ViewQuest(ctx context.Context, userID, name string, 
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("📜 *Side Quest Hari Ini - %s* 🏹\n", report.Name))
 	sb.WriteString(fmt.Sprintf("Job: %s (Lv.%d)\n", domain.FormatJobClass(report.JobClass), report.Level))
-	sb.WriteString("Reward: ½ XP per side quest yang valid. #lapor utama tetap prioritas.\n\n")
+	sb.WriteString("Reward: XP bonus per side quest yang valid (easy/medium/hard). #lapor utama tetap prioritas.\n\n")
 
 	completed := 0
 	for i, t := range tasks {
@@ -140,13 +140,19 @@ func (u *DailyQuestUsecase) ViewQuest(ctx context.Context, userID, name string, 
 		sb.WriteString(fmt.Sprintf("%s %d. %s\n", status, i+1, domain.FormatQuestProgressTask(t)))
 	}
 
-	sb.WriteString(fmt.Sprintf("\nProgress hari ini: %s (%d/%d selesai)\n", formatQuestProgressBar(tasks), completed, len(tasks)))
+	sb.WriteString(fmt.Sprintf("\nProgress hari ini: %s\n", formatQuestProgressBar(tasks)))
 	sb.WriteString(fmt.Sprintf("Total side quest selesai: %d lifetime • %d season\n\n", report.TotalSideQuests, report.SeasonalSideQuests))
-	sb.WriteString("Cara lapor: `#lapor sidequest [nama kegiatan] [jumlah]`\n")
+	sb.WriteString("Cara lapor: `#lapor sidequest <nama kegiatan> <jumlah>`\n")
+	sb.WriteString("Gunakan nama kegiatan sesuai yang tertera di atas.\n")
 	sb.WriteString("Contoh:\n")
-	sb.WriteString("#lapor sidequest jalan 4000\n")
+	sb.WriteString("#lapor sidequest jalan kaki 4000\n")
 	sb.WriteString("#lapor sidequest sepeda 5 km\n")
-	sb.WriteString("#lapor sidequest plank 60 detik")
+	if len(tasks) > 2 {
+		sb.WriteString(fmt.Sprintf("#lapor sidequest %s %s\n", strings.ToLower(tasks[2].Name), formatQuestTarget(tasks[2])))
+	}
+	if len(tasks) > 3 {
+		sb.WriteString(fmt.Sprintf("#lapor sidequest %s %s\n", strings.ToLower(tasks[3].Name), formatQuestTarget(tasks[3])))
+	}
 
 	return sb.String(), nil
 }
@@ -180,6 +186,7 @@ func (u *DailyQuestUsecase) UpdateProgress(ctx context.Context, userID, name str
 
 	var completedTasks []string
 	var rejected []string
+	totalSideQuestPoints := 0
 
 	for _, line := range inputLines {
 		namePart, val := parseLineFloat(line)
@@ -193,7 +200,7 @@ func (u *DailyQuestUsecase) UpdateProgress(ctx context.Context, userID, name str
 				matched = true
 				added := 0
 				if task.Unit == "100m" {
-					if val < 50.0 { // e.g. "lari 2.5" is 2.5 km -> 25 units of 100m
+					if val < 50.0 {
 						added = int(val * 10.0)
 					} else {
 						added = int(val)
@@ -212,6 +219,7 @@ func (u *DailyQuestUsecase) UpdateProgress(ctx context.Context, userID, name str
 
 				tasks[idx].Progress = task.Target
 				completedTasks = append(completedTasks, task.Name)
+				totalSideQuestPoints += sideQuestPoints(task.Difficulty)
 			}
 		}
 		if !matched {
@@ -221,7 +229,7 @@ func (u *DailyQuestUsecase) UpdateProgress(ctx context.Context, userID, name str
 
 	if len(completedTasks) == 0 {
 		if len(rejected) > 0 {
-			return "Side quest belum diterima. Targetnya harus tercapai dulu ya. 💪\n\n- " + strings.Join(rejected, "\n- ") + "\n\nCek target hari ini dengan `#mysidequest`, lalu lapor ulang: `#lapor sidequest <kegiatan> <jumlah>`", nil
+			return "💪 *Semangat! Tinggal sedikit lagi...* 🔥\n\n" + strings.Join(rejected, "\n") + "\n\nAyo lanjutkan sampai target lalu lapor ulang ya! Kamu pasti bisa! ✨\n\n📜 Cek detail target: `#mysidequest`\n📝 Lapor ulang: `#lapor sidequest <kegiatan> <jumlah>`", nil
 		}
 		return "Gagal membaca laporan side quest. Contoh: `#lapor sidequest jalan 4000` atau `#lapor sidequest sepeda 5 km`", nil
 	}
@@ -237,7 +245,7 @@ func (u *DailyQuestUsecase) UpdateProgress(ctx context.Context, userID, name str
 	}
 
 	activityText := "Side quest: " + strings.Join(completedTasks, ", ")
-	reportResult, err := reportUC.ExecuteSideQuest(ctx, userID, name, activityText, len(completedTasks), now)
+	reportResult, err := reportUC.ExecuteSideQuest(ctx, userID, name, activityText, len(completedTasks), totalSideQuestPoints, now)
 	if err != nil {
 		return "", err
 	}
@@ -247,10 +255,12 @@ func (u *DailyQuestUsecase) UpdateProgress(ctx context.Context, userID, name str
 	if len(completedTasks) > 0 {
 		sb.WriteString("🎉 *SIDE QUEST BERHASIL DISELESAIKAN!* 🏆\n\n")
 		sb.WriteString("Selamat, kamu menyelesaikan:\n")
-		for _, name := range completedTasks {
-			sb.WriteString(fmt.Sprintf("- %s\n", name))
+		for _, task := range tasks {
+			if task.Progress >= task.Target {
+				sb.WriteString(fmt.Sprintf("- *%s* (%s)\n", task.Name, formatQuestTarget(task)))
+			}
 		}
-		sb.WriteString("\n💰 Reward: ½ XP per side quest valid.\n\n")
+		sb.WriteString("\n💰 Reward: XP bonus per side quest valid.\n\n")
 	}
 
 	sb.WriteString("📜 *Daftar Quest Saat Ini:*\n")
@@ -267,6 +277,26 @@ func (u *DailyQuestUsecase) UpdateProgress(ctx context.Context, userID, name str
 	sb.WriteString(reportResult)
 
 	return sb.String(), nil
+}
+
+// sideQuestPoints returns the base points for a completed side quest task
+// based on its difficulty. These multipliers are computed behind the scenes;
+// the user-facing notification does not show the raw multiplier values.
+//
+//	Easy:   3 pts (0.3 × 10 base)
+//	Medium: 4 pts (0.4 × 10 base)
+//	Hard:   5 pts (0.5 × 10 base)
+func sideQuestPoints(difficulty string) int {
+	switch strings.ToLower(strings.TrimSpace(difficulty)) {
+	case "easy":
+		return 3
+	case "medium":
+		return 4
+	case "hard":
+		return 5
+	default:
+		return 5
+	}
 }
 
 func parseLineFloat(line string) (string, float64) {
@@ -306,21 +336,23 @@ func formatQuestValue(task domain.QuestTask, value int) string {
 	return fmt.Sprintf("%d %s", value, task.Unit)
 }
 
+// formatQuestProgressBar builds a task-count-based completion bar.
+// Each task contributes equally regardless of its numerical target so that
+// completing Jalan Kaki (4000 langkah) moves the bar the same amount as
+// completing Chair Squat (18x). This avoids the old value-weighted bar where
+// a single easy quest completion dominated the percentage.
 func formatQuestProgressBar(tasks []domain.QuestTask) string {
-	totalTarget := 0
-	totalProgress := 0
+	completed := 0
 	for _, t := range tasks {
-		prog := t.Progress
-		if prog > t.Target {
-			prog = t.Target
+		if t.Progress >= t.Target {
+			completed++
 		}
-		totalTarget += t.Target
-		totalProgress += prog
 	}
 
+	total := len(tasks)
 	percentage := 0
-	if totalTarget > 0 {
-		percentage = (totalProgress * 100) / totalTarget
+	if total > 0 {
+		percentage = (completed * 100) / total
 	}
 
 	barLen := 10
@@ -334,5 +366,5 @@ func formatQuestProgressBar(tasks []domain.QuestTask) string {
 			bar.WriteString("░")
 		}
 	}
-	return fmt.Sprintf("[%s] %d%%", bar.String(), percentage)
+	return fmt.Sprintf("[%s] %d%% (%d/%d selesai)", bar.String(), percentage, completed, total)
 }

--- a/internal/app/usecase/daily_quest_usecase_test.go
+++ b/internal/app/usecase/daily_quest_usecase_test.go
@@ -133,8 +133,8 @@ func TestDailyQuestViewAndComplete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected update progress error: %v", err)
 	}
-	if !strings.Contains(progressMsg, "Side quest belum diterima") {
-		t.Errorf("expected below-target side quest to be rejected, got %q", progressMsg)
+	if !strings.Contains(progressMsg, "Semangat") {
+		t.Errorf("expected below-target side quest to be rejected with motivational message, got %q", progressMsg)
 	}
 
 	// 3. Complete walking side quest.
@@ -149,8 +149,8 @@ func TestDailyQuestViewAndComplete(t *testing.T) {
 	if repo.upsertedReport.TotalSideQuests != 1 || repo.upsertedReport.SeasonalSideQuests != 1 {
 		t.Errorf("expected side quest counters to increase, got lifetime=%d season=%d", repo.upsertedReport.TotalSideQuests, repo.upsertedReport.SeasonalSideQuests)
 	}
-	if repo.upsertedReport.TotalPoints != 205 {
-		t.Errorf("expected side quest to add 5 points, got %d", repo.upsertedReport.TotalPoints)
+	if repo.upsertedReport.TotalPoints != 203 {
+		t.Errorf("expected side quest (easy) to add 3 points, got total=%d (expected 203)", repo.upsertedReport.TotalPoints)
 	}
 }
 

--- a/internal/app/usecase/get_help_usecase.go
+++ b/internal/app/usecase/get_help_usecase.go
@@ -10,12 +10,12 @@ var helpSections = []struct {
 	{
 		emoji:   "📝",
 		title:   "Melaporkan Aktivitas",
-		content: "*#lapor* — Laporkan workout atau aktivitas harianmu.\nContoh: `#lapor` atau `#lapor Push Day`\n\n*#lapor sidequest [kegiatan] [jumlah]* — Laporkan side quest dari `#mysidequest`. Contoh: `#lapor sidequest jalan 4000`. Side quest hanya ½ XP, tapi tetap dihitung untuk streak, stats, leaderboard, dan goal.\n\n🔄 Setiap laporan yang valid akan menambah streak mingguanmu dan total hari aktif.\n❄️ *Streak Freeze* — kamu punya 1 freeze gratis per season. Freeze otomatis melindungi 1 minggu absen. Dapatkan +1 freeze lagi saat kamu mencapai 4 minggu streak!\n\n📌 *Max 3x laporan per hari*: Kamu bisa lapor maksimal 3x dalam sehari. Laporan ke-2 dan ke-3 tetap dihitung 1 hari tapi XP dibagi 2.\n📌 *#lapor-kemarin* — Laporan khusus untuk hari kemarin. Sama seperti #lapor, XP dibagi 2. Max 3x per hari.",
+		content: "*#lapor* — Laporkan workout atau aktivitas harianmu.\nContoh: `#lapor` atau `#lapor Push Day`\n\n*#lapor sidequest [kegiatan] [jumlah]* — Laporkan side quest dari `#mysidequest`. Gunakan nama kegiatan sesuai yang tertera di daftar quest. Contoh: `#lapor sidequest jalan kaki 4000`. Side quest memberi XP bonus kecil, tapi tetap dihitung untuk streak, stats, leaderboard, dan goal.\n\n🔄 Setiap laporan yang valid akan menambah streak mingguanmu dan total hari aktif.\n❄️ *Streak Freeze* — kamu punya 1 freeze gratis per season. Freeze otomatis melindungi 1 minggu absen. Dapatkan +1 freeze lagi saat kamu mencapai 4 minggu streak!\n\n📌 *Max 3x laporan per hari*: Kamu bisa lapor maksimal 3x dalam sehari. Laporan ke-2 dan ke-3 tetap dihitung 1 hari tapi XP dibagi 2.\n📌 *#lapor-kemarin* — Laporan khusus untuk hari kemarin. Sama seperti #lapor, XP dibagi 2. Max 3x per hari.",
 	},
 	{
 		emoji:   "✨",
 		title:   "Side Quest Harian",
-		content: "*#mysidequest* — Lihat side quest easy, medium, dan hard hari ini. Wajib pilih job dulu lewat `#job <id>` agar mendapat side quest.\n\nEasy selalu jalan kaki minimal 4.000 langkah atau sepeda 5 km. Medium/hard berisi latihan ringan yang bisa dilakukan di rumah/kantor, dan naik sedikit sesuai level job.\n\nLapor dengan `#lapor sidequest [kegiatan] [jumlah]`. Target harus tercapai dulu; kalau kurang, laporan ditolak dan kamu bisa ulang setelah menambah aktivitas.",
+		content: "*#mysidequest* — Lihat side quest easy, medium, dan hard hari ini. Wajib pilih job dulu lewat `#job <id>` agar mendapat side quest.\n\nEasy: jalan kaki minimal 4.000 langkah atau sepeda 5 km (pilih salah satu). Medium/hard berisi latihan ringan yang bisa dilakukan di rumah/kantor, dan naik sedikit sesuai level job. XP bonus bervariasi per difficulty, dihitung otomatis di belakang.\n\nLapor dengan `#lapor sidequest [kegiatan] [jumlah]`. Nama kegiatan harus sesuai yang tertera di `#mysidequest`. Target harus tercapai dulu; kalau kurang, laporan ditolak dan kamu bisa ulang setelah menambah aktivitas.",
 	},
 	{
 		emoji:   "❌",
@@ -120,9 +120,9 @@ func (uc *GetHelpUsecase) ExecuteTutorial() string {
 	msg += "✨ *Flow Side Quest Harian*\n"
 	msg += "1. Pilih job dulu dengan `#job <id>` agar side quest terbuka.\n"
 	msg += "2. Setiap pagi bot memberi reminder di grup; cek detail quest kamu dengan `#mysidequest`.\n"
-	msg += "3. Pilih easy, medium, hard, atau beberapa sekaligus jika mau.\n"
-	msg += "4. Lapor dengan format `#lapor sidequest <kegiatan> <jumlah>`, contoh `#lapor sidequest jalan 4000` atau `#lapor sidequest sepeda 5 km`.\n"
-	msg += "5. Side quest memberi ½ XP, tetap masuk streak, stats, leaderboard, goal, dan total side quest di `#mystats`/`#achievements`.\n\n"
+	msg += "3. Pilih easy (jalan kaki atau sepeda), medium, hard, atau beberapa sekaligus.\n"
+	msg += "4. Lapor dengan format `#lapor sidequest <kegiatan> <jumlah>`, gunakan nama kegiatan yang tertera di `#mysidequest`. Contoh: `#lapor sidequest jalan kaki 4000`, `#lapor sidequest sepeda 5 km`, `#lapor sidequest chair squat 18`.\n"
+	msg += "5. Side quest memberi XP bonus kecil (bervariasi per difficulty), tetap masuk streak, stats, leaderboard, goal, dan total side quest di `#mystats`/`#achievements`.\n\n"
 	msg += "_Catatan: Bot hanya merespon di grup yang sudah dikonfigurasi. Semangat terus! 💪_"
 	return msg
 }

--- a/internal/app/usecase/handle_message_usecase.go
+++ b/internal/app/usecase/handle_message_usecase.go
@@ -97,7 +97,7 @@ func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, messa
 		return MessageResponse{Text: text}, err
 	}
 
-	if containsCommand(msg, "#lapor") {
+	if strings.Contains(msg, "#lapor") {
 		workout := domain.ParseHevy(message)
 		text, err := uc.reportUC.Execute(ctx, userID, name, workout)
 		return MessageResponse{Text: text}, err
@@ -203,13 +203,4 @@ func extractSideQuestReport(message string) (string, bool) {
 		return strings.TrimSpace(message[idx+len(command):]), true
 	}
 	return "", false
-}
-
-func containsCommand(message, command string) bool {
-	idx := strings.Index(message, command)
-	if idx == -1 {
-		return false
-	}
-	end := idx + len(command)
-	return end == len(message) || message[end] == ' ' || message[end] == '\n' || message[end] == '\t'
 }

--- a/internal/app/usecase/handle_message_usecase_test.go
+++ b/internal/app/usecase/handle_message_usecase_test.go
@@ -614,6 +614,88 @@ func TestHandleMessage_LaporDoesNotUpdateName(t *testing.T) {
 	}
 }
 
+func TestHandleMessage_LaporWithNonWhitespaceChars(t *testing.T) {
+	// Regression test: #lapor must trigger even when non-whitespace characters
+	// follow it (e.g., #laporhalo, #lapor123). This was broken by the old
+	// containsCommand function which required whitespace or EOS after the command.
+	repo := &mockReportRepo{reports: make(map[string]*domain.Report)}
+	reportUC := usecase.NewReportActivityUsecase(repo)
+	leaderboardUC := usecase.NewGetLeaderboardUsecase(repo)
+	myStatsUC := usecase.NewGetMyStatsUsecase(repo)
+	achievementsUC := usecase.NewGetAchievementsUsecase(repo)
+	comebackUC := usecase.NewComebackChallengeUsecase(repo)
+	updateNameUC := usecase.NewUpdateNameUsecase(repo)
+	handleUC := usecase.NewHandleMessageUsecase(reportUC, leaderboardUC, myStatsUC, achievementsUC, comebackUC, usecase.NewCancelReportUsecase(repo), updateNameUC, nil, usecase.NewBroadcastUpdateUsecase(), usecase.NewGetMotivationUsecase(), usecase.NewGetHelpUsecase())
+
+	ctx := context.Background()
+
+	testCases := []string{
+		"#laporhalo",              // non-whitespace right after command
+		"#lapor123",               // numbers after command
+		"#lapor.hari.ini",         // dots after command
+		"halo#laporhalo",          // text before AND after
+		"sebelum #lapor-hari-ini", // dash-separated with preceding text
+	}
+
+	for i, cmd := range testCases {
+		repo.reports = make(map[string]*domain.Report)
+		msg, err := handleUC.Execute(ctx, "user1", "User", cmd)
+		if err != nil {
+			t.Fatalf("Test %d: unexpected error for %q: %v", i, cmd, err)
+		}
+		if msg.Text == "" {
+			t.Errorf("Test %d: %q should trigger #lapor, got empty response", i, cmd)
+		}
+	}
+}
+
+func TestHandleMessage_LaporCommandPriority(t *testing.T) {
+	// Ensure that more specific commands (kemarin, sidequest) take priority
+	// over the generic #lapor handler even with the relaxed matching.
+	repo := &mockReportRepo{reports: make(map[string]*domain.Report)}
+	reportUC := usecase.NewReportActivityUsecase(repo)
+	leaderboardUC := usecase.NewGetLeaderboardUsecase(repo)
+	myStatsUC := usecase.NewGetMyStatsUsecase(repo)
+	achievementsUC := usecase.NewGetAchievementsUsecase(repo)
+	comebackUC := usecase.NewComebackChallengeUsecase(repo)
+	updateNameUC := usecase.NewUpdateNameUsecase(repo)
+	handleUC := usecase.NewHandleMessageUsecase(reportUC, leaderboardUC, myStatsUC, achievementsUC, comebackUC, usecase.NewCancelReportUsecase(repo), updateNameUC, nil, usecase.NewBroadcastUpdateUsecase(), usecase.NewGetMotivationUsecase(), usecase.NewGetHelpUsecase())
+
+	ctx := context.Background()
+
+	// Setup user data
+	repo.reports["user1"] = &domain.Report{
+		UserID:        "user1",
+		Name:          "User",
+		Streak:        3,
+		ActivityCount: 3,
+	}
+
+	t.Run("#lapor-kemarin still routes to yesterday handler", func(t *testing.T) {
+		msg, err := handleUC.Execute(ctx, "user1", "User", "#lapor-kemarin lari pagi")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Ensure the message was routed somewhere (non-empty) and is NOT the
+		// standard #lapor response. The kemarin handler produces a comeback/
+		// streak-based response that differs from the regular lapor output.
+		if msg.Text == "" {
+			t.Errorf("expected #lapor-kemarin to produce a response, got empty")
+		}
+	})
+
+	t.Run("#lapor sidequest still routes to sidequest handler", func(t *testing.T) {
+		msg, err := handleUC.Execute(ctx, "user1", "User", "#lapor sidequest push up 20x")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Side quest handler returns quest-related message, NOT lapor report
+		if containsSubstring(msg.Text, "Laporan diterima") {
+			t.Errorf("expected #lapor sidequest to route to sidequest handler, not lapor, got: %q", msg.Text)
+		}
+	})
+}
+
 func TestHandleMessage_MySideQuestCommand(t *testing.T) {
 	repo := &mockReportRepo{reports: make(map[string]*domain.Report)}
 	reportUC := usecase.NewReportActivityUsecase(repo)

--- a/internal/app/usecase/report_activity_usecase.go
+++ b/internal/app/usecase/report_activity_usecase.go
@@ -19,9 +19,10 @@ type ReportActivityUsecase struct {
 }
 
 type reportActivityOptions struct {
-	sideQuestCount int
-	activityText   string
-	now            time.Time
+	sideQuestCount  int
+	activityText    string
+	now             time.Time
+	sideQuestPoints int // total points from side quest difficulty multipliers (computed in DailyQuestUsecase)
 }
 
 func NewReportActivityUsecase(repo domain.ReportRepository) *ReportActivityUsecase {
@@ -37,14 +38,15 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 	return uc.execute(ctx, userID, name, workout, reportActivityOptions{})
 }
 
-func (uc *ReportActivityUsecase) ExecuteSideQuest(ctx context.Context, userID, name, activityText string, completedCount int, now time.Time) (string, error) {
+func (uc *ReportActivityUsecase) ExecuteSideQuest(ctx context.Context, userID, name, activityText string, completedCount, sideQuestPoints int, now time.Time) (string, error) {
 	if completedCount < 1 {
 		completedCount = 1
 	}
 	return uc.execute(ctx, userID, name, nil, reportActivityOptions{
-		sideQuestCount: completedCount,
-		activityText:   activityText,
-		now:            now,
+		sideQuestCount:  completedCount,
+		activityText:    activityText,
+		now:             now,
+		sideQuestPoints: sideQuestPoints,
 	})
 }
 
@@ -187,7 +189,11 @@ func (uc *ReportActivityUsecase) execute(ctx context.Context, userID, name strin
 		}
 	}
 	if isSideQuest {
-		basePoints = 5
+		if opts.sideQuestPoints > 0 {
+			basePoints = opts.sideQuestPoints
+		} else {
+			basePoints = 5 // fallback for callers that don't pass difficulty points
+		}
 		streakBonus = 0
 		seasonalFirstBonus = 0
 		report.TotalSideQuests += opts.sideQuestCount
@@ -278,7 +284,7 @@ func (uc *ReportActivityUsecase) execute(ctx context.Context, userID, name strin
 			expBreakdown += " (first season report +5)"
 		}
 		if isSideQuest {
-			expBreakdown += " (side quest, ½ XP)"
+			expBreakdown += " (side quest)"
 		} else if isRepeatReport {
 			expBreakdown += " (repeat report, ½ XP)"
 		}

--- a/internal/domain/quest.go
+++ b/internal/domain/quest.go
@@ -44,17 +44,28 @@ func GenerateDailyQuest(jobClass string, level int, date time.Time) []QuestTask 
 		hardBonus = 5
 	}
 
+	// Medium: light exercises doable at home/office as movement reminders.
+	// Level bonus gently scales with hunter level, capped at Lv.15.
 	mediumOptions := []QuestTask{
 		{ID: "squat", Name: "Chair Squat / Sit-to-Stand", Difficulty: "medium", Target: 18 + mediumBonus*2, Unit: "x", RewardPoints: 5},
 		{ID: "pushup", Name: "Wall Push-up / Desk Push-up", Difficulty: "medium", Target: 15 + mediumBonus*2, Unit: "x", RewardPoints: 5},
 		{ID: "stretching", Name: "Office Stretching", Difficulty: "medium", Target: 8 + mediumBonus, Unit: "menit", RewardPoints: 5},
 		{ID: "shadowboxing", Name: "Shadow Boxing Ringan", Difficulty: "medium", Target: 6 + mediumBonus, Unit: "menit", RewardPoints: 5},
+		{ID: "highknees", Name: "High Knees (Marching)", Difficulty: "medium", Target: 1 + mediumBonus, Unit: "menit", RewardPoints: 5},
+		{ID: "armcircles", Name: "Arm Circles", Difficulty: "medium", Target: 2 + mediumBonus, Unit: "menit", RewardPoints: 5},
+		{ID: "calfraises", Name: "Calf Raises (Jinjit)", Difficulty: "medium", Target: 20 + mediumBonus*2, Unit: "x", RewardPoints: 5},
+		{ID: "shouldershrugs", Name: "Shoulder Shrugs", Difficulty: "medium", Target: 15 + mediumBonus*2, Unit: "x", RewardPoints: 5},
 	}
+	// Hard: slightly more effort, still home-friendly. Level bonus caps at Lv.20.
 	hardOptions := []QuestTask{
 		{ID: "plank", Name: "Plank", Difficulty: "hard", Target: 45 + hardBonus*5, Unit: "detik", RewardPoints: 5},
 		{ID: "jumpingjacks", Name: "Jumping Jacks", Difficulty: "hard", Target: 35 + hardBonus*3, Unit: "x", RewardPoints: 5},
 		{ID: "burpee", Name: "Burpee Ringan", Difficulty: "hard", Target: 8 + hardBonus, Unit: "x", RewardPoints: 5},
 		{ID: "yoga", Name: "Mobility Flow", Difficulty: "hard", Target: 12 + hardBonus, Unit: "menit", RewardPoints: 5},
+		{ID: "mountainclimber", Name: "Mountain Climber", Difficulty: "hard", Target: 30 + hardBonus*5, Unit: "detik", RewardPoints: 5},
+		{ID: "lunges", Name: "Lunges (Bergantian)", Difficulty: "hard", Target: 10 + hardBonus, Unit: "x per kaki", RewardPoints: 5},
+		{ID: "glutebridge", Name: "Glute Bridge", Difficulty: "hard", Target: 15 + hardBonus*2, Unit: "x", RewardPoints: 5},
+		{ID: "reversecrunch", Name: "Reverse Crunch", Difficulty: "hard", Target: 10 + hardBonus, Unit: "x", RewardPoints: 5},
 	}
 
 	return []QuestTask{
@@ -105,6 +116,24 @@ func MatchTask(input string, taskID string) bool {
 		return strings.Contains(input, "cardio") || strings.Contains(input, "kardio")
 	case "weight":
 		return strings.Contains(input, "beban") || strings.Contains(input, "weight") || strings.Contains(input, "strength")
+	// Medium additions — home/office movement reminders
+	case "highknees":
+		return strings.Contains(input, "high knee") || strings.Contains(input, "marching") || strings.Contains(input, "knee") && strings.Contains(input, "high")
+	case "armcircles":
+		return strings.Contains(input, "arm circle") || strings.Contains(input, "circle") || strings.Contains(input, "putaran lengan")
+	case "calfraises":
+		return strings.Contains(input, "calf") || strings.Contains(input, "jinjit")
+	case "shouldershrugs":
+		return strings.Contains(input, "shrug") || strings.Contains(input, "bahu")
+	// Hard additions — slightly more effort, still home-friendly
+	case "mountainclimber":
+		return strings.Contains(input, "mountain") || strings.Contains(input, "climber") || strings.Contains(input, "panjat")
+	case "lunges":
+		return strings.Contains(input, "lunge") || strings.Contains(input, "lunjak")
+	case "glutebridge":
+		return strings.Contains(input, "glute") || strings.Contains(input, "bridge") || strings.Contains(input, "pinggul") || strings.Contains(input, "jembatan")
+	case "reversecrunch":
+		return strings.Contains(input, "reverse crunch") || strings.Contains(input, "crunch") && !strings.Contains(input, "bicycle")
 	}
 	return false
 }
@@ -115,9 +144,9 @@ func FormatQuestProgressTask(task QuestTask) string {
 	if task.Unit == "100m" {
 		targetKm := float64(task.Target) / 10.0
 		progressKm := float64(task.Progress) / 10.0
-		return fmt.Sprintf("%s %s: %.1f/%.1f km (+½ XP)", difficulty, task.Name, progressKm, targetKm)
+		return fmt.Sprintf("%s %s: %.1f/%.1f km", difficulty, task.Name, progressKm, targetKm)
 	}
-	return fmt.Sprintf("%s %s: %d/%d %s (+½ XP)", difficulty, task.Name, task.Progress, task.Target, task.Unit)
+	return fmt.Sprintf("%s %s: %d/%d %s", difficulty, task.Name, task.Progress, task.Target, task.Unit)
 }
 
 // FormatQuestTask returns a descriptive string for a quest task without showing progress (showing only target).
@@ -125,9 +154,9 @@ func FormatQuestTask(task QuestTask) string {
 	difficulty := formatQuestDifficulty(task.Difficulty)
 	if task.Unit == "100m" {
 		targetKm := float64(task.Target) / 10.0
-		return fmt.Sprintf("%s %s: %.1f km (+½ XP)", difficulty, task.Name, targetKm)
+		return fmt.Sprintf("%s %s: %.1f km", difficulty, task.Name, targetKm)
 	}
-	return fmt.Sprintf("%s %s: %d %s (+½ XP)", difficulty, task.Name, task.Target, task.Unit)
+	return fmt.Sprintf("%s %s: %d %s", difficulty, task.Name, task.Target, task.Unit)
 }
 
 func formatQuestDifficulty(difficulty string) string {

--- a/internal/domain/quest_test.go
+++ b/internal/domain/quest_test.go
@@ -42,6 +42,7 @@ func TestMatchTask(t *testing.T) {
 		taskID string
 		want   bool
 	}{
+		// Original exercises
 		{"pushup 5", "pushup", true},
 		{"push up 10", "pushup", true},
 		{"Push-Up 3", "pushup", true},
@@ -52,6 +53,26 @@ func TestMatchTask(t *testing.T) {
 		{"cycling 20", "sepeda", true},
 		{"burpee 10", "burpee", true},
 		{"something else 10", "pushup", false},
+		// New medium exercises
+		{"high knees 1 menit", "highknees", true},
+		{"marching 2 menit", "highknees", true},
+		{"arm circle 2 menit", "armcircles", true},
+		{"putaran lengan 1 menit", "armcircles", true},
+		{"calf raises 20", "calfraises", true},
+		{"jinjit 20", "calfraises", true},
+		{"shoulder shrug 15", "shouldershrugs", true},
+		{"shrug bahu 15", "shouldershrugs", true},
+		// New hard exercises
+		{"mountain climber 30 detik", "mountainclimber", true},
+		{"gerakan panjat 30", "mountainclimber", true},
+		{"lunges 10", "lunges", true},
+		{"lunjak 10", "lunges", true},
+		{"glute bridge 15", "glutebridge", true},
+		{"jembatan pinggul 15", "glutebridge", true},
+		{"reverse crunch 10", "reversecrunch", true},
+		// Negative cases
+		{"bicycle crunch 10", "reversecrunch", false}, // should not match: exclude "bicycle"
+		{"random text", "highknees", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- Add more medium and hard daily quest options to diversify challenges.
- Implement variable XP rewards for side quests based on difficulty, replacing flat 5 points.
- Improve  view and  instructions with clearer examples and dynamic quest name suggestions.
- Refactor  command parsing to be more flexible, allowing non-whitespace characters after  while maintaining specific command priority.