### PR TITLE
Feat: Menambahkan command #attributes untuk penjelasan status RPG dan pembaruan kata kunci

### DIFF
--- a/internal/app/usecase/get_help_usecase.go
+++ b/internal/app/usecase/get_help_usecase.go
@@ -62,6 +62,11 @@ var helpSections = []struct {
 		title:   "Bantuan",
 		content: "*#help* — Tampilkan panduan ini kapan saja!",
 	},
+	{
+		emoji:   "⚔️",
+		title:   "Status RPG (Attributes)",
+		content: "Bot akan membaca laporanmu dan menaikkan status tertentu berdasarkan kata kunci aktivitas.\n\n💪 *STR (Strength)*: beban, weight, strength, gym, angkat, powerlifting\n🏃‍♂️ *STA (Stamina)*: lari, run, sepeda, cycle, hiit, kardio, cardio, renang, swim\n⚡ *AGI (Agility)*: bola, futsal, basket, bulutangkis, tenis, sprint, muaythai, boxing, calisthenics, agility\n🧘‍♂️ *VIT (Vitality)*: yoga, pilates, stretching, recovery, jalan, walk, meditasi, sleep\n\nJika tidak ada kata kunci spesifik, laporan akan otomatis meningkatkan *VIT*.",
+	},
 }
 
 type GetHelpUsecase struct{}

--- a/internal/app/usecase/get_help_usecase.go
+++ b/internal/app/usecase/get_help_usecase.go
@@ -65,7 +65,7 @@ var helpSections = []struct {
 	{
 		emoji:   "⚔️",
 		title:   "Status RPG (Attributes)",
-		content: "Bot akan membaca laporanmu dan menaikkan status tertentu berdasarkan kata kunci aktivitas.\n\n💪 *STR (Strength)*: beban, weight, strength, gym, angkat, powerlifting\n🏃‍♂️ *STA (Stamina)*: lari, run, sepeda, cycle, hiit, kardio, cardio, renang, swim\n⚡ *AGI (Agility)*: bola, futsal, basket, bulutangkis, tenis, sprint, muaythai, boxing, calisthenics, agility\n🧘‍♂️ *VIT (Vitality)*: yoga, pilates, stretching, recovery, jalan, walk, meditasi, sleep\n\nJika tidak ada kata kunci spesifik, laporan akan otomatis meningkatkan *VIT*.",
+		content: "Bot akan membaca laporanmu dan menaikkan status tertentu berdasarkan kata kunci aktivitas.\n\n💪 *STR (Strength)*: beban, weight, strength, gym, angkat, powerlifting\n🏃‍♂️ *STA (Stamina)*: lari, run, running, sepeda, cycle, hiit, kardio, cardio, renang, swim\n⚡ *AGI (Agility)*: bola, futsal, basket, bulutangkis, tenis, sprint, muaythai, boxing, calisthenics, padel, padle\n🧘‍♂️ *VIT (Vitality)*: yoga, pilates, stretching, recovery, jalan, walk, meditasi\n\nJika tidak ada kata kunci spesifik, laporan akan otomatis meningkatkan *VIT*.",
 	},
 }
 

--- a/internal/app/usecase/get_help_usecase.go
+++ b/internal/app/usecase/get_help_usecase.go
@@ -65,7 +65,7 @@ var helpSections = []struct {
 	{
 		emoji:   "⚔️",
 		title:   "Status RPG (Attributes)",
-		content: "Bot akan membaca laporanmu dan menaikkan status tertentu berdasarkan kata kunci aktivitas.\n\n💪 *STR (Strength)*: beban, weight, strength, gym, angkat, powerlifting\n🏃‍♂️ *STA (Stamina)*: lari, run, running, sepeda, cycle, hiit, kardio, cardio, renang, swim\n⚡ *AGI (Agility)*: bola, futsal, basket, bulutangkis, tenis, sprint, muaythai, boxing, calisthenics, padel, padle\n🧘‍♂️ *VIT (Vitality)*: yoga, pilates, stretching, recovery, jalan, walk, meditasi\n\nJika tidak ada kata kunci spesifik, laporan akan otomatis meningkatkan *VIT*.",
+		content: "Bot akan membaca laporanmu dan menaikkan status tertentu berdasarkan kata kunci aktivitas.\n\n💪 *STR (Strength)*: beban, weight, strength, gym, angkat, powerlifting, push, pull, leg\n🏃‍♂️ *STA (Stamina)*: lari, run, running, sepeda, cycle, hiit, kardio, cardio, renang, swim\n⚡ *AGI (Agility)*: bola, futsal, basket, bulutangkis, tenis, sprint, muaythai, boxing, calisthenics, padel, padle\n🧘‍♂️ *VIT (Vitality)*: yoga, pilates, stretching, recovery, jalan, walk, meditasi\n\nJika tidak ada kata kunci spesifik, laporan akan otomatis meningkatkan *VIT*.",
 	},
 }
 
