### PR TITLE
feat(leaderboard): add weekly activity and progress bars

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { StatsOverview } from './components/StatsOverview';
 import { LeaderboardTable } from './components/LeaderboardTable';
 import { HunterCard } from './components/HunterCard';
 import { ProfileModal } from './components/ProfileModal';
+import { MotivationBanner } from './components/MotivationBanner';
 
 const PAGE_SIZE = 15;
 type Theme = 'light' | 'dark';
@@ -181,6 +182,8 @@ function App() {
 
         {/* Stats Section */}
         <StatsOverview summary={summary} loading={loading} />
+
+        {!loading && !error && hunters.length > 0 && <MotivationBanner />}
 
         {/* Dynamic Display Area */}
         {loading ? (

--- a/frontend/src/components/LeaderboardTable.tsx
+++ b/frontend/src/components/LeaderboardTable.tsx
@@ -1,14 +1,46 @@
 import React, { useState, useMemo } from 'react';
-import { Search, SlidersHorizontal, Flame, Trophy, Award, Activity, User } from 'lucide-react';
-import type { EnrichedReport } from '../types';
+import { Search, SlidersHorizontal, Flame, Trophy, Award, User, CalendarDays } from 'lucide-react';
+import type { EnrichedReport, TierProgress } from '../types';
 
 interface LeaderboardTableProps {
   hunters: EnrichedReport[];
   onSelectHunter: (hunter: EnrichedReport) => void;
 }
 
-type TabType = 'seasonal' | 'lifetime' | 'streak';
+type TabType = 'seasonal' | 'lifetime' | 'streak' | 'week';
 const PAGE_SIZE = 15;
+
+const ProgressBar: React.FC<{ progress: TierProgress; valueLabel: string; tone?: 'gold' | 'blue' | 'red' | 'green' }> = ({
+  progress,
+  valueLabel,
+  tone = 'blue',
+}) => {
+  const gradient = {
+    gold: 'from-system-gold to-system-purple',
+    blue: 'from-system-blue to-system-purple',
+    red: 'from-system-red to-system-gold',
+    green: 'from-system-green to-system-blue',
+  }[tone];
+
+  return (
+    <div className="min-w-[180px]">
+      <div className="h-2.5 w-full rounded-full bg-gray-900 border border-gray-800 overflow-hidden">
+        <div
+          className={`h-full rounded-full bg-gradient-to-r ${gradient} transition-all duration-500`}
+          style={{ width: `${progress.percent}%` }}
+        />
+      </div>
+      <div className="mt-1 flex justify-between text-[9px] font-mono text-gray-500">
+        <span>{valueLabel}</span>
+        {progress.is_max ? (
+          <span className="text-system-gold">MAX</span>
+        ) : (
+          <span>→ {progress.next_icon} {progress.next_name} ({progress.remaining} pts)</span>
+        )}
+      </div>
+    </div>
+  );
+};
 
 export const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ hunters, onSelectHunter }) => {
   const [search, setSearch] = useState('');
@@ -54,11 +86,19 @@ export const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ hunters, onS
           return b.activity_count - a.activity_count;
         }
         return b.total_points - a.total_points;
-      } else { // activeTab === 'streak'
+      } else if (activeTab === 'streak') {
         if (b.streak === a.streak) {
-          return b.seasonal_activity_count - a.seasonal_activity_count;
+          return b.max_streak - a.max_streak;
         }
         return b.streak - a.streak;
+      } else {
+        if (b.week_active_days === a.week_active_days) {
+          if (b.streak === a.streak) {
+            return a.name.localeCompare(b.name);
+          }
+          return b.streak - a.streak;
+        }
+        return b.week_active_days - a.week_active_days;
       }
     });
 
@@ -99,12 +139,160 @@ export const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ hunters, onS
     }
   };
 
