### PR TITLE
feat(quest): introduce daily side quest feature

### DIFF
--- a/frontend/src/components/PersonalPage.tsx
+++ b/frontend/src/components/PersonalPage.tsx
@@ -1,5 +1,5 @@
-import { ArrowLeft, Shield, Swords, Zap, Heart, Trophy, LogOut } from 'lucide-react';
-import type { EnrichedReport } from '../types';
+import { ArrowLeft, Shield, Swords, Zap, Heart, Trophy, LogOut, ScrollText, CheckCircle2, Circle } from 'lucide-react';
+import type { EnrichedReport, QuestTask } from '../types';
 
 interface PersonalPageProps {
   user: EnrichedReport;
@@ -13,8 +13,28 @@ function getRankGlow(rankName: string) {
   return 'glass-glow-blue';
 }
 
+function formatQuestDifficulty(difficulty: string) {
+  if (difficulty === 'easy') return '🟢 Easy';
+  if (difficulty === 'medium') return '🟡 Medium';
+  if (difficulty === 'hard') return '🔴 Hard';
+  return difficulty;
+}
+
+function formatQuestTarget(task: QuestTask) {
+  if (task.id === 'easycardio') return 'jalan kaki 4000 langkah atau sepeda 5 km';
+  if (task.unit === '100m') return `${(task.target / 10).toFixed(1)} km`;
+  return `${task.target} ${task.unit}`;
+}
+
+function formatQuestProgress(task: QuestTask) {
+  if (task.id === 'easycardio') return task.progress >= task.target ? 'selesai' : 'belum selesai';
+  if (task.unit === '100m') return `${(task.progress / 10).toFixed(1)} / ${(task.target / 10).toFixed(1)} km`;
+  return `${task.progress} / ${task.target} ${task.unit}`;
+}
+
 export function PersonalPage({ user, onLogout }: PersonalPageProps) {
   const glowClass = getRankGlow(user.rank_name);
+  const sideQuests = user.today_side_quests ?? [];
 
   return (
     <div className="min-h-[60vh] flex flex-col items-center px-4 py-8">
@@ -114,6 +134,61 @@ export function PersonalPage({ user, onLogout }: PersonalPageProps) {
               </div>
             ))}
           </div>
+        </div>
+
+        {/* Daily side quests */}
+        <div className={`glass rounded-3xl p-6 mt-6 ${glowClass}`}>
+          <div className="flex items-start justify-between gap-4 mb-5">
+            <div>
+              <h3 className="text-lg font-bold font-orbitron text-white flex items-center gap-2">
+                <ScrollText className="text-system-green" size={18} />
+                Side Quest Hari Ini
+              </h3>
+              <p className="text-xs text-gray-500 font-mono mt-1 leading-relaxed">
+                Sama seperti <span className="text-gray-300">#mysidequest</span>. Selesaikan via WhatsApp dengan format <span className="text-gray-300">#lapor sidequest &lt;kegiatan&gt; &lt;jumlah&gt;</span>.
+              </p>
+            </div>
+            <div className="text-right shrink-0">
+              <div className="text-sm font-bold font-orbitron text-white">
+                {sideQuests.filter((quest) => quest.progress >= quest.target).length}/{sideQuests.length}
+              </div>
+              <div className="text-[10px] text-gray-500 font-mono uppercase">Selesai</div>
+            </div>
+          </div>
+
+          {sideQuests.length === 0 ? (
+            <div className="rounded-2xl border border-gray-800/50 bg-gray-950/50 p-4 text-center">
+              <p className="text-sm text-gray-400 font-mono">Side quest belum terbuka.</p>
+              <p className="text-xs text-gray-600 font-mono mt-1">Pilih job dulu di WhatsApp dengan #jobs dan #job &lt;id&gt;.</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {sideQuests.map((quest) => {
+                const done = quest.progress >= quest.target;
+                return (
+                  <div key={quest.id} className="rounded-2xl border border-gray-800/50 bg-gray-950/50 p-4">
+                    <div className="flex items-start gap-3">
+                      {done ? (
+                        <CheckCircle2 className="text-system-green shrink-0 mt-0.5" size={18} />
+                      ) : (
+                        <Circle className="text-gray-600 shrink-0 mt-0.5" size={18} />
+                      )}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1">
+                          <p className="text-sm font-bold text-white font-mono">{quest.name}</p>
+                          <span className="text-[10px] text-gray-400 font-mono uppercase tracking-wider">
+                            {formatQuestDifficulty(quest.difficulty)}
+                          </span>
+                        </div>
+                        <p className="text-xs text-gray-500 font-mono mt-1">Target: {formatQuestTarget(quest)}</p>
+                        <p className="text-xs text-gray-600 font-mono mt-1">Progress: {formatQuestProgress(quest)}</p>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -58,6 +58,17 @@ export interface EnrichedReport {
   week_activity: boolean[];
   estimated_weekly_points: number;
   is_active_today: boolean;
+  today_side_quests?: QuestTask[];
+}
+
+export interface QuestTask {
+  id: string;
+  name: string;
+  difficulty: 'easy' | 'medium' | 'hard' | string;
+  target: number;
+  progress: number;
+  unit: string;
+  reward_points: number;
 }
 
 export interface GlobalSummary {

--- a/internal/app/usecase/daily_quest_usecase.go
+++ b/internal/app/usecase/daily_quest_usecase.go
@@ -40,7 +40,7 @@ func (u *DailyQuestUsecase) GetOrGenerateQuestList(ctx context.Context, userID, 
 	}
 
 	// Generate and save new quest
-	tasks := domain.GenerateDailyQuest(jobClass, level, now)
+	tasks := domain.GenerateDailyQuestForUser(userID, jobClass, level, now)
 	bytes, err := json.Marshal(tasks)
 	if err != nil {
 		return nil, err
@@ -147,11 +147,11 @@ func (u *DailyQuestUsecase) ViewQuest(ctx context.Context, userID, name string, 
 	sb.WriteString("Contoh:\n")
 	sb.WriteString("#lapor sidequest jalan kaki 4000\n")
 	sb.WriteString("#lapor sidequest sepeda 5 km\n")
-	if len(tasks) > 2 {
-		sb.WriteString(fmt.Sprintf("#lapor sidequest %s %s\n", strings.ToLower(tasks[2].Name), formatQuestTarget(tasks[2])))
-	}
-	if len(tasks) > 3 {
-		sb.WriteString(fmt.Sprintf("#lapor sidequest %s %s\n", strings.ToLower(tasks[3].Name), formatQuestTarget(tasks[3])))
+	for _, task := range tasks {
+		if task.ID == "easycardio" {
+			continue
+		}
+		sb.WriteString(fmt.Sprintf("#lapor sidequest %s %s\n", strings.ToLower(task.Name), formatQuestTarget(task)))
 	}
 
 	return sb.String(), nil
@@ -199,7 +199,13 @@ func (u *DailyQuestUsecase) UpdateProgress(ctx context.Context, userID, name str
 			if domain.MatchTask(namePart, task.ID) {
 				matched = true
 				added := 0
-				if task.Unit == "100m" {
+				if task.ID == "easycardio" {
+					if !isEasyCardioComplete(namePart, val) {
+						rejected = append(rejected, fmt.Sprintf("%s butuh minimal jalan kaki 4000 langkah atau sepeda 5 km, laporanmu baru %s", task.Name, formatEasyCardioReport(namePart, val)))
+						continue
+					}
+					added = task.Target
+				} else if task.Unit == "100m" {
 					if val < 50.0 {
 						added = int(val * 10.0)
 					} else {
@@ -326,14 +332,43 @@ func parseLineFloat(line string) (string, float64) {
 }
 
 func formatQuestTarget(task domain.QuestTask) string {
+	if task.ID == "easycardio" {
+		return "4000 langkah / 5 km"
+	}
 	return formatQuestValue(task, task.Target)
 }
 
 func formatQuestValue(task domain.QuestTask, value int) string {
+	if task.ID == "easycardio" {
+		if value >= task.Target {
+			return "selesai"
+		}
+		return "belum selesai"
+	}
 	if task.Unit == "100m" {
 		return fmt.Sprintf("%.1f km", float64(value)/10.0)
 	}
 	return fmt.Sprintf("%d %s", value, task.Unit)
+}
+
+func isEasyCardioComplete(namePart string, value float64) bool {
+	if domain.MatchTask(namePart, "jalan") {
+		return value >= 4000
+	}
+	if domain.MatchTask(namePart, "sepeda") {
+		return value >= 5 && value < 1000 || value >= 5000
+	}
+	return false
+}
+
+func formatEasyCardioReport(namePart string, value float64) string {
+	if domain.MatchTask(namePart, "sepeda") && value < 1000 {
+		return fmt.Sprintf("%.1f km", value)
+	}
+	if domain.MatchTask(namePart, "sepeda") {
+		return fmt.Sprintf("%.0f m", value)
+	}
+	return fmt.Sprintf("%.0f langkah", value)
 }
 
 // formatQuestProgressBar builds a task-count-based completion bar.

--- a/internal/app/usecase/daily_quest_usecase_test.go
+++ b/internal/app/usecase/daily_quest_usecase_test.go
@@ -122,8 +122,8 @@ func TestDailyQuestViewAndComplete(t *testing.T) {
 	if err := json.Unmarshal([]byte(qJSON), &tasks); err != nil {
 		t.Fatalf("failed to parse stored quest tasks: %v", err)
 	}
-	if len(tasks) != 4 {
-		t.Fatalf("expected 4 generated tasks, got %d", len(tasks))
+	if len(tasks) != 3 {
+		t.Fatalf("expected 3 generated tasks, got %d", len(tasks))
 	}
 
 	t.Logf("Generated tasks: %+v", tasks)

--- a/internal/domain/quest.go
+++ b/internal/domain/quest.go
@@ -20,6 +20,13 @@ type QuestTask struct {
 // GenerateDailyQuest deterministically generates daily side quest options.
 // A selected job is required; users without a job do not receive side quests.
 func GenerateDailyQuest(jobClass string, level int, date time.Time) []QuestTask {
+	return GenerateDailyQuestForUser("", jobClass, level, date)
+}
+
+// GenerateDailyQuestForUser generates a stable daily quest list per user.
+// The same user keeps the same list all day, while different users can receive
+// different medium/hard starter movements even when they share the same job.
+func GenerateDailyQuestForUser(userID, jobClass string, level int, date time.Time) []QuestTask {
 	if strings.TrimSpace(jobClass) == "" {
 		return nil
 	}
@@ -27,6 +34,7 @@ func GenerateDailyQuest(jobClass string, level int, date time.Time) []QuestTask 
 	dateStr := date.Format("2006-01-02")
 	h := fnv.New32a()
 	h.Write([]byte(dateStr))
+	h.Write([]byte(userID))
 	h.Write([]byte(jobClass))
 	hashValue := int(h.Sum32())
 
@@ -49,28 +57,28 @@ func GenerateDailyQuest(jobClass string, level int, date time.Time) []QuestTask 
 	mediumOptions := []QuestTask{
 		{ID: "squat", Name: "Chair Squat / Sit-to-Stand", Difficulty: "medium", Target: 18 + mediumBonus*2, Unit: "x", RewardPoints: 5},
 		{ID: "pushup", Name: "Wall Push-up / Desk Push-up", Difficulty: "medium", Target: 15 + mediumBonus*2, Unit: "x", RewardPoints: 5},
-		{ID: "stretching", Name: "Office Stretching", Difficulty: "medium", Target: 8 + mediumBonus, Unit: "menit", RewardPoints: 5},
-		{ID: "shadowboxing", Name: "Shadow Boxing Ringan", Difficulty: "medium", Target: 6 + mediumBonus, Unit: "menit", RewardPoints: 5},
+		{ID: "stretching", Name: "Office Stretching / Mobility", Difficulty: "medium", Target: 8 + mediumBonus, Unit: "menit", RewardPoints: 5},
 		{ID: "highknees", Name: "High Knees (Marching)", Difficulty: "medium", Target: 1 + mediumBonus, Unit: "menit", RewardPoints: 5},
 		{ID: "armcircles", Name: "Arm Circles", Difficulty: "medium", Target: 2 + mediumBonus, Unit: "menit", RewardPoints: 5},
 		{ID: "calfraises", Name: "Calf Raises (Jinjit)", Difficulty: "medium", Target: 20 + mediumBonus*2, Unit: "x", RewardPoints: 5},
-		{ID: "shouldershrugs", Name: "Shoulder Shrugs", Difficulty: "medium", Target: 15 + mediumBonus*2, Unit: "x", RewardPoints: 5},
+		{ID: "stairs", Name: "Naik-Turun Tangga", Difficulty: "medium", Target: 5 + mediumBonus, Unit: "menit", RewardPoints: 5},
+		{ID: "deskplank", Name: "Desk Plank", Difficulty: "medium", Target: 30 + mediumBonus*5, Unit: "detik", RewardPoints: 5},
 	}
 	// Hard: slightly more effort, still home-friendly. Level bonus caps at Lv.20.
 	hardOptions := []QuestTask{
 		{ID: "plank", Name: "Plank", Difficulty: "hard", Target: 45 + hardBonus*5, Unit: "detik", RewardPoints: 5},
 		{ID: "jumpingjacks", Name: "Jumping Jacks", Difficulty: "hard", Target: 35 + hardBonus*3, Unit: "x", RewardPoints: 5},
-		{ID: "burpee", Name: "Burpee Ringan", Difficulty: "hard", Target: 8 + hardBonus, Unit: "x", RewardPoints: 5},
+		{ID: "squatjump", Name: "Squat Jump Ringan", Difficulty: "hard", Target: 8 + hardBonus, Unit: "x", RewardPoints: 5},
 		{ID: "yoga", Name: "Mobility Flow", Difficulty: "hard", Target: 12 + hardBonus, Unit: "menit", RewardPoints: 5},
 		{ID: "mountainclimber", Name: "Mountain Climber", Difficulty: "hard", Target: 30 + hardBonus*5, Unit: "detik", RewardPoints: 5},
 		{ID: "lunges", Name: "Lunges (Bergantian)", Difficulty: "hard", Target: 10 + hardBonus, Unit: "x per kaki", RewardPoints: 5},
 		{ID: "glutebridge", Name: "Glute Bridge", Difficulty: "hard", Target: 15 + hardBonus*2, Unit: "x", RewardPoints: 5},
 		{ID: "reversecrunch", Name: "Reverse Crunch", Difficulty: "hard", Target: 10 + hardBonus, Unit: "x", RewardPoints: 5},
+		{ID: "lateralshuffle", Name: "Lateral Shuffle", Difficulty: "hard", Target: 45 + hardBonus*5, Unit: "detik", RewardPoints: 5},
 	}
 
 	return []QuestTask{
-		{ID: "jalan", Name: "Jalan Kaki", Difficulty: "easy", Target: 4000, Unit: "langkah", RewardPoints: 5},
-		{ID: "sepeda", Name: "Bersepeda", Difficulty: "easy", Target: 50, Unit: "100m", RewardPoints: 5},
+		{ID: "easycardio", Name: "Jalan Kaki / Bersepeda", Difficulty: "easy", Target: 1, Unit: "opsi", RewardPoints: 5},
 		mediumOptions[hashValue%len(mediumOptions)],
 		hardOptions[(hashValue/len(mediumOptions))%len(hardOptions)],
 	}
@@ -90,6 +98,8 @@ func MatchTask(input string, taskID string) bool {
 		return strings.Contains(input, "plank")
 	case "burpee":
 		return strings.Contains(input, "burpee")
+	case "easycardio":
+		return MatchTask(input, "jalan") || MatchTask(input, "sepeda")
 	case "jalan":
 		return strings.Contains(input, "jalan") || strings.Contains(input, "walk")
 	case "lari":
@@ -125,6 +135,10 @@ func MatchTask(input string, taskID string) bool {
 		return strings.Contains(input, "calf") || strings.Contains(input, "jinjit")
 	case "shouldershrugs":
 		return strings.Contains(input, "shrug") || strings.Contains(input, "bahu")
+	case "stairs":
+		return strings.Contains(input, "tangga") || strings.Contains(input, "stair")
+	case "deskplank":
+		return strings.Contains(input, "desk plank") || strings.Contains(input, "plank meja")
 	// Hard additions — slightly more effort, still home-friendly
 	case "mountainclimber":
 		return strings.Contains(input, "mountain") || strings.Contains(input, "climber") || strings.Contains(input, "panjat")
@@ -134,6 +148,10 @@ func MatchTask(input string, taskID string) bool {
 		return strings.Contains(input, "glute") || strings.Contains(input, "bridge") || strings.Contains(input, "pinggul") || strings.Contains(input, "jembatan")
 	case "reversecrunch":
 		return strings.Contains(input, "reverse crunch") || strings.Contains(input, "crunch") && !strings.Contains(input, "bicycle")
+	case "squatjump":
+		return strings.Contains(input, "squat jump") || strings.Contains(input, "jump squat")
+	case "lateralshuffle":
+		return strings.Contains(input, "lateral") || strings.Contains(input, "shuffle")
 	}
 	return false
 }
@@ -141,6 +159,9 @@ func MatchTask(input string, taskID string) bool {
 // FormatQuestProgressTask returns a descriptive string for a quest task, resolving Ranger 100m units to km.
 func FormatQuestProgressTask(task QuestTask) string {
 	difficulty := formatQuestDifficulty(task.Difficulty)
+	if task.ID == "easycardio" {
+		return fmt.Sprintf("%s %s: %d/%d selesai (jalan kaki 4000 langkah atau sepeda 5 km)", difficulty, task.Name, task.Progress, task.Target)
+	}
 	if task.Unit == "100m" {
 		targetKm := float64(task.Target) / 10.0
 		progressKm := float64(task.Progress) / 10.0
@@ -152,6 +173,9 @@ func FormatQuestProgressTask(task QuestTask) string {
 // FormatQuestTask returns a descriptive string for a quest task without showing progress (showing only target).
 func FormatQuestTask(task QuestTask) string {
 	difficulty := formatQuestDifficulty(task.Difficulty)
+	if task.ID == "easycardio" {
+		return fmt.Sprintf("%s %s: jalan kaki 4000 langkah atau sepeda 5 km", difficulty, task.Name)
+	}
 	if task.Unit == "100m" {
 		targetKm := float64(task.Target) / 10.0
 		return fmt.Sprintf("%s %s: %.1f km", difficulty, task.Name, targetKm)

--- a/internal/domain/quest_test.go
+++ b/internal/domain/quest_test.go
@@ -16,23 +16,27 @@ func TestGenerateDailyQuest(t *testing.T) {
 
 	// 2. Job quest tests
 	tasksFighter := GenerateDailyQuest("fighter", 0, now)
-	if len(tasksFighter) != 4 {
-		t.Fatalf("expected 4 tasks, got %d", len(tasksFighter))
+	if len(tasksFighter) != 3 {
+		t.Fatalf("expected 3 tasks, got %d", len(tasksFighter))
 	}
-	if tasksFighter[0].ID != "jalan" || tasksFighter[0].Target != 4000 || tasksFighter[0].Difficulty != "easy" {
-		t.Errorf("expected easy walk target, got %+v", tasksFighter[0])
-	}
-	if tasksFighter[1].ID != "sepeda" || tasksFighter[1].Target != 50 || tasksFighter[1].Difficulty != "easy" {
-		t.Errorf("expected easy bike target, got %+v", tasksFighter[1])
+	if tasksFighter[0].ID != "easycardio" || tasksFighter[0].Target != 1 || tasksFighter[0].Difficulty != "easy" {
+		t.Errorf("expected easy walk/bike target, got %+v", tasksFighter[0])
 	}
 
 	// 3. Medium/hard scale gently with level.
 	tasksLv20 := GenerateDailyQuest("fighter", 20, now)
-	if tasksLv20[2].Target <= tasksFighter[2].Target {
-		t.Errorf("expected medium target to scale up, got lv0=%d lv20=%d", tasksFighter[2].Target, tasksLv20[2].Target)
+	if tasksLv20[1].Target <= tasksFighter[1].Target {
+		t.Errorf("expected medium target to scale up, got lv0=%d lv20=%d", tasksFighter[1].Target, tasksLv20[1].Target)
 	}
-	if tasksLv20[3].Target <= tasksFighter[3].Target {
-		t.Errorf("expected hard target to scale up, got lv0=%d lv20=%d", tasksFighter[3].Target, tasksLv20[3].Target)
+	if tasksLv20[2].Target <= tasksFighter[2].Target {
+		t.Errorf("expected hard target to scale up, got lv0=%d lv20=%d", tasksFighter[2].Target, tasksLv20[2].Target)
+	}
+
+	// 4. User-specific hash gives users different medium/hard rotations.
+	tasksUserA := GenerateDailyQuestForUser("628111", "fighter", 5, now)
+	tasksUserB := GenerateDailyQuestForUser("628222", "fighter", 5, now)
+	if tasksUserA[1].ID == tasksUserB[1].ID && tasksUserA[2].ID == tasksUserB[2].ID {
+		t.Errorf("expected different users to get randomized medium/hard quests, got %+v and %+v", tasksUserA, tasksUserB)
 	}
 }
 
@@ -52,6 +56,8 @@ func TestMatchTask(t *testing.T) {
 		{"running 5", "lari", true},
 		{"cycling 20", "sepeda", true},
 		{"burpee 10", "burpee", true},
+		{"jalan kaki 4000", "easycardio", true},
+		{"sepeda 5 km", "easycardio", true},
 		{"something else 10", "pushup", false},
 		// New medium exercises
 		{"high knees 1 menit", "highknees", true},
@@ -62,6 +68,8 @@ func TestMatchTask(t *testing.T) {
 		{"jinjit 20", "calfraises", true},
 		{"shoulder shrug 15", "shouldershrugs", true},
 		{"shrug bahu 15", "shouldershrugs", true},
+		{"naik turun tangga 5 menit", "stairs", true},
+		{"desk plank 30 detik", "deskplank", true},
 		// New hard exercises
 		{"mountain climber 30 detik", "mountainclimber", true},
 		{"gerakan panjat 30", "mountainclimber", true},
@@ -70,6 +78,8 @@ func TestMatchTask(t *testing.T) {
 		{"glute bridge 15", "glutebridge", true},
 		{"jembatan pinggul 15", "glutebridge", true},
 		{"reverse crunch 10", "reversecrunch", true},
+		{"squat jump 8", "squatjump", true},
+		{"lateral shuffle 45 detik", "lateralshuffle", true},
 		// Negative cases
 		{"bicycle crunch 10", "reversecrunch", false}, // should not match: exclude "bicycle"
 		{"random text", "highknees", false},

--- a/internal/infra/http/handler.go
+++ b/internal/infra/http/handler.go
@@ -176,6 +176,7 @@ type EnrichedReport struct {
 	WeekActivity          []bool                      `json:"week_activity"`
 	EstimatedWeeklyPoints int                         `json:"estimated_weekly_points"`
 	IsActiveToday         bool                        `json:"is_active_today"`
+	TodaySideQuests       []domain.QuestTask          `json:"today_side_quests,omitempty"`
 }
 
 // TierProgress is precomputed for the web UI so templates/components only render it.
@@ -508,7 +509,17 @@ func (s *Server) HandleGetUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	weekActivity, weekActiveDays := buildWeekActivity(activityDates, weekStart)
-	s.writeJSON(w, http.StatusOK, enrichReportWithMasking(report, today, weekActivity, weekActiveDays, false))
+	enriched := enrichReportWithMasking(report, today, weekActivity, weekActiveDays, false)
+	if strings.TrimSpace(report.JobClass) != "" {
+		questUC := usecase.NewDailyQuestUsecase(s.repo)
+		tasks, err := questUC.GetOrGenerateQuestList(r.Context(), report.UserID, report.JobClass, report.Level, now)
+		if err != nil {
+			s.writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		enriched.TodaySideQuests = tasks
+	}
+	s.writeJSON(w, http.StatusOK, enriched)
 }
 
 func (s *Server) HandleStatic(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
- frontend now displays daily side quests with progress and target information
- backend generates user-specific quest lists, including an 'easy cardio' combined task
- report parsing and progress updates for quests now handle 'easy cardio' logic, allowing varied reporting (steps/km)
- new quest options and task matching keywords have been added or updated in the domain layer