@@ -100,7 +100,19 @@ func (uc *GetHelpUsecase) Execute() string {
 🏃 #strava — hubungkan Strava via chat pribadi
 ✏️ #setname [nama] — ubah nama tampil
 📚 #tutorial — cara pakai bot lengkap
+⚔️ #attributes — info kata kunci status RPG
 ❓ #help — list command ini`
+}
+
+func (uc *GetHelpUsecase) ExecuteAttributes() string {
+	msg := "⚔️ *Status RPG (Attributes)* ⚔️\n\n"
+	msg += "Setiap kali kamu `#lapor`, bot akan membaca kata kunci dari laporanmu dan memberikan atribut ke status tertentu. Berikut daftar kata kuncinya:\n\n"
+	msg += "💪 *STR (Strength)*: beban, weight, strength, gym, angkat, powerlifting, push, pull, leg\n"
+	msg += "🏃‍♂️ *STA (Stamina)*: lari, run, running, sepeda, cycle, hiit, kardio, cardio, renang, swim\n"
+	msg += "⚡ *AGI (Agility)*: bola, futsal, basket, bulutangkis, tenis, sprint, muaythai, boxing, calisthenics, padel, padle\n"
+	msg += "🧘‍♂️ *VIT (Vitality)*: yoga, pilates, stretching, recovery, jalan, walk, meditasi\n\n"
+	msg += "💡 *Tips:* Jika tidak ada kata kunci di atas yang cocok dalam teks laporanmu, secara default atributmu akan otomatis masuk ke *VIT*."
+	return msg
 }
 
 func (uc *GetHelpUsecase) ExecuteTutorial() string {

--- a/internal/app/usecase/get_mystats_usecase.go
+++ b/internal/app/usecase/get_mystats_usecase.go
@@ -73,6 +73,13 @@ func (uc *GetMyStatsUsecase) Execute(ctx context.Context, userID, name string) (
 	}
 	sb.WriteString(fmt.Sprintf("🎖️ Level: Lv.%d • %s (lifetime)\n", report.Level, domain.FormatLevel(report.TotalPoints)))
 	sb.WriteString(fmt.Sprintf("🧭 Job: %s\n", domain.FormatJobClass(report.JobClass)))
+	
+	sb.WriteString("\n💪 Attributes:\n")
+	sb.WriteString(fmt.Sprintf("STR (Strength) : %d pts\n", max(1, report.Str)))
+	sb.WriteString(fmt.Sprintf("STA (Stamina)  : %d pts\n", max(1, report.Sta)))
+	sb.WriteString(fmt.Sprintf("AGI (Agility)  : %d pts\n", max(1, report.Agi)))
+	sb.WriteString(fmt.Sprintf("VIT (Vitality) : %d pts\n\n", max(1, report.Vit)))
+
 	sb.WriteString(fmt.Sprintf("📈 %s\n", domain.FormatNumericLevelProgressBar(report.TotalPoints)))
 	sb.WriteString(fmt.Sprintf("📊 %s\n\n", domain.FormatProgressBar(report.TotalPoints)))
 

--- a/internal/app/usecase/handle_message_usecase.go
+++ b/internal/app/usecase/handle_message_usecase.go
@@ -79,7 +79,7 @@ func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, messa
 
 	if strings.Contains(msg, "#lapor-kemarin") {
 		workout := domain.ParseHevy(message)
-		text, err := uc.reportUC.ExecuteYesterday(ctx, userID, name, workout)
+		text, err := uc.reportUC.ExecuteYesterdayWithMessage(ctx, userID, name, message, workout)
 		return MessageResponse{Text: text}, err
 	}
 
@@ -99,7 +99,7 @@ func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, messa
 
 	if strings.Contains(msg, "#lapor") {
 		workout := domain.ParseHevy(message)
-		text, err := uc.reportUC.Execute(ctx, userID, name, workout)
+		text, err := uc.reportUC.ExecuteWithMessage(ctx, userID, name, message, workout)
 		return MessageResponse{Text: text}, err
 	}
 

--- a/internal/app/usecase/handle_message_usecase.go
+++ b/internal/app/usecase/handle_message_usecase.go
@@ -77,6 +77,11 @@ func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, messa
 		return MessageResponse{Text: text}, nil
 	}
 
