### PR TITLE
feat(bot): simplify help message and direct to web portal

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -391,6 +391,7 @@ func main() {
 			}
 
 			response += usecase.BuildWellnessReminder()
+			response += "\n\n🌐 Lihat klasemen & stats: https://lapor-bot.web.id/"
 
 			targetJID, err := types.ParseJID(cfg.GroupID)
 			if err != nil {

--- a/internal/app/usecase/daily_quest_usecase.go
+++ b/internal/app/usecase/daily_quest_usecase.go
@@ -87,7 +87,7 @@ func (u *DailyQuestUsecase) SendDailyQuests(ctx context.Context, now time.Time, 
 	}
 
 	dateStr := domain.GetToday(now).Format("02 Jan 2006")
-	msgText := fmt.Sprintf("🌅 *Selamat pagi, Hunters!*\n\nSide quest hari ini sudah terbuka untuk %d hunter yang sudah memilih job. Buka `#mysidequest` untuk lihat pilihan easy, medium, dan hard hari ini.\n\nPilih yang ringan dulu juga boleh—minimal jalan kaki 4.000 langkah atau sepeda 5 km, atau gerakan singkat di rumah/kantor. Side quest cuma bonus kecil; misi utama tetap konsisten olahraga dan lapor di grup. ✨\n\n📅 %s\n📝 Lapor side quest: `#lapor sidequest <kegiatan> <jumlah>`", eligibleCount, dateStr)
+	msgText := fmt.Sprintf("🌅 *Selamat pagi, Hunters!*\n\nSide quest hari ini sudah terbuka untuk %d hunter yang sudah memilih job. Buka `#mysidequest` untuk lihat pilihan easy, medium, dan hard hari ini.\n\nPilih yang ringan dulu juga boleh—minimal jalan kaki 4.000 langkah atau sepeda 5 km, atau gerakan singkat di rumah/kantor. Side quest cuma bonus kecil; misi utama tetap konsisten olahraga dan lapor di grup. ✨\n\n📅 %s\n📝 Lapor side quest: `#lapor sidequest <kegiatan> <jumlah>`\n\n🌐 Lihat klasemen & stats: https://lapor-bot.web.id/", eligibleCount, dateStr)
 
 	targetJID, err := types.ParseJID(groupID)
 	if err != nil {

--- a/internal/app/usecase/get_help_usecase.go
+++ b/internal/app/usecase/get_help_usecase.go
@@ -79,29 +79,14 @@ func (uc *GetHelpUsecase) Execute() string {
 	return `🤖 *Command Lapor Bot*
 
 📝 #lapor — laporan aktivitas harian (max 3x/hari)
-✨ #mysidequest — lihat side quest hari ini
-✨ #lapor sidequest [kegiatan] [jumlah] — lapor side quest ½ XP
+✨ #lapor sidequest [kegiatan] [jumlah] — lapor side quest
 📌 #lapor-kemarin — laporan khusus hari kemarin (max 3x/hari)
 ❌ #cancel — batalkan laporan hari ini
 🧹 #cancel-all — batalkan semua laporan hari ini
-📊 #mystats — statistik personal
-🎯 #goal set [1-7] [aktivitas] — set goal 7 hari sejak sekarang
-🎯 #goal — progress goal aktif
-🔄 #goal reset — reset goal aktif
-🏆 #leaderboard — leaderboard lifetime
-📅 #leaderboard-weekly — leaderboard minggu ini
-🏹 #leaderboard-seasonal — leaderboard season
-🎖️ #ranks — rank hunter season
-🏅 #achievements — detail badge dan syarat unlock
-🔄 #comeback — progress comeback challenge
-🧭 #jobs — daftar job
-🧭 #job [id] — pilih job hunter
-✨ #motivasi — quote motivasi
-🏃 #strava — hubungkan Strava via chat pribadi
-✏️ #setname [nama] — ubah nama tampil
-📚 #tutorial — cara pakai bot lengkap
-⚔️ #attributes — info kata kunci status RPG
-❓ #help — list command ini`
+📚 #tutorial — panduan lengkap penggunaan bot
+❓ #help — list command ini
+
+🌐 Klasemen & stats personal: https://lapor-bot.web.id/`
 }
 
 func (uc *GetHelpUsecase) ExecuteAttributes() string {
@@ -140,6 +125,7 @@ func (uc *GetHelpUsecase) ExecuteTutorial() string {
 	msg += "3. Pilih easy (jalan kaki atau sepeda), medium, hard, atau beberapa sekaligus.\n"
 	msg += "4. Lapor dengan format `#lapor sidequest <kegiatan> <jumlah>`, gunakan nama kegiatan yang tertera di `#mysidequest`. Contoh: `#lapor sidequest jalan kaki 4000`, `#lapor sidequest sepeda 5 km`, `#lapor sidequest chair squat 18`.\n"
 	msg += "5. Side quest memberi XP bonus kecil (bervariasi per difficulty), tetap masuk streak, stats, leaderboard, goal, dan total side quest di `#mystats`/`#achievements`.\n\n"
-	msg += "_Catatan: Bot hanya merespon di grup yang sudah dikonfigurasi. Semangat terus! 💪_"
+	msg += "_Catatan: Bot hanya merespon di grup yang sudah dikonfigurasi. Semangat terus! 💪_\n\n" +
+		"🌐 Klasemen & stats personal: https://lapor-bot.web.id/"
 	return msg
 }

--- a/internal/app/usecase/handle_message_usecase.go
+++ b/internal/app/usecase/handle_message_usecase.go
@@ -2,7 +2,6 @@ package usecase
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -67,6 +66,10 @@ func NewHandleMessageUsecase(
 func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, message string) (MessageResponse, error) {
 	msg := strings.ToLower(strings.TrimSpace(message))
 
+	if msg == "" {
+		return MessageResponse{}, nil
+	}
+
 	if strings.Contains(msg, "#tutorial") {
 		text := uc.helpUC.ExecuteTutorial()
 		return MessageResponse{Text: text}, nil
@@ -77,10 +80,10 @@ func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, messa
 		return MessageResponse{Text: text}, nil
 	}
 
-	if strings.Contains(msg, "#attributes") || strings.Contains(msg, "#attributs") || strings.Contains(msg, "#atributs") {
-		text := uc.helpUC.ExecuteAttributes()
-		return MessageResponse{Text: text}, nil
-	}
+	// if strings.Contains(msg, "#attributes") || strings.Contains(msg, "#attributs") || strings.Contains(msg, "#atributs") {
+	// 	text := uc.helpUC.ExecuteAttributes()
+	// 	return MessageResponse{Text: text}, nil
+	// }
 
 	if strings.Contains(msg, "#lapor-kemarin") {
 		workout := domain.ParseHevy(message)
@@ -88,10 +91,10 @@ func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, messa
 		return MessageResponse{Text: text}, err
 	}
 
-	if strings.Contains(msg, "#mysidequest") {
-		text, err := uc.dailyQuestUC.ViewQuest(ctx, userID, name, time.Now())
-		return MessageResponse{Text: text}, err
-	}
+	// if strings.Contains(msg, "#mysidequest") {
+	// 	text, err := uc.dailyQuestUC.ViewQuest(ctx, userID, name, time.Now())
+	// 	return MessageResponse{Text: text}, err
+	// }
 
 	if arg, ok := extractSideQuestReport(message); ok {
 		if arg == "" {
@@ -118,84 +121,89 @@ func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, messa
 		return MessageResponse{Text: text}, err
 	}
 
-	if strings.Contains(msg, "#motivasi") {
-		text := uc.motivationUC.Execute()
-		return MessageResponse{Text: text}, nil
-	}
+	// if strings.Contains(msg, "#motivasi") {
+	// 	text := uc.motivationUC.Execute()
+	// 	return MessageResponse{Text: text}, nil
+	// }
 
-	if strings.Contains(msg, "#jobs") {
-		return MessageResponse{Text: uc.jobUC.List()}, nil
-	}
+	// if strings.Contains(msg, "#jobs") {
+	// 	return MessageResponse{Text: uc.jobUC.List()}, nil
+	// }
 
-	if strings.Contains(msg, "#goal") {
-		text, err := uc.goalUC.Execute(ctx, userID, name, message)
-		return MessageResponse{Text: text}, err
-	}
+	// if strings.Contains(msg, "#goal") {
+	// 	text, err := uc.goalUC.Execute(ctx, userID, name, message)
+	// 	return MessageResponse{Text: text}, err
+	// }
 
-	if strings.Contains(msg, "#job") {
-		idx := strings.Index(msg, "#job")
-		jobID := strings.TrimSpace(msg[idx+len("#job"):])
-		if jobID == "" {
-			return MessageResponse{Text: "Pilih job dengan format: #job <id>. Cek daftar job dengan #jobs."}, nil
-		}
-		text, err := uc.jobUC.Select(ctx, userID, name, jobID)
-		return MessageResponse{Text: text}, err
-	}
+	// if strings.Contains(msg, "#job") {
+	// 	idx := strings.Index(msg, "#job")
+	// 	jobID := strings.TrimSpace(msg[idx+len("#job"):])
+	// 	if jobID == "" {
+	// 		return MessageResponse{Text: "Pilih job dengan format: #job <id>. Cek daftar job dengan #jobs."}, nil
+	// 	}
+	// 	text, err := uc.jobUC.Select(ctx, userID, name, jobID)
+	// 	return MessageResponse{Text: text}, err
+	// }
 
-	if strings.Contains(msg, "#setname") {
-		idx := strings.Index(msg, "#setname")
-		newName := strings.TrimSpace(message[idx+len("#setname"):])
-		text, err := uc.updateNameUC.Execute(ctx, userID, newName)
-		return MessageResponse{Text: text}, err
-	}
+	// if strings.Contains(msg, "#setname") {
+	// 	idx := strings.Index(msg, "#setname")
+	// 	newName := strings.TrimSpace(message[idx+len("#setname"):])
+	// 	text, err := uc.updateNameUC.Execute(ctx, userID, newName)
+	// 	return MessageResponse{Text: text}, err
+	// }
 
-	if strings.Contains(msg, "#leaderboard-weekly") {
-		text, err := uc.weeklyLeaderboardUC.Execute(ctx)
-		return MessageResponse{Text: text}, err
-	}
+	// if strings.Contains(msg, "#leaderboard-weekly") {
+	// 	text, err := uc.weeklyLeaderboardUC.Execute(ctx)
+	// 	return MessageResponse{Text: text}, err
+	// }
 
-	if strings.Contains(msg, "#leaderboard-seasonal") {
-		text, err := uc.leaderboardUC.ExecuteSeasonal(ctx)
-		return MessageResponse{Text: text}, err
-	}
+	// if strings.Contains(msg, "#leaderboard-seasonal") {
+	// 	text, err := uc.leaderboardUC.ExecuteSeasonal(ctx)
+	// 	return MessageResponse{Text: text}, err
+	// }
 
-	if strings.Contains(msg, "#ranks") {
-		text, err := uc.leaderboardUC.ExecuteRanks(ctx)
-		return MessageResponse{Text: text}, err
-	}
+	// if strings.Contains(msg, "#ranks") {
+	// 	text, err := uc.leaderboardUC.ExecuteRanks(ctx)
+	// 	return MessageResponse{Text: text}, err
+	// }
 
-	if strings.Contains(msg, "#leaderboard") {
-		text, err := uc.leaderboardUC.Execute(ctx)
-		return MessageResponse{Text: text}, err
-	}
+	// if strings.Contains(msg, "#leaderboard") {
+	// 	text, err := uc.leaderboardUC.Execute(ctx)
+	// 	return MessageResponse{Text: text}, err
+	// }
 
-	if strings.Contains(msg, "#mystats") {
-		text, err := uc.myStatsUC.Execute(ctx, userID, name)
-		return MessageResponse{Text: text}, err
-	}
+	// if strings.Contains(msg, "#mystats") {
+	// 	text, err := uc.myStatsUC.Execute(ctx, userID, name)
+	// 	return MessageResponse{Text: text}, err
+	// }
 
-	if strings.Contains(msg, "#achievements") {
-		text, err := uc.achievementsUC.Execute(ctx)
-		return MessageResponse{Text: text}, err
-	}
+	// if strings.Contains(msg, "#achievements") {
+	// 	text, err := uc.achievementsUC.Execute(ctx)
+	// 	return MessageResponse{Text: text}, err
+	// }
 
-	if strings.Contains(msg, "#comeback") {
-		text, err := uc.comebackUC.Execute(ctx, userID, name)
-		return MessageResponse{Text: text}, err
-	}
+	// if strings.Contains(msg, "#comeback") {
+	// 	text, err := uc.comebackUC.Execute(ctx, userID, name)
+	// 	return MessageResponse{Text: text}, err
+	// }
 
-	if strings.Contains(msg, "#strava") {
-		authURL := uc.linkStravaUC.GetAuthURL(userID, name)
-		text := fmt.Sprintf("🚴‍♂️ *Integrasi Strava* 🏃‍♂️\n\nKlik link di bawah ini untuk menghubungkan akun Strava kamu:\n\n%s\n\nSetelah berhasil, aktivitas larimu akan otomatis dilaporkan! 🎉", authURL)
-		return MessageResponse{Text: text, IsPrivate: true}, nil
-	}
+	// if strings.Contains(msg, "#strava") {
+	// 	authURL := uc.linkStravaUC.GetAuthURL(userID, name)
+	// 	text := fmt.Sprintf("🚴‍♂️ *Integrasi Strava* 🏃‍♂️\n\nKlik link di bawah ini untuk menghubungkan akun Strava kamu:\n\n%s\n\nSetelah berhasil, aktivitas larimu akan otomatis dilaporkan! 🎉", authURL)
+	// 	return MessageResponse{Text: text, IsPrivate: true}, nil
+	// }
 
-	if strings.HasPrefix(msg, "!broadcast_update") {
-		text := uc.broadcastUpdateUC.Execute()
-		return MessageResponse{Text: text}, nil
-	}
+	// if strings.HasPrefix(msg, "!broadcast_update") {
+	// 	text := uc.broadcastUpdateUC.Execute()
+	// 	return MessageResponse{Text: text}, nil
+	// }
 
-	return MessageResponse{}, nil
+	return MessageResponse{
+		Text: "📋 Maaf, command yang kamu kirim belum tersedia nih! 😅\n\n" +
+			"Coba cek command yang bisa dipakai dengan `#help` atau langsung kunjungi:\n" +
+			"🌐 https://lapor-bot.web.id/\n\n" +
+			"Di sana kamu bisa lihat klasemen, stats personal, dan info lainnya! ✨",
+	}, nil
 }
 
 func extractSideQuestReport(message string) (string, bool) {

--- a/internal/app/usecase/handle_message_usecase_test.go
+++ b/internal/app/usecase/handle_message_usecase_test.go
@@ -287,18 +287,14 @@ func TestHandleMessage_LeaderboardCommand(t *testing.T) {
 		ActivityCount: 5,
 	}
 
-	// Test #leaderboard command
+	// #leaderboard command is currently disabled — should get fallback message
 	msg, err := handleUC.Execute(ctx, "user1", "User", "#leaderboard")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// Should return leaderboard output
-	if msg.Text == "" {
-		t.Error("#leaderboard should return a response")
-	}
-	if !containsSubstring(msg.Text, "Hidup Sehat SWE Growth") {
-		t.Errorf("Response should contain 'Hidup Sehat SWE Growth', got '%s'", msg.Text)
+	if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
+		t.Errorf("Disabled command should return fallback with website URL, got '%s'", msg.Text)
 	}
 }
 
@@ -320,8 +316,8 @@ func TestHandleMessage_LeaderboardCaseInsensitive(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unexpected error for '%s': %v", cmd, err)
 		}
-		if msg.Text == "" {
-			t.Errorf("Command '%s' should return a response", cmd)
+		if msg.Text == "" || !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
+			t.Errorf("Disabled command '%s' should return fallback with website URL, got '%s'", cmd, msg.Text)
 		}
 	}
 }
@@ -348,21 +344,12 @@ func TestHandleMessage_WeeklyLeaderboardCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if !containsSubstring(msg.Text, "Berikut posisi sementara mingguan") {
-		t.Fatalf("Expected weekly leaderboard response, got %q", msg.Text)
-	}
-	if containsSubstring(msg.Text, "30 Days of Sweat Challenge") {
-		t.Fatalf("Weekly command should not fall back to the regular leaderboard response")
-	}
-	if !containsSubstring(msg.Text, "1. Alice: 3 hari") {
-		t.Errorf("Expected Alice to appear with 3 hari, got %q", msg.Text)
-	}
-	if !containsSubstring(msg.Text, "2. Budi: 1 hari") {
-		t.Errorf("Expected Budi to appear with 1 hari, got %q", msg.Text)
+	if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
+		t.Fatalf("Disabled weekly leaderboard should return fallback with website URL, got %q", msg.Text)
 	}
 }
 
-func TestHandleMessage_UnknownCommand_ReturnsEmpty(t *testing.T) {
+func TestHandleMessage_UnknownCommand_ReturnsFallback(t *testing.T) {
 	repo := &mockReportRepo{reports: make(map[string]*domain.Report)}
 	reportUC := usecase.NewReportActivityUsecase(repo)
 	leaderboardUC := usecase.NewGetLeaderboardUsecase(repo)
@@ -378,8 +365,8 @@ func TestHandleMessage_UnknownCommand_ReturnsEmpty(t *testing.T) {
 		"hello",
 		"random message",
 		"#invalid",
-		"lapor",       // missing #
-		"leaderboard", // missing #
+		"lapor",
+		"leaderboard",
 	}
 
 	for _, msgText := range testCases {
@@ -387,8 +374,8 @@ func TestHandleMessage_UnknownCommand_ReturnsEmpty(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unexpected error for '%s': %v", msgText, err)
 		}
-		if result.Text != "" {
-			t.Errorf("Unknown command '%s' should return empty string, got '%s'", msgText, result.Text)
+		if !containsSubstring(result.Text, "https://lapor-bot.web.id/") {
+			t.Errorf("Unknown command '%s' should return fallback with website URL, got '%s'", msgText, result.Text)
 		}
 	}
 }
@@ -470,22 +457,22 @@ func TestHandleMessage_GamificationCommands(t *testing.T) {
 		Achievements:  "first_report",
 	}
 
-	// Test #mystats
+	// #mystats is now disabled — should get fallback
 	msg, err := handleUC.Execute(ctx, "user1", "Gamer", "#mystats")
 	if err != nil {
 		t.Fatalf("Unexpected error for #mystats: %v", err)
 	}
-	if msg.Text == "" || !containsSubstring(msg.Text, "Statistik kamu, Gamer") {
-		t.Errorf("#mystats response invalid: %s", msg.Text)
+	if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
+		t.Errorf("Disabled #mystats should return fallback with website URL, got: %s", msg.Text)
 	}
 
-	// Test #achievements
+	// #achievements is now disabled — should get fallback
 	msg, err = handleUC.Execute(ctx, "user1", "Gamer", "#achievements")
 	if err != nil {
 		t.Fatalf("Unexpected error for #achievements: %v", err)
 	}
-	if msg.Text == "" || !containsSubstring(msg.Text, "Season Badge Challenge") {
-		t.Errorf("#achievements response invalid: %s", msg.Text)
+	if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
+		t.Errorf("Disabled #achievements should return fallback with website URL, got: %s", msg.Text)
 	}
 }
 
@@ -501,12 +488,13 @@ func TestHandleMessage_JobCommands(t *testing.T) {
 
 	ctx := context.Background()
 
+	// #jobs command is now disabled — should get fallback
 	msg, err := handleUC.Execute(ctx, "user1", "Hunter", "#jobs")
 	if err != nil {
 		t.Fatalf("unexpected error for #jobs: %v", err)
 	}
-	if !containsSubstring(msg.Text, "Daftar Hunter Jobs") || !containsSubstring(msg.Text, "#job ranger") {
-		t.Fatalf("#jobs response should include job list and selection example, got %q", msg.Text)
+	if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
+		t.Fatalf("Disabled #jobs should return fallback with website URL, got %q", msg.Text)
 	}
 
 	repo.reports["user1"] = &domain.Report{
@@ -515,25 +503,28 @@ func TestHandleMessage_JobCommands(t *testing.T) {
 		TotalPoints: 100,
 	}
 
+	// #job command is now disabled — should get fallback
 	msg, err = handleUC.Execute(ctx, "user1", "Hunter", "#job ranger")
 	if err != nil {
 		t.Fatalf("unexpected error for #job: %v", err)
 	}
-	if !containsSubstring(msg.Text, "Job dipilih") || !containsSubstring(msg.Text, "Ranger") {
-		t.Fatalf("#job response should confirm selected job, got %q", msg.Text)
-	}
-	if repo.reports["user1"].JobClass != "ranger" {
-		t.Fatalf("expected stored job ranger, got %q", repo.reports["user1"].JobClass)
+	if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
+		t.Fatalf("Disabled #job should return fallback with website URL, got %q", msg.Text)
 	}
 
+	// #job command is now disabled — set job directly in repo for lapor test
+	repo.reports["user1"].JobClass = "ranger"
+
+	// #mystats doesn't show job anymore since mystats is disabled
 	msg, err = handleUC.Execute(ctx, "user1", "Hunter", "#mystats")
 	if err != nil {
 		t.Fatalf("unexpected error for #mystats: %v", err)
 	}
-	if !containsSubstring(msg.Text, "Job: Ranger") {
-		t.Fatalf("#mystats should include selected job, got %q", msg.Text)
+	if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
+		t.Fatalf("Disabled #mystats should return fallback with website URL, got %q", msg.Text)
 	}
 
+	// #lapor still works and should show the job
 	msg, err = handleUC.Execute(ctx, "user1", "Hunter", "#lapor")
 	if err != nil {
 		t.Fatalf("unexpected error for #lapor: %v", err)
@@ -555,34 +546,21 @@ func TestHandleMessage_SetNameCommand(t *testing.T) {
 
 	ctx := context.Background()
 
-	// 1. Test #setname for new user
+	// #setname command is now disabled — should get fallback
 	msg, err := handleUC.Execute(ctx, "userVip", "OldName", "#setname King Budi")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if !containsSubstring(msg.Text, "Namamu telah diatur sebagai King Budi") {
-		t.Errorf("Unexpected response: %s", msg.Text)
+	if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
+		t.Errorf("Disabled #setname should return fallback, got: %s", msg.Text)
 	}
 
-	// Verify repo
-	r := repo.reports["userVip"]
-	if r == nil || r.Name != "King Budi" {
-		t.Errorf("Expected name 'King Budi' in repo, got %+v", r)
-	}
-
-	// 2. Test #setname for existing user
 	msg, err = handleUC.Execute(ctx, "userVip", "King Budi", "#setname Budi Solo")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if !containsSubstring(msg.Text, "dari King Budi menjadi Budi Solo") {
-		t.Errorf("Unexpected response: %s", msg.Text)
-	}
-
-	// Verify repo update
-	r = repo.reports["userVip"]
-	if r.Name != "Budi Solo" {
-		t.Errorf("Expected name 'Budi Solo' in repo, got %s", r.Name)
+	if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
+		t.Errorf("Disabled #setname should return fallback, got: %s", msg.Text)
 	}
 }
 
@@ -598,19 +576,23 @@ func TestHandleMessage_LaporDoesNotUpdateName(t *testing.T) {
 
 	ctx := context.Background()
 
-	// 1. Setup user with a specific name via #setname
-	_, _ = handleUC.Execute(ctx, "user1", "InitialPushName", "#setname ManualName")
+	// setname is disabled — PushName is used directly in #lapor instead
+	_, _ = handleUC.Execute(ctx, "user1", "InitialPushName", "#lapor")
 
-	// 2. Report with a different PushName
+	r := repo.reports["user1"]
+	if r == nil || r.Name != "InitialPushName" {
+		t.Errorf("Expected name from PushName 'InitialPushName', got '%s'", r.Name)
+	}
+
+	// Report again with different PushName — names don't auto-update either
 	_, err := handleUC.Execute(ctx, "user1", "DifferentPushName", "#lapor")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// 3. Verify name remains "ManualName"
-	r := repo.reports["user1"]
-	if r.Name != "ManualName" {
-		t.Errorf("Expected name to remain 'ManualName', but got '%s'", r.Name)
+	r = repo.reports["user1"]
+	if r.Name != "InitialPushName" {
+		t.Errorf("Expected name to remain from first report, but got '%s'", r.Name)
 	}
 }
 
@@ -717,13 +699,13 @@ func TestHandleMessage_MySideQuestCommand(t *testing.T) {
 		Level:       1,
 	}
 
+	// #mysidequest command is now disabled — should get fallback
 	msg, err := handleUC.Execute(ctx, "user123", "TestUser", "#mysidequest")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	expected := "Side Quest Hari Ini - TestUser"
-	if !containsSubstring(msg.Text, expected) {
-		t.Errorf("Expected message to contain '%s', got '%s'", expected, msg.Text)
+	if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
+		t.Errorf("Disabled #mysidequest should return fallback with website URL, got '%s'", msg.Text)
 	}
 }

--- a/internal/app/usecase/morning_workout_checkpoint_usecase.go
+++ b/internal/app/usecase/morning_workout_checkpoint_usecase.go
@@ -62,6 +62,7 @@ func BuildMorningWorkoutCheckpointMessage(activeToday, pendingToday []*domain.Re
 	}
 
 	sb.WriteString("\n\n✨ Kalau sudah punya job, cek bonus gerak harian dengan `#mysidequest`.")
+	sb.WriteString("\n\n🌐 Lihat klasemen & stats: https://lapor-bot.web.id/")
 
 	return sb.String()
 }

--- a/internal/app/usecase/remind_inactive_users_usecase.go
+++ b/internal/app/usecase/remind_inactive_users_usecase.go
@@ -193,6 +193,7 @@ func BuildReminderMessage(
 	// Append health pillar reminders (olahraga, makanan, istirahat, kelola stres)
 	sb.WriteString(BuildWellnessReminder())
 	sb.WriteString("\n\n✨ Sudah punya job? Cek side quest hari ini dengan `#mysidequest` untuk bonus gerak ringan sebelum hari selesai.")
+	sb.WriteString("\n\n🌐 Lihat klasemen & stats: https://lapor-bot.web.id/")
 
 	mentions = deduplicateMentions(mentions)
 	return sb.String(), mentions

--- a/internal/app/usecase/weekly_hunter_ranks_announcement_usecase.go
+++ b/internal/app/usecase/weekly_hunter_ranks_announcement_usecase.go
@@ -69,6 +69,7 @@ func (u *WeeklyHunterRanksAnnouncementUsecase) Execute(ctx context.Context, now 
 	}
 
 	sb.WriteString("\nTetap konsisten berlatih untuk menaikkan rank-mu! Semangat🔥")
+	sb.WriteString("\n\n🌐 Lihat klasemen & stats: https://lapor-bot.web.id/")
 
 	return sb.String(), nil
 }


### PR DESCRIPTION
- Remove numerous in-bot commands, consolidating them into a single web portal link for cleaner UX.
- Direct users to the web portal (https://lapor-bot.web.id/) for detailed stats, leaderboards, and gamification features.
- Provide a default fallback message for unrecognized commands, guiding users to  or the web portal.