### PR TITLE
feat(auth): implement personal user page and login

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,17 @@
 import { useState, useEffect, useMemo } from 'react';
-import { LayoutGrid, Table2, RefreshCw, AlertCircle, ShieldAlert, HeartPulse, Sun, Moon } from 'lucide-react';
+import { LayoutGrid, Table2, RefreshCw, AlertCircle, ShieldAlert, HeartPulse, Sun, Moon, LogIn } from 'lucide-react';
 import type { EnrichedReport, GlobalSummary } from './types';
 import { StatsOverview } from './components/StatsOverview';
 import { LeaderboardTable } from './components/LeaderboardTable';
 import { HunterCard } from './components/HunterCard';
 import { ProfileModal } from './components/ProfileModal';
 import { MotivationBanner } from './components/MotivationBanner';
+import { LoginPage } from './components/LoginPage';
+import { PersonalPage } from './components/PersonalPage';
 
 const PAGE_SIZE = 15;
 type Theme = 'light' | 'dark';
+type Page = 'dashboard' | 'login' | 'personal';
 
 function getInitialTheme(): Theme {
   if (typeof document === 'undefined') return 'dark';
@@ -25,6 +28,8 @@ function App() {
   const [viewMode, setViewMode] = useState<'table' | 'cards'>('table');
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
   const [cardPage, setCardPage] = useState(1);
+  const [page, setPage] = useState<Page>('dashboard');
+  const [personalUser, setPersonalUser] = useState<EnrichedReport | null>(null);
 
   const seasonTitle = summary
     ? `SWEG Healthy Club - Season ${summary.current_season}`
@@ -149,6 +154,15 @@ function App() {
           </button>
 
           <button
+            type="button"
+            onClick={() => setPage('login')}
+            className="flex items-center gap-2 px-3 py-2 rounded-xl bg-system-blue/10 hover:bg-system-blue/20 border border-system-blue/30 font-mono text-xs text-system-blue hover:text-white transition-colors"
+          >
+            <LogIn size={14} />
+            Masuk
+          </button>
+
+          <button
             onClick={() => fetchData(true)}
             disabled={loading || refreshing}
             className="flex items-center gap-2 px-4.5 py-2 rounded-xl bg-gray-950 hover:bg-gray-900 border border-gray-800 font-mono text-xs text-gray-300 hover:text-white transition-colors disabled:opacity-50"
@@ -161,88 +175,112 @@ function App() {
 
       {/* Main Content Dashboard Frame */}
       <main className="max-w-7xl mx-auto">
-        {/* Error Alert panel */}
-        {error && (
-          <div className="mb-6 p-4.5 rounded-2xl bg-system-red/10 border border-system-red/35 flex items-start gap-3 text-sm text-red-300">
-            <AlertCircle className="text-system-red mt-0.5 shrink-0" size={18} />
-            <div>
-              <p className="font-bold font-mono uppercase text-xs tracking-wider text-system-red">
-                System Link Disrupted
-              </p>
-              <p className="mt-1 text-xs font-mono">{error}</p>
-              <button
-                onClick={() => fetchData()}
-                className="mt-3 text-xs font-bold text-white hover:underline uppercase tracking-wide block font-mono"
-              >
-                Reconnect System Core
-              </button>
-            </div>
-          </div>
+        {page === 'login' && (
+          <LoginPage
+            onLoginSuccess={(user) => {
+              setPersonalUser(user);
+              setPage('personal');
+            }}
+            onBack={() => setPage('dashboard')}
+          />
         )}
 
-        {/* Stats Section */}
-        <StatsOverview summary={summary} loading={loading} />
+        {page === 'personal' && personalUser && (
+          <PersonalPage
+            user={personalUser}
+            onLogout={() => {
+              setPersonalUser(null);
+              setPage('dashboard');
+            }}
+          />
+        )}
 
-        {!loading && !error && hunters.length > 0 && <MotivationBanner />}
-
-        {/* Dynamic Display Area */}
-        {loading ? (
-          <div className="py-20 flex flex-col items-center justify-center">
-            <div className="relative w-16 h-16">
-              <div className="absolute inset-0 rounded-full border-4 border-gray-800"></div>
-              <div className="absolute inset-0 rounded-full border-4 border-t-system-blue border-r-transparent border-b-transparent border-l-transparent animate-spin"></div>
-            </div>
-            <p className="text-xs text-gray-400 mt-6 font-mono tracking-widest uppercase animate-pulse">
-              Retrieving Hunter Status...
-            </p>
-          </div>
-        ) : hunters.length === 0 ? (
-          <div className="glass rounded-3xl p-16 text-center border border-gray-800">
-            <ShieldAlert className="text-system-gold mx-auto mb-4 animate-bounce" size={40} />
-            <h3 className="text-lg font-bold text-white font-orbitron">No Roster Registered</h3>
-            <p className="text-xs text-gray-500 font-mono mt-2 max-w-sm mx-auto">
-              The database does not contain any active reports yet. Have members submit a workout report using "#lapor" on WhatsApp!
-            </p>
-          </div>
-        ) : viewMode === 'table' ? (
-          <LeaderboardTable hunters={hunters} onSelectHunter={setSelectedHunter} />
-        ) : (
+        {page === 'dashboard' && (
           <>
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
-              {visibleCardHunters.map((hunter) => (
-                <HunterCard
-                  key={hunter.user_id}
-                  hunter={hunter}
-                  onClick={() => setSelectedHunter(hunter)}
-                />
-              ))}
-            </div>
-            <nav className="mt-6 flex flex-col sm:flex-row items-center justify-between gap-3 glass rounded-2xl p-4" aria-label="Card pagination">
-              <p className="text-xs text-gray-500 font-mono uppercase tracking-wider">
-                Showing {visibleCardHunters.length === 0 ? 0 : (safeCardPage - 1) * PAGE_SIZE + 1}-{Math.min(safeCardPage * PAGE_SIZE, hunters.length)} of {hunters.length}
-              </p>
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  onClick={() => goToCardPage(safeCardPage - 1)}
-                  disabled={safeCardPage <= 1}
-                  className="px-3 py-2 rounded-xl bg-gray-950 border border-gray-800 text-xs font-mono text-gray-300 disabled:opacity-40 hover:text-white transition-colors"
-                >
-                  Previous
-                </button>
-                <span className="px-3 py-2 text-xs font-mono text-gray-500">
-                  Page {safeCardPage} / {cardTotalPages}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => goToCardPage(safeCardPage + 1)}
-                  disabled={safeCardPage >= cardTotalPages}
-                  className="px-3 py-2 rounded-xl bg-gray-950 border border-gray-800 text-xs font-mono text-gray-300 disabled:opacity-40 hover:text-white transition-colors"
-                >
-                  Next
-                </button>
+            {/* Error Alert panel */}
+            {error && (
+              <div className="mb-6 p-4.5 rounded-2xl bg-system-red/10 border border-system-red/35 flex items-start gap-3 text-sm text-red-300">
+                <AlertCircle className="text-system-red mt-0.5 shrink-0" size={18} />
+                <div>
+                  <p className="font-bold font-mono uppercase text-xs tracking-wider text-system-red">
+                    System Link Disrupted
+                  </p>
+                  <p className="mt-1 text-xs font-mono">{error}</p>
+                  <button
+                    onClick={() => fetchData()}
+                    className="mt-3 text-xs font-bold text-white hover:underline uppercase tracking-wide block font-mono"
+                  >
+                    Reconnect System Core
+                  </button>
+                </div>
               </div>
-            </nav>
+            )}
+
+            {/* Stats Section */}
+            <StatsOverview summary={summary} loading={loading} />
+
+            {!loading && !error && hunters.length > 0 && <MotivationBanner />}
+
+            {/* Dynamic Display Area */}
+            {loading ? (
+              <div className="py-20 flex flex-col items-center justify-center">
+                <div className="relative w-16 h-16">
+                  <div className="absolute inset-0 rounded-full border-4 border-gray-800"></div>
+                  <div className="absolute inset-0 rounded-full border-4 border-t-system-blue border-r-transparent border-b-transparent border-l-transparent animate-spin"></div>
+                </div>
+                <p className="text-xs text-gray-400 mt-6 font-mono tracking-widest uppercase animate-pulse">
+                  Retrieving Hunter Status...
+                </p>
+              </div>
+            ) : hunters.length === 0 ? (
+              <div className="glass rounded-3xl p-16 text-center border border-gray-800">
+                <ShieldAlert className="text-system-gold mx-auto mb-4 animate-bounce" size={40} />
+                <h3 className="text-lg font-bold text-white font-orbitron">No Roster Registered</h3>
+                <p className="text-xs text-gray-500 font-mono mt-2 max-w-sm mx-auto">
+                  The database does not contain any active reports yet. Have members submit a workout report using "#lapor" on WhatsApp!
+                </p>
+              </div>
+            ) : viewMode === 'table' ? (
+              <LeaderboardTable hunters={hunters} onSelectHunter={setSelectedHunter} />
+            ) : (
+              <>
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
+                  {visibleCardHunters.map((hunter) => (
+                    <HunterCard
+                      key={hunter.user_id}
+                      hunter={hunter}
+                      onClick={() => setSelectedHunter(hunter)}
+                    />
+                  ))}
+                </div>
+                <nav className="mt-6 flex flex-col sm:flex-row items-center justify-between gap-3 glass rounded-2xl p-4" aria-label="Card pagination">
+                  <p className="text-xs text-gray-500 font-mono uppercase tracking-wider">
+                    Showing {visibleCardHunters.length === 0 ? 0 : (safeCardPage - 1) * PAGE_SIZE + 1}-{Math.min(safeCardPage * PAGE_SIZE, hunters.length)} of {hunters.length}
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => goToCardPage(safeCardPage - 1)}
+                      disabled={safeCardPage <= 1}
+                      className="px-3 py-2 rounded-xl bg-gray-950 border border-gray-800 text-xs font-mono text-gray-300 disabled:opacity-40 hover:text-white transition-colors"
+                    >
+                      Previous
+                    </button>
+                    <span className="px-3 py-2 text-xs font-mono text-gray-500">
+                      Page {safeCardPage} / {cardTotalPages}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => goToCardPage(safeCardPage + 1)}
+                      disabled={safeCardPage >= cardTotalPages}
+                      className="px-3 py-2 rounded-xl bg-gray-950 border border-gray-800 text-xs font-mono text-gray-300 disabled:opacity-40 hover:text-white transition-colors"
+                    >
+                      Next
+                    </button>
+                  </div>
+                </nav>
+              </>
+            )}
           </>
         )}
       </main>

--- a/frontend/src/components/LoginPage.tsx
+++ b/frontend/src/components/LoginPage.tsx
@@ -1,0 +1,137 @@
+import { useState, type FormEvent } from 'react';
+import { LogIn, ArrowLeft, Phone, User, AlertCircle, Loader2 } from 'lucide-react';
+import type { EnrichedReport } from '../types';
+
+interface LoginPageProps {
+  onLoginSuccess: (user: EnrichedReport) => void;
+  onBack: () => void;
+}
+
+export function LoginPage({ onLoginSuccess, onBack }: LoginPageProps) {
+  const [countryCode, setCountryCode] = useState('62');
+  const [phone, setPhone] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!countryCode || !/^\d+$/.test(countryCode)) {
+      setError('Kode negara wajib diisi (angka saja).');
+      return;
+    }
+
+    const digits = phone.replace(/\D/g, '');
+    if (!digits) {
+      setError('Nomor telepon wajib diisi.');
+      return;
+    }
+    if (digits.length < 6 || digits.length > 14) {
+      setError('Nomor harus 6-14 digit (tanpa kode negara).');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/user?phone=${countryCode}${digits}`);
+      if (res.status === 404) {
+        setError('User tidak ditemukan. Pastikan nomor sudah pernah lapor di grup.');
+        return;
+      }
+      if (!res.ok) throw new Error('Gagal menghubungi server.');
+      const data = (await res.json()) as EnrichedReport;
+      onLoginSuccess(data);
+    } catch {
+      setError('Gagal menghubungi server. Coba lagi nanti.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-[70vh] flex items-center justify-center px-4">
+      <div className="w-full max-w-md glass rounded-3xl p-8 border border-system-green/20">
+        <div className="flex items-center gap-3 mb-6">
+          <button
+            onClick={onBack}
+            className="p-2 rounded-xl bg-gray-950 hover:bg-gray-900 border border-gray-800 text-gray-400 hover:text-white transition-colors"
+            title="Kembali"
+          >
+            <ArrowLeft size={16} />
+          </button>
+          <div>
+            <h2 className="text-lg font-bold font-orbitron text-white tracking-wide flex items-center gap-2">
+              <User className="text-system-blue" size={18} />
+              Akses Personal
+            </h2>
+            <p className="text-xs text-gray-500 font-mono mt-0.5 uppercase tracking-wider">
+              Masuk dengan nomor HP yang sudah pernah lapor
+            </p>
+          </div>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-xs text-gray-400 font-mono uppercase tracking-wider mb-1.5">
+              Nomor Telepon
+            </label>
+            <div className="flex gap-2">
+              <div className="relative shrink-0">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm pointer-events-none">
+                  +
+                </span>
+                <input
+                  type="text"
+                  value={countryCode}
+                  onChange={(e) => setCountryCode(e.target.value.replace(/\D/g, ''))}
+                  placeholder="62"
+                  maxLength={3}
+                  className="w-16 pl-6 pr-2 py-2.5 rounded-xl bg-gray-950 border border-gray-800 text-white text-sm font-mono focus:outline-none focus:border-system-blue transition-colors"
+                  disabled={loading}
+                />
+              </div>
+              <div className="relative flex-1">
+                <Phone className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" size={14} />
+                <input
+                  type="text"
+                  value={phone}
+                  onChange={(e) => setPhone(e.target.value.replace(/\D/g, ''))}
+                  placeholder="8xxxxxx"
+                  maxLength={14}
+                  className="w-full pl-9 pr-3 py-2.5 rounded-xl bg-gray-950 border border-gray-800 text-white text-sm font-mono focus:outline-none focus:border-system-blue transition-colors"
+                  disabled={loading}
+                  autoFocus
+                />
+              </div>
+            </div>
+          </div>
+
+          {error && (
+            <div className="p-3 rounded-xl bg-system-red/10 border border-system-red/35 flex items-start gap-2">
+              <AlertCircle className="text-system-red mt-0.5 shrink-0" size={14} />
+              <p className="text-xs text-red-300 font-mono">{error}</p>
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full flex items-center justify-center gap-2 px-5 py-3 rounded-xl bg-system-blue/10 hover:bg-system-blue/20 border border-system-blue/30 text-system-blue font-bold font-orbitron text-sm tracking-wider uppercase transition-colors disabled:opacity-50"
+          >
+            {loading ? (
+              <Loader2 className="animate-spin" size={16} />
+            ) : (
+              <LogIn size={16} />
+            )}
+            {loading ? 'Mencari...' : 'Masuk'}
+          </button>
+        </form>
+
+        <p className="text-[10px] text-gray-600 font-mono mt-5 text-center tracking-wide uppercase">
+          Pastikan nomor HP kamu terdaftar di database laporan grup
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/PersonalPage.tsx
+++ b/frontend/src/components/PersonalPage.tsx
@@ -1,0 +1,121 @@
+import { ArrowLeft, Shield, Swords, Zap, Heart, Trophy, LogOut } from 'lucide-react';
+import type { EnrichedReport } from '../types';
+
+interface PersonalPageProps {
+  user: EnrichedReport;
+  onLogout: () => void;
+}
+
+function getRankGlow(rankName: string) {
+  if (rankName.includes('S-Rank') || rankName.includes('Monarch')) return 'glass-glow-gold';
+  if (rankName.includes('A-Rank')) return 'glass-glow-purple';
+  if (rankName.includes('B-Rank') || rankName.includes('C-Rank')) return 'glass-glow-blue';
+  return 'glass-glow-blue';
+}
+
+export function PersonalPage({ user, onLogout }: PersonalPageProps) {
+  const glowClass = getRankGlow(user.rank_name);
+
+  return (
+    <div className="min-h-[60vh] flex flex-col items-center px-4 py-8">
+      <div className="w-full max-w-2xl">
+        {/* Top bar */}
+        <div className="flex items-center justify-between mb-6">
+          <button
+            onClick={onLogout}
+            className="flex items-center gap-2 px-3 py-2 rounded-xl bg-gray-950 hover:bg-gray-900 border border-gray-800 text-gray-400 hover:text-white font-mono text-xs transition-colors"
+          >
+            <ArrowLeft size={14} />
+            Kembali
+          </button>
+
+          <button
+            onClick={onLogout}
+            className="flex items-center gap-2 px-3 py-2 rounded-xl bg-system-red/10 hover:bg-system-red/20 border border-system-red/20 text-system-red font-mono text-xs transition-colors"
+          >
+            <LogOut size={14} />
+            Keluar
+          </button>
+        </div>
+
+        {/* User identity card */}
+        <div className={`glass rounded-3xl p-6 mb-6 ${glowClass}`}>
+          <div className="flex items-start gap-4">
+            <div className="w-14 h-14 rounded-2xl bg-gray-950 border border-gray-800 flex items-center justify-center text-2xl shrink-0">
+              {user.job_icon}
+            </div>
+            <div className="flex-1 min-w-0">
+              <h2 className="text-xl font-bold font-orbitron text-white tracking-wide truncate">
+                {user.name}
+              </h2>
+              <p className="text-xs text-gray-500 font-mono">
+                {user.job_name} {user.level_icon} Lv.{user.level}
+              </p>
+              <p className="text-[10px] text-gray-600 font-mono mt-1">
+                {user.user_id}
+              </p>
+            </div>
+            <div className="text-right shrink-0">
+              <div className="text-xs text-gray-400 font-mono uppercase tracking-wider">Rank</div>
+              <div className="text-sm font-bold font-orbitron text-white">
+                {user.rank_icon} {user.rank_name}
+              </div>
+            </div>
+          </div>
+
+          {/* Quick stats row */}
+          <div className="grid grid-cols-4 gap-3 mt-5 pt-4 border-t border-gray-800/50">
+            {[
+              { icon: Shield, label: 'Str', value: user.str },
+              { icon: Zap, label: 'Sta', value: user.sta },
+              { icon: Swords, label: 'Agi', value: user.agi },
+              { icon: Heart, label: 'Vit', value: user.vit },
+            ].map((stat) => {
+              const Icon = stat.icon;
+              return (
+                <div key={stat.label} className="text-center">
+                  <Icon className="text-gray-500 mx-auto mb-1" size={14} />
+                  <div className="text-sm font-bold font-orbitron text-white">{stat.value}</div>
+                  <div className="text-[10px] text-gray-500 font-mono uppercase">{stat.label}</div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Placeholder content */}
+        <div className={`glass rounded-3xl p-10 text-center ${glowClass}`}>
+          <Trophy className="text-system-gold mx-auto mb-4" size={40} />
+          <h3 className="text-lg font-bold font-orbitron text-white">
+            {user.rank_icon} Personal Dashboard — Coming Soon
+          </h3>
+          <p className="text-xs text-gray-500 font-mono mt-2 max-w-md mx-auto leading-relaxed">
+            Data personal lengkap akan ditampilkan di sini — statistik detail,
+            progress goals, history workout, dan achievements kamu.
+          </p>
+
+          <div className="grid grid-cols-2 gap-3 mt-6 max-w-sm mx-auto">
+            {[
+              { label: 'Total Points', value: user.total_points },
+              { label: 'Streak', value: `${user.streak} hari` },
+              { label: 'Max Streak', value: `${user.max_streak} hari` },
+              { label: 'Season Points', value: user.seasonal_points },
+            ].map((stat) => (
+              <div
+                key={stat.label}
+                className="glass rounded-xl p-3 border border-gray-800/30"
+              >
+                <div className="text-sm font-bold font-orbitron text-white">
+                  {stat.value}
+                </div>
+                <div className="text-[10px] text-gray-500 font-mono uppercase">
+                  {stat.label}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/internal/infra/http/handler.go
+++ b/internal/infra/http/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fardannozami/whatsapp-gateway/internal/app/usecase"
 	"github.com/fardannozami/whatsapp-gateway/internal/config"
 	"github.com/fardannozami/whatsapp-gateway/internal/domain"
+	"github.com/fardannozami/whatsapp-gateway/internal/domain/phone"
 	"go.mau.fi/whatsmeow"
 )
 
@@ -44,6 +45,7 @@ func (s *Server) RegisterHandlers(mux *http.ServeMux) {
 	mux.HandleFunc("/api/leaderboard", s.HandleLeaderboard)
 	mux.HandleFunc("/api/summary", s.HandleSummary)
 	mux.HandleFunc("/api/motivation", s.HandleMotivation)
+	mux.HandleFunc("/api/user", s.HandleGetUser)
 	mux.HandleFunc("/", s.HandleStatic)
 }
 
@@ -275,6 +277,10 @@ func buildWeekActivity(activityDates []time.Time, weekStart time.Time) ([]bool, 
 }
 
 func enrichReport(r *domain.Report, today time.Time, weekActivity []bool, weekActiveDays int) EnrichedReport {
+	return enrichReportWithMasking(r, today, weekActivity, weekActiveDays, true)
+}
+
+func enrichReportWithMasking(r *domain.Report, today time.Time, weekActivity []bool, weekActiveDays int, mask bool) EnrichedReport {
 	xpProg := domain.GetNumericLevelProgress(r.TotalPoints)
 	lvl := domain.GetLevel(r.TotalPoints)
 	rank := domain.GetSeasonRank(r.SeasonalPoints)
@@ -317,8 +323,13 @@ func enrichReport(r *domain.Report, today time.Time, weekActivity []bool, weekAc
 		daysSinceLastReport = 0
 	}
 
+	userID := r.UserID
+	if mask {
+		userID = maskPhone(r.UserID)
+	}
+
 	return EnrichedReport{
-		UserID:                maskPhone(r.UserID),
+		UserID:                userID,
 		Name:                  r.Name,
 		JobClass:              r.JobClass,
 		JobName:               jobName,
@@ -463,6 +474,41 @@ func (s *Server) HandleMotivation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.writeJSON(w, http.StatusOK, map[string]string{"quote": usecase.RandomQuote()})
+}
+
+func (s *Server) HandleGetUser(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		s.writeJSON(w, http.StatusNoContent, nil)
+		return
+	}
+
+	rawPhone := r.URL.Query().Get("phone")
+	normalized, err := phone.Normalize(rawPhone)
+	if err != nil {
+		s.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Nomor telepon tidak valid"})
+		return
+	}
+
+	report, err := s.repo.GetReport(r.Context(), normalized)
+	if err != nil {
+		s.writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if report == nil {
+		s.writeJSON(w, http.StatusNotFound, map[string]string{"error": "User tidak ditemukan"})
+		return
+	}
+
+	now := time.Now()
+	today := domain.GetToday(now)
+	weekStart := domain.GetStartOfISOWeekStrict(now)
+	activityDates, err := s.repo.GetUserActivityDates(r.Context(), report.UserID)
+	if err != nil {
+		s.writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	weekActivity, weekActiveDays := buildWeekActivity(activityDates, weekStart)
+	s.writeJSON(w, http.StatusOK, enrichReportWithMasking(report, today, weekActivity, weekActiveDays, false))
 }
 
 func (s *Server) HandleStatic(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
- Add  endpoint to fetch a single user's report by phone number
- Introduce new  and  components for user authentication
- Implement logic to manage page state (dashboard, login, personal) and user data
- Modify  to allow unmasking phone numbers for personal views, ensuring privacy in public leaderboards
- Integrate  for user authentication, storing logged-in user data for  display