+	if strings.Contains(msg, "#attributes") || strings.Contains(msg, "#attributs") || strings.Contains(msg, "#atributs") {
+		text := uc.helpUC.ExecuteAttributes()
+		return MessageResponse{Text: text}, nil
+	}
+
 	if strings.Contains(msg, "#lapor-kemarin") {
 		workout := domain.ParseHevy(message)
 		text, err := uc.reportUC.ExecuteYesterdayWithMessage(ctx, userID, name, message, workout)

--- a/internal/app/usecase/report_activity_usecase.go
+++ b/internal/app/usecase/report_activity_usecase.go
@@ -223,6 +223,13 @@ func (uc *ReportActivityUsecase) execute(ctx context.Context, userID, name strin
 	var statGains []string
 	if reportPoints > 0 && len(attrs) > 0 {
 		statPoints := reportPoints / len(attrs)
+		
+		scalingLevel := oldNumericLevel
+		if scalingLevel < 1 {
+			scalingLevel = 1
+		}
+		statPoints = statPoints / scalingLevel
+		
 		if statPoints == 0 {
 			statPoints = 1 // Ensure at least 1 point if it divided down to 0
 		}
@@ -553,6 +560,13 @@ func (uc *ReportActivityUsecase) executeYesterday(ctx context.Context, userID, n
 	var statGains []string
 	if reportPoints > 0 && len(attrs) > 0 {
 		statPoints := reportPoints / len(attrs)
+		
+		scalingLevel := oldNumericLevel
+		if scalingLevel < 1 {
+			scalingLevel = 1
+		}
+		statPoints = statPoints / scalingLevel
+		
 		if statPoints == 0 {
 			statPoints = 1 // Ensure at least 1 point
 		}

--- a/internal/app/usecase/report_activity_usecase.go
+++ b/internal/app/usecase/report_activity_usecase.go
@@ -38,6 +38,12 @@ func (uc *ReportActivityUsecase) Execute(ctx context.Context, userID, name strin
 	return uc.execute(ctx, userID, name, workout, reportActivityOptions{})
 }
 
+func (uc *ReportActivityUsecase) ExecuteWithMessage(ctx context.Context, userID, name, message string, workout *domain.HevyWorkout) (string, error) {
+	return uc.execute(ctx, userID, name, workout, reportActivityOptions{
+		activityText: message,
+	})
+}
+
 func (uc *ReportActivityUsecase) ExecuteSideQuest(ctx context.Context, userID, name, activityText string, completedCount, sideQuestPoints int, now time.Time) (string, error) {
 	if completedCount < 1 {
 		completedCount = 1
@@ -206,6 +212,38 @@ func (uc *ReportActivityUsecase) execute(ctx context.Context, userID, name strin
 	report.TotalPoints += reportPoints
 	report.SeasonalPoints += reportPoints
 
+	activityForParse := opts.activityText
+	if workout != nil {
+		activityForParse += " " + workout.Title
+		for _, ex := range workout.Exercises {
+			activityForParse += " " + ex
+		}
+	}
+	attrs := domain.DetermineAttributes(activityForParse)
+	var statGains []string
+	if reportPoints > 0 && len(attrs) > 0 {
+		statPoints := reportPoints / len(attrs)
+		if statPoints == 0 {
+			statPoints = 1 // Ensure at least 1 point if it divided down to 0
+		}
+		for _, attr := range attrs {
+			switch attr {
+			case domain.AttrStr:
+				report.Str += statPoints
+				statGains = append(statGains, fmt.Sprintf("STR +%d", statPoints))
+			case domain.AttrSta:
+				report.Sta += statPoints
+				statGains = append(statGains, fmt.Sprintf("STA +%d", statPoints))
+			case domain.AttrAgi:
+				report.Agi += statPoints
+				statGains = append(statGains, fmt.Sprintf("AGI +%d", statPoints))
+			case domain.AttrVit:
+				report.Vit += statPoints
+				statGains = append(statGains, fmt.Sprintf("VIT +%d", statPoints))
+			}
+		}
+	}
+
 	var newAchievements []domain.Achievement
 	var comebackAchievements []domain.ComebackAchievement
 	pointsGained := 0
@@ -289,6 +327,10 @@ func (uc *ReportActivityUsecase) execute(ctx context.Context, userID, name strin
 			expBreakdown += " (repeat report, ½ XP)"
 		}
 
+		if len(statGains) > 0 {
+			expBreakdown += fmt.Sprintf("\n💪 Attributes: %s", strings.Join(statGains, ", "))
+		}
+
 		if isSideQuest {
 			response = fmt.Sprintf("Side quest diterima, %s%s menyelesaikan %d side quest. Tetap dihitung untuk streak, stats, leaderboard, dan goal. 🔥\n%s",
 				cyclePrefix, name, opts.sideQuestCount, expBreakdown)
@@ -361,11 +403,20 @@ func (uc *ReportActivityUsecase) execute(ctx context.Context, userID, name strin
 
 	response += fmt.Sprintf("\n%s", domain.FormatNumericLevelProgressBar(report.TotalPoints))
 	response += fmt.Sprintf("\n%s", domain.FormatProgressBar(report.TotalPoints))
+	response += fmt.Sprintf("\n\n%s", formatCurrentAttributes(report))
 
 	return response, nil
 }
 
 func (uc *ReportActivityUsecase) ExecuteYesterday(ctx context.Context, userID, name string, workout *domain.HevyWorkout) (string, error) {
+	return uc.executeYesterday(ctx, userID, name, "", workout)
+}
+
+func (uc *ReportActivityUsecase) ExecuteYesterdayWithMessage(ctx context.Context, userID, name, message string, workout *domain.HevyWorkout) (string, error) {
+	return uc.executeYesterday(ctx, userID, name, message, workout)
+}
+
+func (uc *ReportActivityUsecase) executeYesterday(ctx context.Context, userID, name, activityText string, workout *domain.HevyWorkout) (string, error) {
 	lock := uc.userLock(userID)
 	lock.Lock()
 	defer lock.Unlock()
@@ -491,6 +542,38 @@ func (uc *ReportActivityUsecase) ExecuteYesterday(ctx context.Context, userID, n
 	report.TotalPoints += reportPoints
 	report.SeasonalPoints += reportPoints
 
+	activityForParse := activityText
+	if workout != nil {
+		activityForParse += " " + workout.Title
+		for _, ex := range workout.Exercises {
+			activityForParse += " " + ex
+		}
+	}
+	attrs := domain.DetermineAttributes(activityForParse)
+	var statGains []string
+	if reportPoints > 0 && len(attrs) > 0 {
+		statPoints := reportPoints / len(attrs)
+		if statPoints == 0 {
+			statPoints = 1 // Ensure at least 1 point
+		}
+		for _, attr := range attrs {
+			switch attr {
+			case domain.AttrStr:
+				report.Str += statPoints
+				statGains = append(statGains, fmt.Sprintf("STR +%d", statPoints))
+			case domain.AttrSta:
+				report.Sta += statPoints
+				statGains = append(statGains, fmt.Sprintf("STA +%d", statPoints))
+			case domain.AttrAgi:
+				report.Agi += statPoints
+				statGains = append(statGains, fmt.Sprintf("AGI +%d", statPoints))
+			case domain.AttrVit:
+				report.Vit += statPoints
+				statGains = append(statGains, fmt.Sprintf("VIT +%d", statPoints))
+			}
+		}
+	}
+
 	newAchievements := domain.CheckNewSeasonAchievements(report)
 	pointsGained := 0
 
@@ -564,6 +647,10 @@ func (uc *ReportActivityUsecase) ExecuteYesterday(ctx context.Context, userID, n
 		}
 		expBreakdown += " (lapor kemarin, ½ XP)"
 
+		if len(statGains) > 0 {
+			expBreakdown += fmt.Sprintf("\n💪 Attributes: %s", strings.Join(statGains, ", "))
+		}
+
 		response = fmt.Sprintf("Laporan kemarin diterima, %s%s sudah berkeringat %d hari. Lanjutkan 🔥 (streak %d minggu)\n%s",
 			cyclePrefix, name, report.ActivityCount, report.Streak, expBreakdown)
 		if report.JobClass != "" {
@@ -628,6 +715,7 @@ func (uc *ReportActivityUsecase) ExecuteYesterday(ctx context.Context, userID, n
 
 	response += fmt.Sprintf("\n%s", domain.FormatNumericLevelProgressBar(report.TotalPoints))
 	response += fmt.Sprintf("\n%s", domain.FormatProgressBar(report.TotalPoints))
+	response += fmt.Sprintf("\n\n%s", formatCurrentAttributes(report))
 
 	return response, nil
 }
@@ -681,4 +769,16 @@ func (uc *ReportActivityUsecase) getNextComebackTarget(report *domain.Report) *d
 		}
 	}
 	return nil
+}
+
+func formatCurrentAttributes(report *domain.Report) string {
+	str := report.Str
+	if str < 1 { str = 1 }
+	sta := report.Sta
+	if sta < 1 { sta = 1 }
+	agi := report.Agi
+	if agi < 1 { agi = 1 }
+	vit := report.Vit
+	if vit < 1 { vit = 1 }
+	return fmt.Sprintf("🛡️ Stats: STR %d | STA %d | AGI %d | VIT %d", str, sta, agi, vit)
 }

--- a/internal/domain/report.go
+++ b/internal/domain/report.go
@@ -75,13 +75,13 @@ func DetermineAttributes(text string) []AttributeType {
 	if strings.Contains(text, "beban") || strings.Contains(text, "weight") || strings.Contains(text, "strength") || strings.Contains(text, "gym") || strings.Contains(text, "angkat") || strings.Contains(text, "powerlifting") || strings.Contains(text, "push") || strings.Contains(text, "pull") || strings.Contains(text, "leg") {
 		attrs = append(attrs, AttrStr)
 	}
-	if strings.Contains(text, "lari") || strings.Contains(text, "run") || strings.Contains(text, "sepeda") || strings.Contains(text, "cycle") || strings.Contains(text, "hiit") || strings.Contains(text, "kardio") || strings.Contains(text, "cardio") || strings.Contains(text, "renang") || strings.Contains(text, "swim") {
+	if strings.Contains(text, "lari") || strings.Contains(text, "run") || strings.Contains(text, "running") || strings.Contains(text, "sepeda") || strings.Contains(text, "cycle") || strings.Contains(text, "hiit") || strings.Contains(text, "kardio") || strings.Contains(text, "cardio") || strings.Contains(text, "renang") || strings.Contains(text, "swim") {
 		attrs = append(attrs, AttrSta)
 	}
-	if strings.Contains(text, "bola") || strings.Contains(text, "futsal") || strings.Contains(text, "basket") || strings.Contains(text, "bulutangkis") || strings.Contains(text, "tenis") || strings.Contains(text, "sprint") || strings.Contains(text, "muaythai") || strings.Contains(text, "boxing") || strings.Contains(text, "calisthenics") || strings.Contains(text, "agility") {
+	if strings.Contains(text, "bola") || strings.Contains(text, "futsal") || strings.Contains(text, "basket") || strings.Contains(text, "bulutangkis") || strings.Contains(text, "tenis") || strings.Contains(text, "sprint") || strings.Contains(text, "muaythai") || strings.Contains(text, "boxing") || strings.Contains(text, "calisthenics") || strings.Contains(text, "padel") || strings.Contains(text, "padle") {
 		attrs = append(attrs, AttrAgi)
 	}
-	if strings.Contains(text, "yoga") || strings.Contains(text, "pilates") || strings.Contains(text, "stretching") || strings.Contains(text, "recovery") || strings.Contains(text, "jalan") || strings.Contains(text, "walk") || strings.Contains(text, "meditasi") || strings.Contains(text, "sleep") {
+	if strings.Contains(text, "yoga") || strings.Contains(text, "pilates") || strings.Contains(text, "stretching") || strings.Contains(text, "recovery") || strings.Contains(text, "jalan") || strings.Contains(text, "walk") || strings.Contains(text, "meditasi") {
 		attrs = append(attrs, AttrVit)
 	}
 

--- a/internal/domain/report.go
+++ b/internal/domain/report.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 )
 
@@ -30,6 +31,10 @@ type Report struct {
 	GoalsCompleted        int       `json:"goals_completed" db:"goals_completed"`
 	TotalSideQuests       int       `json:"total_side_quests" db:"total_side_quests"`
 	SeasonalSideQuests    int       `json:"seasonal_side_quests" db:"seasonal_side_quests"`
+	Str                   int       `json:"str" db:"str"`
+	Sta                   int       `json:"sta" db:"sta"`
+	Agi                   int       `json:"agi" db:"agi"`
+	Vit                   int       `json:"vit" db:"vit"`
 }
 
 type ActivityLeaderboardEntry struct {
@@ -51,6 +56,41 @@ type WeeklyGoal struct {
 type GoalActivity struct {
 	Date     time.Time
 	Activity string
+}
+
+type AttributeType string
+
+const (
+	AttrStr AttributeType = "STR"
+	AttrSta AttributeType = "STA"
+	AttrAgi AttributeType = "AGI"
+	AttrVit AttributeType = "VIT"
+)
+
+// DetermineAttributes parses an activity text to find matching RPG attributes.
+func DetermineAttributes(text string) []AttributeType {
+	text = strings.ToLower(text)
+	var attrs []AttributeType
+
+	if strings.Contains(text, "beban") || strings.Contains(text, "weight") || strings.Contains(text, "strength") || strings.Contains(text, "gym") || strings.Contains(text, "angkat") || strings.Contains(text, "powerlifting") || strings.Contains(text, "push") || strings.Contains(text, "pull") || strings.Contains(text, "leg") {
+		attrs = append(attrs, AttrStr)
+	}
+	if strings.Contains(text, "lari") || strings.Contains(text, "run") || strings.Contains(text, "sepeda") || strings.Contains(text, "cycle") || strings.Contains(text, "hiit") || strings.Contains(text, "kardio") || strings.Contains(text, "cardio") || strings.Contains(text, "renang") || strings.Contains(text, "swim") {
+		attrs = append(attrs, AttrSta)
+	}
+	if strings.Contains(text, "bola") || strings.Contains(text, "futsal") || strings.Contains(text, "basket") || strings.Contains(text, "bulutangkis") || strings.Contains(text, "tenis") || strings.Contains(text, "sprint") || strings.Contains(text, "muaythai") || strings.Contains(text, "boxing") || strings.Contains(text, "calisthenics") || strings.Contains(text, "agility") {
+		attrs = append(attrs, AttrAgi)
+	}
+	if strings.Contains(text, "yoga") || strings.Contains(text, "pilates") || strings.Contains(text, "stretching") || strings.Contains(text, "recovery") || strings.Contains(text, "jalan") || strings.Contains(text, "walk") || strings.Contains(text, "meditasi") || strings.Contains(text, "sleep") {
+		attrs = append(attrs, AttrVit)
+	}
+
+	if len(attrs) == 0 {
+		// Default to VIT (General Health/Vitality) if no specific keywords match
+		attrs = append(attrs, AttrVit)
+	}
+
+	return attrs
 }
 
 // ReportCutoffOffset is the spare time allowed for late-night reporting.

--- a/internal/infra/sqlite/report_repository.go
+++ b/internal/infra/sqlite/report_repository.go
@@ -26,7 +26,8 @@ const selectColumns = `user_id, name, COALESCE(job_class, ''), streak, activity_
 	COALESCE(seasonal_points, 0), COALESCE(seasonal_activity_count, 0),
 	COALESCE(seasonal_max_streak, 0), COALESCE(seasonal_achievements, ''),
 	COALESCE(streak_freezes, 0), COALESCE(goals_completed, 0),
-	COALESCE(total_side_quests, 0), COALESCE(seasonal_side_quests, 0)`
+	COALESCE(total_side_quests, 0), COALESCE(seasonal_side_quests, 0),
+	COALESCE(str, 0), COALESCE(sta, 0), COALESCE(agi, 0), COALESCE(vit, 0)`
 
 func scanReport(scanner interface{ Scan(dest ...any) error }) (*domain.Report, error) {
 	var report domain.Report
@@ -39,6 +40,7 @@ func scanReport(scanner interface{ Scan(dest ...any) error }) (*domain.Report, e
 		&report.SeasonalMaxStreak, &report.SeasonalAchievements,
 		&report.StreakFreezes, &report.GoalsCompleted,
 		&report.TotalSideQuests, &report.SeasonalSideQuests,
+		&report.Str, &report.Sta, &report.Agi, &report.Vit,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -63,8 +65,8 @@ func (r *ReportRepository) GetReport(ctx context.Context, userID string) (*domai
 
 func upsertReport(ctx context.Context, execer execContexter, report *domain.Report) error {
 	query := `
-		INSERT INTO user_reports (user_id, name, job_class, streak, activity_count, last_report_date, max_streak, total_points, level, achievements, comeback_streak, inactive_days, centurion_cycles, seasonal_points, seasonal_activity_count, seasonal_max_streak, seasonal_achievements, streak_freezes, goals_completed, total_side_quests, seasonal_side_quests)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO user_reports (user_id, name, job_class, streak, activity_count, last_report_date, max_streak, total_points, level, achievements, comeback_streak, inactive_days, centurion_cycles, seasonal_points, seasonal_activity_count, seasonal_max_streak, seasonal_achievements, streak_freezes, goals_completed, total_side_quests, seasonal_side_quests, str, sta, agi, vit)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(user_id) DO UPDATE SET
 			name = excluded.name,
 			job_class = excluded.job_class,
@@ -84,7 +86,11 @@ func upsertReport(ctx context.Context, execer execContexter, report *domain.Repo
 			seasonal_achievements = excluded.seasonal_achievements,
 			streak_freezes = excluded.streak_freezes,
 			total_side_quests = excluded.total_side_quests,
-			seasonal_side_quests = excluded.seasonal_side_quests
+			seasonal_side_quests = excluded.seasonal_side_quests,
+			str = excluded.str,
+			sta = excluded.sta,
+			agi = excluded.agi,
+			vit = excluded.vit
 	`
 	_, err := execer.ExecContext(ctx, query,
 		report.UserID, report.Name, report.JobClass, report.Streak, report.ActivityCount,
@@ -93,6 +99,7 @@ func upsertReport(ctx context.Context, execer execContexter, report *domain.Repo
 		report.SeasonalPoints, report.SeasonalActivityCount, report.SeasonalMaxStreak,
 		report.SeasonalAchievements, report.StreakFreezes, report.GoalsCompleted,
 		report.TotalSideQuests, report.SeasonalSideQuests,
+		report.Str, report.Sta, report.Agi, report.Vit,
 	)
 	return err
 }
@@ -288,6 +295,10 @@ func (r *ReportRepository) InitTable(ctx context.Context) error {
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN goals_completed INTEGER DEFAULT 0")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN total_side_quests INTEGER DEFAULT 0")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN seasonal_side_quests INTEGER DEFAULT 0")
+	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN str INTEGER DEFAULT 0")
+	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN sta INTEGER DEFAULT 0")
+	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN agi INTEGER DEFAULT 0")
+	_, _ = r.db.ExecContext(ctx, "ALTER TABLE user_reports ADD COLUMN vit INTEGER DEFAULT 0")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE activity_logs ADD COLUMN report_count INTEGER NOT NULL DEFAULT 1")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE activity_logs ADD COLUMN activity_text TEXT DEFAULT ''")
 	_, _ = r.db.ExecContext(ctx, "ALTER TABLE strava_accounts ADD COLUMN name TEXT")


### PR DESCRIPTION
## Deskripsi Perubahan
Pull Request ini menambahkan command baru `#attributes` untuk memudahkan user melihat daftar lengkap kata kunci aktivitas yang memengaruhi status RPG (STR, STA, AGI, VIT). 

Selain itu, PR ini juga memperbaiki informasi di menu bantuan agar lebih akurat dengan kondisi kode saat ini.

## Detail Perubahan:
- **Fitur Baru:** Menambahkan command `#attributes` (juga mendukung typo `#attributs` dan `#atributs`) untuk menampilkan penjelasan detail atribut RPG.
- **Menu Bantuan:** Menambahkan command `#attributes` ke dalam list pada command `#help`.
- **Update Tutorial:** Melengkapi kata kunci untuk atribut STR (Strength) pada menu tutorial dengan menambahkan kata `push`, `pull`, dan `leg` agar sesuai dengan logika parsing aktivitas yang ada.

## Cara Test:
1. Jalankan bot.
2. Kirim pesan `#attributes` atau `#atributs`. Bot akan membalas dengan list lengkap kata kunci tiap status.
3. Kirim pesan `#help` untuk melihat bahwa command `#attributes` sudah masuk di dalam daftar bantuan.