+  const getStreakStatus = (hunter: EnrichedReport) => {
+    if (hunter.days_since_last_report <= 7 && hunter.streak > 0) return '🔥 Active';
+    if (hunter.comeback_streak > 0 || hunter.days_since_last_report <= 14) return '🗡️ Comeback';
+    return '💔 Inactive';
+  };
+
+  const renderHunterCell = (hunter: EnrichedReport) => (
+    <td className="py-4 pl-4 align-middle">
+      <div className="flex items-center gap-2">
+        <div className="relative">
+          <div className="w-8 h-8 rounded-full bg-gray-900 flex items-center justify-center border border-gray-800 group-hover:border-system-blue transition-colors">
+            <User size={14} className="text-gray-400" />
+          </div>
+          {hunter.is_active_today && (
+            <span className="absolute bottom-0 right-0 w-2.5 h-2.5 bg-system-green border-2 border-dark-bg rounded-full animate-pulse"></span>
+          )}
+        </div>
+        <div>
+          <div className="text-sm font-semibold text-white group-hover:text-system-blue transition-colors">
+            {hunter.name}
+          </div>
+          <div className="text-[10px] text-gray-500 font-mono">{hunter.user_id}</div>
+        </div>
+      </div>
+    </td>
+  );
+
+  const renderJobCell = (hunter: EnrichedReport) => (
+    <td className="py-4 pl-4 align-middle">
+      <span className={`text-xs px-2.5 py-1 rounded-md border font-mono ${getJobBadgeClass(hunter.job_class)}`}>
+        {hunter.job_icon} {hunter.job_name}
+      </span>
+    </td>
+  );
+
+  const renderStreak = (weeks: number) => (
+    <span className="flex items-center justify-center gap-1 text-system-red font-mono">
+      <Flame size={14} />
+      <span className="font-bold">{weeks}</span>
+      <span className="text-[10px] text-gray-500">minggu</span>
+    </span>
+  );
+
+  const renderWeekDots = (hunter: EnrichedReport) => (
+    <div className="flex justify-center gap-1" aria-label={`${hunter.week_active_days} dari 7 hari aktif minggu ini`}>
+      {hunter.week_activity.map((active, idx) => (
+        <span
+          key={`${hunter.user_id}-week-${idx}`}
+          className={`h-3 w-3 rounded-sm border ${active ? 'bg-system-green border-system-green/60 shadow-neon-purple' : 'bg-gray-900 border-gray-800'}`}
+          title={active ? 'Aktif' : 'Belum aktif'}
+        />
+      ))}
+    </div>
+  );
+
+  const renderRows = () => visibleHunters.map((hunter, idx) => {
+    const rank = pageStartRank + idx;
+    const rowClass = `group transition-all hover:bg-gray-800/20 cursor-pointer ${
+      rank < 3 ? 'bg-gradient-to-r from-gray-950/20 to-transparent' : ''
+    }`;
+
+    if (activeTab === 'seasonal') {
+      return (
+        <tr key={hunter.user_id} onClick={() => onSelectHunter(hunter)} className={rowClass}>
+          <td className="py-4 pl-4 text-center font-mono align-middle"><div className="flex justify-center">{getRankBadge(rank)}</div></td>
+          {renderHunterCell(hunter)}
+          {renderJobCell(hunter)}
+          <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-white">
+            <span className="font-bold">{hunter.rank_icon} {hunter.rank_name}</span>
+          </td>
+          <td className="py-4 pl-4 text-center align-middle text-sm">{renderStreak(hunter.streak)}</td>
+          <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+            <span className="font-bold">{hunter.seasonal_activity_count}</span>
+            <span className="text-[10px] text-gray-500"> hari / season ini</span>
+          </td>
+          <td className="py-4 pl-4 pr-4 align-middle">
+            <ProgressBar progress={hunter.season_rank_progress} valueLabel={`${hunter.seasonal_points} season pts`} tone="gold" />
+          </td>
+        </tr>
+      );
+    }
+
+    if (activeTab === 'lifetime') {
+      return (
+        <tr key={hunter.user_id} onClick={() => onSelectHunter(hunter)} className={rowClass}>
+          <td className="py-4 pl-4 text-center font-mono align-middle"><div className="flex justify-center">{getRankBadge(rank)}</div></td>
+          {renderHunterCell(hunter)}
+          {renderJobCell(hunter)}
+          <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-white">
+            <span className="font-bold">{hunter.level_icon} {hunter.level_name}</span>
+          </td>
+          <td className="py-4 pl-4 text-center font-mono align-middle text-sm text-gray-300">
+            <span className="font-bold">Lv.{hunter.level}</span>
+          </td>
+          <td className="py-4 pl-4 align-middle">
+            <ProgressBar progress={hunter.level_tier_progress} valueLabel={`${hunter.total_points} lifetime XP`} tone="blue" />
+          </td>
+          <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+            <span className="font-bold">{hunter.activity_count}</span>
+            <span className="text-[10px] text-gray-500"> hari lifetime</span>
+          </td>
+          <td className="py-4 pl-4 text-center align-middle text-sm pr-4">{renderStreak(hunter.max_streak)}</td>
+        </tr>
+      );
+    }
+
+    if (activeTab === 'streak') {
+      return (
+        <tr key={hunter.user_id} onClick={() => onSelectHunter(hunter)} className={rowClass}>
+          <td className="py-4 pl-4 text-center font-mono align-middle"><div className="flex justify-center">{getRankBadge(rank)}</div></td>
+          {renderHunterCell(hunter)}
+          {renderJobCell(hunter)}
+          <td className="py-4 pl-4 text-center align-middle text-sm">{renderStreak(hunter.streak)}</td>
+          <td className="py-4 pl-4 text-center align-middle text-sm">{renderStreak(hunter.max_streak)}</td>
+          <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+            <span className="font-bold">{hunter.activity_count}</span>
+            <span className="text-[10px] text-gray-500"> hari lifetime</span>
+          </td>
+          <td className="py-4 pl-4 text-center align-middle font-mono text-sm pr-4 text-gray-300">{getStreakStatus(hunter)}</td>
+        </tr>
+      );
+    }
+
+    return (
+      <tr key={hunter.user_id} onClick={() => onSelectHunter(hunter)} className={rowClass}>
+        <td className="py-4 pl-4 text-center font-mono align-middle"><div className="flex justify-center">{getRankBadge(rank)}</div></td>
+        {renderHunterCell(hunter)}
+        {renderJobCell(hunter)}
+        <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+          <span className="font-bold">{hunter.week_active_days}</span>
+          <span className="text-[10px] text-gray-500"> / 7 hari minggu ini</span>
+        </td>
+        <td className="py-4 pl-4 text-center align-middle">{renderWeekDots(hunter)}</td>
+        <td className="py-4 pl-4 text-center align-middle text-sm">{renderStreak(hunter.streak)}</td>
+        <td className="py-4 pl-4 text-right pr-4 font-mono font-bold align-middle text-system-gold">
+          {hunter.estimated_weekly_points} <span className="text-[9px] text-gray-500">PTS estimasi</span>
+        </td>
+      </tr>
+    );
+  });
+
+  const tableHeaders = {
+    seasonal: ['Rank', 'Hunter', 'Job', 'Season Rank', 'Streak (minggu)', 'Active Days (season ini)', 'Season Points + Progress'],
+    lifetime: ['Rank', 'Hunter', 'Job', 'Level Tier (lifetime)', 'Level Numeric', 'XP Progress ke Tier Berikutnya', 'Total Hari (lifetime)', 'Best Streak (minggu)'],
+    streak: ['Rank', 'Hunter', 'Job', 'Current Streak (minggu)', 'Best Streak (minggu)', 'Lifetime Days', 'Status'],
+    week: ['Rank', 'Hunter', 'Job', 'Hari Aktif Minggu Ini', 'Activity Dots (7 hari)', 'Streak (minggu)', 'PTS Estimasi'],
+  }[activeTab];
+
   return (
     <div className="glass rounded-3xl p-5 md:p-6 mb-8">
       {/* Top Controls: Tabs and Filters */}
       <div className="flex flex-col lg:flex-row gap-4 items-stretch lg:items-center justify-between mb-6 border-b border-gray-850 pb-5">
         {/* Leaderboard Mode Tabs */}
-        <div className="flex bg-gray-950/80 p-1.5 rounded-xl border border-gray-800/60 max-w-fit">
+        <div className="flex flex-wrap bg-gray-950/80 p-1.5 rounded-xl border border-gray-800/60 max-w-fit">
           <button
             onClick={() => {
               setActiveTab('seasonal');
@@ -117,7 +305,7 @@ export const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ hunters, onS
             }`}
           >
             <Trophy size={14} />
-            Season Ranks
+            Season Rank
           </button>
           <button
             onClick={() => {
@@ -146,6 +334,20 @@ export const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ hunters, onS
           >
             <Flame size={14} />
             Streak Masters
+          </button>
+          <button
+            onClick={() => {
+              setActiveTab('week');
+              setPage(1);
+            }}
+            className={`flex items-center gap-2 px-4 py-2 rounded-lg text-xs font-bold font-orbitron tracking-wider transition-all uppercase ${
+              activeTab === 'week'
+                ? 'bg-gradient-to-r from-system-purple to-system-blue text-white shadow-neon-blue'
+                : 'text-gray-400 hover:text-white'
+            }`}
+          >
+            <CalendarDays size={14} />
+            Minggu Ini
           </button>
         </div>
 
@@ -189,106 +391,25 @@ export const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ hunters, onS
 
       {/* Table Renders */}
       <div className="overflow-x-auto">
-        <table className="w-full min-w-[700px] border-collapse">
+        <table className="w-full min-w-[860px] border-collapse">
           <thead>
             <tr className="border-b border-gray-850 text-left text-gray-500 text-[10px] font-mono font-bold tracking-widest uppercase">
-              <th className="pb-3 pl-4 w-12 text-center">Rank</th>
-              <th className="pb-3 pl-4">Hunter</th>
-              <th className="pb-3 pl-4">Job Class</th>
-              <th className="pb-3 pl-4 text-center">Level</th>
-              <th className="pb-3 pl-4 text-center">Streak</th>
-              <th className="pb-3 pl-4 text-center">Active Days</th>
-              <th className="pb-3 pl-4 text-right pr-4">
-                {activeTab === 'seasonal' ? 'Season Points' : activeTab === 'lifetime' ? 'Total XP' : 'Current Streak'}
-              </th>
+              {tableHeaders.map((header, idx) => (
+                <th key={header} className={`pb-3 pl-4 ${idx === 0 ? 'w-12 text-center' : ''} ${idx >= 3 && idx !== tableHeaders.length - 1 ? 'text-center' : ''} ${idx === tableHeaders.length - 1 ? 'text-right pr-4' : ''}`}>
+                  {header}
+                </th>
+              ))}
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-900/60">
             {filteredAndSorted.length === 0 ? (
               <tr>
-                <td colSpan={7} className="py-8 text-center text-xs text-gray-500 font-mono italic">
+                <td colSpan={tableHeaders.length} className="py-8 text-center text-xs text-gray-500 font-mono italic">
                   No active hunters match the filters.
                 </td>
               </tr>
             ) : (
-              visibleHunters.map((hunter, idx) => {
-                const rank = pageStartRank + idx;
-                return (
-                <tr
-                  key={hunter.user_id}
-                  onClick={() => onSelectHunter(hunter)}
-                  className={`group transition-all hover:bg-gray-800/20 cursor-pointer ${
-                    rank < 3 ? 'bg-gradient-to-r from-gray-950/20 to-transparent' : ''
-                  }`}
-                >
-                  {/* Rank */}
-                  <td className="py-4 pl-4 text-center font-mono align-middle">
-                    <div className="flex justify-center">{getRankBadge(rank)}</div>
-                  </td>
-
-                  {/* Name */}
-                  <td className="py-4 pl-4 align-middle">
-                    <div className="flex items-center gap-2">
-                      <div className="relative">
-                        <div className="w-8 h-8 rounded-full bg-gray-900 flex items-center justify-center border border-gray-800 group-hover:border-system-blue transition-colors">
-                          <User size={14} className="text-gray-400" />
-                        </div>
-                        {hunter.is_active_today && (
-                          <span className="absolute bottom-0 right-0 w-2.5 h-2.5 bg-system-green border-2 border-dark-bg rounded-full animate-pulse"></span>
-                        )}
-                      </div>
-                      <div>
-                        <div className="text-sm font-semibold text-white group-hover:text-system-blue transition-colors">
-                          {hunter.name}
-                        </div>
-                        <div className="text-[10px] text-gray-500 font-mono">{hunter.user_id}</div>
-                      </div>
-                    </div>
-                  </td>
-
-                  {/* Job Class */}
-                  <td className="py-4 pl-4 align-middle">
-                    <span className={`text-xs px-2.5 py-1 rounded-md border font-mono ${getJobBadgeClass(hunter.job_class)}`}>
-                      {hunter.job_icon} {hunter.job_name}
-                    </span>
-                  </td>
-
-                  {/* Level */}
-                  <td className="py-4 pl-4 text-center font-mono align-middle text-sm text-gray-300">
-                    <span className="font-bold">Lv.{hunter.level}</span>
-                  </td>
-
-                  {/* Streak */}
-                  <td className="py-4 pl-4 text-center align-middle font-mono text-sm">
-                    <span className="flex items-center justify-center gap-1 text-system-red">
-                      <Flame size={14} />
-                      <span className="font-bold">{hunter.streak}</span>
-                      <span className="text-[10px] text-gray-500">w</span>
-                    </span>
-                  </td>
-
-                  {/* Active Days */}
-                  <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
-                    <span className="flex items-center justify-center gap-1">
-                      <Activity size={12} className="text-system-blue" />
-                      <span className="font-bold">{hunter.seasonal_activity_count}</span>
-                      <span className="text-[10px] text-gray-500">d</span>
-                    </span>
-                  </td>
-
-                  {/* Sort Target Value */}
-                  <td className="py-4 pl-4 text-right pr-4 font-mono font-bold align-middle">
-                    {activeTab === 'seasonal' ? (
-                      <span className="text-system-gold">{hunter.seasonal_points} <span className="text-[9px] text-gray-500">PTS</span></span>
-                    ) : activeTab === 'lifetime' ? (
-                      <span className="text-system-blue">{hunter.total_points} <span className="text-[9px] text-gray-500">XP</span></span>
-                    ) : (
-                      <span className="text-system-red">{hunter.streak} <span className="text-[9px] text-gray-500">WEEKS</span></span>
-                    )}
-                  </td>
-                </tr>
-                );
-              })
+              renderRows()
             )}
           </tbody>
         </table>

--- a/frontend/src/components/MotivationBanner.tsx
+++ b/frontend/src/components/MotivationBanner.tsx
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+import { Sparkles } from 'lucide-react';
+
+export function MotivationBanner() {
+  const [quote, setQuote] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/motivation')
+      .then((res) => res.json())
+      .then((data) => {
+        if (!cancelled && data.quote) setQuote(data.quote);
+      })
+      .catch(() => {
+        if (!cancelled) setQuote(null);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (!quote) return null;
+
+  return (
+    <div className="mb-6 px-5 py-4 glass rounded-2xl border border-system-green/20 flex items-center gap-3">
+      <Sparkles className="text-system-gold shrink-0" size={18} />
+      <p className="text-sm text-gray-300 font-medium italic">
+        &ldquo;{quote}&rdquo;
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5,6 +5,17 @@ export interface NumericLevelProgress {
   TotalPoints: number;
 }
 
+export interface TierProgress {
+  current_min: number;
+  next_min: number;
+  value: number;
+  percent: number;
+  remaining: number;
+  next_name: string;
+  next_icon: string;
+  is_max: boolean;
+}
+
 export interface EnrichedReport {
   user_id: string;
   name: string;
@@ -22,9 +33,11 @@ export interface EnrichedReport {
   level_name: string;
   level_icon: string;
   xp_progress: NumericLevelProgress;
+  level_tier_progress: TierProgress;
   achievements: string[];
   comeback_streak: number;
   inactive_days: number;
+  days_since_last_report: number;
   centurion_cycles: number;
   seasonal_points: number;
   seasonal_activity_count: number;
@@ -40,6 +53,10 @@ export interface EnrichedReport {
   vit: number;
   rank_name: string;
   rank_icon: string;
+  season_rank_progress: TierProgress;
+  week_active_days: number;
+  week_activity: boolean[];
+  estimated_weekly_points: number;
   is_active_today: boolean;
 }
 

--- a/internal/domain/level.go
+++ b/internal/domain/level.go
@@ -84,19 +84,19 @@ func NumericLevelFromTotalPoints(totalPoints int) int {
 	return GetNumericLevelProgress(totalPoints).Level
 }
 
-// AllLevels defines the progression tiers in ascending order.
-// Curved to reward early engagement while making max tier a long-term achievement.
-// With ~17 weeks per 4-month season, dedicated users can reach Tier 5-6 in season 1,
-// Tier 7 in season 2-3, and Tier 8 in season 4+.
+// AllLevels defines lifetime progression tiers in ascending order.
+// Lifetime points never reset, so upper tiers are intentionally long-term goals
+// across many seasons instead of single-season finish lines.
 var AllLevels = []Level{
 	{Tier: 1, Name: "Newbie", Icon: "🌱", MinPoints: 0},
 	{Tier: 2, Name: "Fighter", Icon: "💪", MinPoints: 50},
-	{Tier: 3, Name: "Warrior", Icon: "⚔️", MinPoints: 120},
-	{Tier: 4, Name: "Champion", Icon: "🏆", MinPoints: 250},
-	{Tier: 5, Name: "Legend", Icon: "👑", MinPoints: 500},
-	{Tier: 6, Name: "Immortal", Icon: "🔱", MinPoints: 1000},
-	{Tier: 7, Name: "Titan", Icon: "⭐", MinPoints: 2000},
-	{Tier: 8, Name: "God", Icon: "⚡", MinPoints: 3500},
+	{Tier: 3, Name: "Warrior", Icon: "⚔️", MinPoints: 200},
+	{Tier: 4, Name: "Champion", Icon: "🏆", MinPoints: 500},
+	{Tier: 5, Name: "Legend", Icon: "👑", MinPoints: 1000},
+	{Tier: 6, Name: "Immortal", Icon: "🔱", MinPoints: 2500},
+	{Tier: 7, Name: "Titan", Icon: "⭐", MinPoints: 5000},
+	{Tier: 8, Name: "God", Icon: "⚡", MinPoints: 10000},
+	{Tier: 9, Name: "Cosmic", Icon: "🌌", MinPoints: 20000},
 }
 
 // AllSeasonRanks defines rank titles for the current season only.
@@ -180,6 +180,16 @@ func GetNextLevel(totalPoints int) (*Level, int) {
 	return nil, 0
 }
 
+// GetNextSeasonRank returns the next season rank and missing seasonal points, or nil at max rank.
+func GetNextSeasonRank(seasonalPoints int) (*Rank, int) {
+	for _, r := range AllSeasonRanks {
+		if seasonalPoints < r.MinPoints {
+			return &r, r.MinPoints - seasonalPoints
+		}
+	}
+	return nil, 0
+}
+
 // FormatLevel returns a display string like "Fighter 💪"
 func FormatLevel(totalPoints int) string {
 	lvl := GetLevel(totalPoints)
@@ -191,7 +201,8 @@ func FormatLevel(totalPoints int) string {
 func FormatProgressBar(totalPoints int) string {
 	next, _ := GetNextLevel(totalPoints)
 	if next == nil {
-		return "MAX LEVEL! 🔱"
+		current := GetLevel(totalPoints)
+		return fmt.Sprintf("MAX LEVEL! %s", current.Icon)
 	}
 
 	current := GetLevel(totalPoints)

--- a/internal/domain/level_test.go
+++ b/internal/domain/level_test.go
@@ -1,0 +1,51 @@
+package domain
+
+import "testing"
+
+func TestGetLevel_UsesLongTermLifetimeThresholds(t *testing.T) {
+	tests := []struct {
+		points int
+		name   string
+	}{
+		{points: 0, name: "Newbie"},
+		{points: 50, name: "Fighter"},
+		{points: 199, name: "Fighter"},
+		{points: 200, name: "Warrior"},
+		{points: 499, name: "Warrior"},
+		{points: 500, name: "Champion"},
+		{points: 999, name: "Champion"},
+		{points: 1000, name: "Legend"},
+		{points: 2499, name: "Legend"},
+		{points: 2500, name: "Immortal"},
+		{points: 3500, name: "Immortal"},
+		{points: 4999, name: "Immortal"},
+		{points: 5000, name: "Titan"},
+		{points: 9999, name: "Titan"},
+		{points: 10000, name: "God"},
+		{points: 19999, name: "God"},
+		{points: 20000, name: "Cosmic"},
+	}
+
+	for _, tt := range tests {
+		if got := GetLevel(tt.points).Name; got != tt.name {
+			t.Fatalf("GetLevel(%d) = %q, want %q", tt.points, got, tt.name)
+		}
+	}
+}
+
+func TestGetNextLevel_ReturnsNilAtMaxLifetimeTier(t *testing.T) {
+	next, remaining := GetNextLevel(20000)
+	if next != nil || remaining != 0 {
+		t.Fatalf("GetNextLevel(20000) = %+v, %d; want nil, 0", next, remaining)
+	}
+}
+
+func TestGetNextSeasonRank_UsesSeasonThresholds(t *testing.T) {
+	next, remaining := GetNextSeasonRank(915)
+	if next == nil {
+		t.Fatal("expected next season rank")
+	}
+	if next.Name != "S-Rank Hunter" || remaining != 85 {
+		t.Fatalf("next rank = %s, remaining = %d; want S-Rank Hunter, 85", next.Name, remaining)
+	}
+}

--- a/internal/infra/http/handler.go
+++ b/internal/infra/http/handler.go
@@ -43,6 +43,7 @@ func (s *Server) RegisterHandlers(mux *http.ServeMux) {
 	mux.HandleFunc("/strava/webhook", s.HandleStravaWebhook)
 	mux.HandleFunc("/api/leaderboard", s.HandleLeaderboard)
 	mux.HandleFunc("/api/summary", s.HandleSummary)
+	mux.HandleFunc("/api/motivation", s.HandleMotivation)
 	mux.HandleFunc("/", s.HandleStatic)
 }
 
@@ -148,9 +149,11 @@ type EnrichedReport struct {
 	LevelName             string                      `json:"level_name"`
 	LevelIcon             string                      `json:"level_icon"`
 	XPProgress            domain.NumericLevelProgress `json:"xp_progress"`
+	LevelTierProgress     TierProgress                `json:"level_tier_progress"`
 	Achievements          []string                    `json:"achievements"`
 	ComebackStreak        int                         `json:"comeback_streak"`
 	InactiveDays          int                         `json:"inactive_days"`
+	DaysSinceLastReport   int                         `json:"days_since_last_report"`
 	CenturionCycles       int                         `json:"centurion_cycles"`
 	SeasonalPoints        int                         `json:"seasonal_points"`
 	SeasonalActivityCount int                         `json:"seasonal_activity_count"`
@@ -166,7 +169,23 @@ type EnrichedReport struct {
 	Vit                   int                         `json:"vit"`
 	RankName              string                      `json:"rank_name"`
 	RankIcon              string                      `json:"rank_icon"`
+	SeasonRankProgress    TierProgress                `json:"season_rank_progress"`
+	WeekActiveDays        int                         `json:"week_active_days"`
+	WeekActivity          []bool                      `json:"week_activity"`
+	EstimatedWeeklyPoints int                         `json:"estimated_weekly_points"`
 	IsActiveToday         bool                        `json:"is_active_today"`
+}
+
+// TierProgress is precomputed for the web UI so templates/components only render it.
+type TierProgress struct {
+	CurrentMin int    `json:"current_min"`
+	NextMin    int    `json:"next_min"`
+	Value      int    `json:"value"`
+	Percent    int    `json:"percent"`
+	Remaining  int    `json:"remaining"`
+	NextName   string `json:"next_name"`
+	NextIcon   string `json:"next_icon"`
+	IsMax      bool   `json:"is_max"`
 }
 
 // GlobalSummary holds aggregated dashboard data.
@@ -186,7 +205,76 @@ func maskPhone(phone string) string {
 	return phone[:5] + "****" + phone[len(phone)-3:]
 }
 
-func enrichReport(r *domain.Report) EnrichedReport {
+func buildTierProgress(value, currentMin int, nextMin int, nextName, nextIcon string, isMax bool) TierProgress {
+	progress := TierProgress{
+		CurrentMin: currentMin,
+		NextMin:    nextMin,
+		Value:      value,
+		Percent:    100,
+		NextName:   nextName,
+		NextIcon:   nextIcon,
+		IsMax:      isMax,
+	}
+	if isMax {
+		return progress
+	}
+
+	progress.Remaining = nextMin - value
+	if progress.Remaining < 0 {
+		progress.Remaining = 0
+	}
+
+	rangeTotal := nextMin - currentMin
+	if rangeTotal <= 0 {
+		return progress
+	}
+	percent := ((value - currentMin) * 100) / rangeTotal
+	if percent < 0 {
+		percent = 0
+	}
+	if percent > 100 {
+		percent = 100
+	}
+	progress.Percent = percent
+	return progress
+}
+
+func buildLevelTierProgress(totalPoints int, level domain.Level) TierProgress {
+	next, _ := domain.GetNextLevel(totalPoints)
+	if next == nil {
+		return buildTierProgress(totalPoints, level.MinPoints, level.MinPoints, "", "", true)
+	}
+	return buildTierProgress(totalPoints, level.MinPoints, next.MinPoints, next.Name, next.Icon, false)
+}
+
+func buildSeasonRankProgress(seasonalPoints int, rank domain.Rank) TierProgress {
+	next, _ := domain.GetNextSeasonRank(seasonalPoints)
+	if next == nil {
+		return buildTierProgress(seasonalPoints, rank.MinPoints, rank.MinPoints, "", "", true)
+	}
+	return buildTierProgress(seasonalPoints, rank.MinPoints, next.MinPoints, next.Name, next.Icon, false)
+}
+
+func buildWeekActivity(activityDates []time.Time, weekStart time.Time) ([]bool, int) {
+	activeDates := make(map[string]bool, len(activityDates))
+	for _, date := range activityDates {
+		activeDates[date.Format(time.DateOnly)] = true
+	}
+
+	activity := make([]bool, 7)
+	activeDays := 0
+	for i := range activity {
+		date := weekStart.AddDate(0, 0, i)
+		active := activeDates[date.Format(time.DateOnly)]
+		activity[i] = active
+		if active {
+			activeDays++
+		}
+	}
+	return activity, activeDays
+}
+
+func enrichReport(r *domain.Report, today time.Time, weekActivity []bool, weekActiveDays int) EnrichedReport {
 	xpProg := domain.GetNumericLevelProgress(r.TotalPoints)
 	lvl := domain.GetLevel(r.TotalPoints)
 	rank := domain.GetSeasonRank(r.SeasonalPoints)
@@ -222,10 +310,12 @@ func enrichReport(r *domain.Report) EnrichedReport {
 		}
 	}
 
-	now := time.Now()
-	today := domain.GetToday(now)
 	lastReportDay := domain.GetToday(r.LastReportDate)
 	isActiveToday := today.Equal(lastReportDay)
+	daysSinceLastReport := int(today.Sub(lastReportDay).Hours() / 24)
+	if daysSinceLastReport < 0 {
+		daysSinceLastReport = 0
+	}
 
 	return EnrichedReport{
 		UserID:                maskPhone(r.UserID),
@@ -244,9 +334,11 @@ func enrichReport(r *domain.Report) EnrichedReport {
 		LevelName:             lvl.Name,
 		LevelIcon:             lvl.Icon,
 		XPProgress:            xpProg,
+		LevelTierProgress:     buildLevelTierProgress(r.TotalPoints, lvl),
 		Achievements:          achs,
 		ComebackStreak:        r.ComebackStreak,
 		InactiveDays:          r.InactiveDays,
+		DaysSinceLastReport:   daysSinceLastReport,
 		CenturionCycles:       r.CenturionCycles,
 		SeasonalPoints:        r.SeasonalPoints,
 		SeasonalActivityCount: r.SeasonalActivityCount,
@@ -262,6 +354,10 @@ func enrichReport(r *domain.Report) EnrichedReport {
 		Vit:                   r.Vit,
 		RankName:              rank.Name,
 		RankIcon:              rank.Icon,
+		SeasonRankProgress:    buildSeasonRankProgress(r.SeasonalPoints, rank),
+		WeekActiveDays:        weekActiveDays,
+		WeekActivity:          weekActivity,
+		EstimatedWeeklyPoints: weekActiveDays * 10,
 		IsActiveToday:         isActiveToday,
 	}
 }
@@ -290,8 +386,17 @@ func (s *Server) HandleLeaderboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var enriched []EnrichedReport
+	now := time.Now()
+	today := domain.GetToday(now)
+	weekStart := domain.GetStartOfISOWeekStrict(now)
 	for _, rep := range reports {
-		enriched = append(enriched, enrichReport(rep))
+		activityDates, err := s.repo.GetUserActivityDates(r.Context(), rep.UserID)
+		if err != nil {
+			s.writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		weekActivity, weekActiveDays := buildWeekActivity(activityDates, weekStart)
+		enriched = append(enriched, enrichReport(rep, today, weekActivity, weekActiveDays))
 	}
 
 	s.writeJSON(w, http.StatusOK, enriched)
@@ -352,6 +457,14 @@ func (s *Server) HandleSummary(w http.ResponseWriter, r *http.Request) {
 	s.writeJSON(w, http.StatusOK, summary)
 }
 
+func (s *Server) HandleMotivation(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		s.writeJSON(w, http.StatusNoContent, nil)
+		return
+	}
+	s.writeJSON(w, http.StatusOK, map[string]string{"quote": usecase.RandomQuote()})
+}
+
 func (s *Server) HandleStatic(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodOptions {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -374,4 +487,3 @@ func (s *Server) HandleStatic(w http.ResponseWriter, r *http.Request) {
 
 	http.ServeFile(w, r, fullPath)
 }
-


### PR DESCRIPTION
- introduce a new  tab to the leaderboard, showing weekly activity dots and estimated points
- implement progress bars for  and  with  interface
- refine lifetime level thresholds and introduce a new  tier
- integrate  for conditional display in the main application layout