### PR TITLE
feat(commands): Migrate to slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Bot WhatsApp sederhana untuk melacak aktivitas harian grup (cth: "30 Days of Swe
 
 ## Fitur
 
-- 📝 **Self-Reporting (`#lapor`)**: Member grup dapat melapor aktivitas harian mereka.
+- 📝 **Self-Reporting (`/lapor`)**: Member grup dapat melapor aktivitas harian mereka.
 - 🔥 **Streak Tracking**: Menghitung streak harian secara otomatis.
-- 🏆 **Leaderboard (`#leaderboard`)**: Menampilkan klasemen streak tertinggi.
+- 🏆 **Web Dashboard**: Menampilkan klasemen, stats personal, ranking season, dan achievement di https://lapor-bot.web.id/.
 - 📱 **Multi-Login Support**: Mendukung login menggunakan QR Code atau Pairing Code.
 - 💾 **SQLite Database**: Penyimpanan data ringan dan lokal.
 
@@ -84,32 +84,27 @@ Bot hanya merespon perintah berikut di dalam grup yang telah dikonfigurasi (`GRO
 
 | Perintah | Fungsi |
 | --- | --- |
-| `#lapor` | Merekam aktivitas harian user. Menambah streak jika laporan hari ini/kemarin. |
-| `#mysidequest` | Menampilkan side quest harian untuk user yang sudah memilih job. |
-| `#lapor sidequest [kegiatan] [jumlah]` | Melaporkan side quest. Reward ½ XP, tetap dihitung ke streak, stats, leaderboard, dan goal. |
-| `#cancel` | Membatalkan laporan hari ini. Hanya bisa digunakan di hari yang sama. |
-| `#leaderboard` | Menampilkan klasemen streak, daftar yang "Keep Streak" 🔥 dan "Lose Streak" 💔. |
-| `#leaderboard-weekly` | Menampilkan klasemen total hari aktif minggu ini. |
-| `#ranks` | Menampilkan ranking hunter selama season berjalan. |
-| `#mystats` | Menampilkan statistik personal ringkas (level, rank, streak, poin). |
-| `#achievements` | Menampilkan daftar badge season dan progress member. |
-| `#jobs` | Menampilkan daftar hunter jobs yang bisa dipilih. |
-| `#job [id]` | Memilih hunter job. Contoh: `#job ranger`. |
-| `#comeback` | Menampilkan status comeback challenge setelah absen. |
-| `#motivasi` | Menampilkan pesan motivasi acak untuk semangat berolahraga. |
-| `#help` | Menampilkan list command yang tersedia. |
-| `#tutorial` | Menampilkan panduan lengkap cara memakai bot. |
-| `#strava` | Menghubungkan akun Strava untuk laporan otomatis. |
-| `#setname [nama]` | Mengubah nama tampilan di leaderboard. |
+| `/lapor` | Merekam aktivitas harian user. Menambah streak jika laporan hari ini. |
+| `/lapor-kemarin` | Merekam laporan khusus hari kemarin. |
+| `/lapor sidequest` | Menampilkan side quest harian untuk user yang sudah punya job. |
+| `/lapor sidequest [kegiatan] [jumlah]` | Melaporkan side quest. Reward bonus kecil, tetap dihitung ke streak, stats, dan leaderboard. |
+| `/cancel` | Membatalkan laporan terakhir hari ini. Hanya bisa digunakan di hari yang sama. |
+| `/cancel-all` | Membatalkan semua laporan hari ini. |
+| `/help` | Menampilkan list command yang tersedia. |
+| `/tutorial` | Menampilkan panduan lengkap cara memakai bot, termasuk link web stats dan klasemen. |
+
+Command lain yang diawali `/` akan mendapat pesan fallback berisi link bantuan dan web dashboard. Pesan biasa tanpa prefix `/` tidak akan dibalas bot.
+
+🌐 Klasemen, stats personal, ranking season, achievement, dan progres lain tersedia di https://lapor-bot.web.id/.
 
 ### Fitur Gamifikasi 🏅
-- **Season Ranks (`#ranks`)**: Rank ala hunter dihitung dari seasonal points dan reset setiap season.
-- **Hunter Jobs (`#jobs`, `#job [id]`)**: Pilih job profile seperti fighter, tanker, assassin, mage, ranger, healer, atau necromancer. Job tampil di `#mystats` dan laporan harian.
-- **Side Quest (`#mysidequest`)**: Bonus gerak harian easy/medium/hard untuk user yang sudah punya job. Lapor dengan `#lapor sidequest jalan 4000` atau `#lapor sidequest sepeda 5 km`.
+- **Season Ranks**: Rank ala hunter dihitung dari seasonal points dan reset setiap season. Cek di web dashboard.
+- **Hunter Jobs**: Job profile seperti fighter, tanker, assassin, mage, ranger, healer, atau necromancer tampil di web dashboard dan laporan harian.
+- **Side Quest (`/lapor sidequest`)**: Bonus gerak harian easy/medium/hard untuk user yang sudah punya job. Lapor dengan `/lapor sidequest jalan 4000` atau `/lapor sidequest sepeda 5 km`.
 - **Season Badges**: Badge reset setiap season supaya semua member mulai berburu dari awal.
 - **Lifetime Level & EXP**: Total poin dan level numerik (`Lv.0+`) tetap tersimpan lintas season. EXP naik level memakai kurva `5×level² + 50×level + 100` agar makin tinggi level makin lama naiknya.
 - **Milestone Notification**: Dapat notifikasi khusus saat mencapai streak tertenu (7, 14, 30 hari, dst).
-- **Leaderboard**: Bersaing dengan teman untuk streak tertinggi.
+- **Leaderboard**: Bersaing dengan teman untuk streak tertinggi di https://lapor-bot.web.id/.
 
 ## Struktur Project
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -237,7 +237,7 @@ function App() {
                 <ShieldAlert className="text-system-gold mx-auto mb-4 animate-bounce" size={40} />
                 <h3 className="text-lg font-bold text-white font-orbitron">No Roster Registered</h3>
                 <p className="text-xs text-gray-500 font-mono mt-2 max-w-sm mx-auto">
-                  The database does not contain any active reports yet. Have members submit a workout report using "#lapor" on WhatsApp!
+                  The database does not contain any active reports yet. Have members submit a workout report using "/lapor" on WhatsApp!
                 </p>
               </div>
             ) : viewMode === 'table' ? (

--- a/frontend/src/components/PersonalPage.tsx
+++ b/frontend/src/components/PersonalPage.tsx
@@ -145,7 +145,7 @@ export function PersonalPage({ user, onLogout }: PersonalPageProps) {
                 Side Quest Hari Ini
               </h3>
               <p className="text-xs text-gray-500 font-mono mt-1 leading-relaxed">
-                Sama seperti <span className="text-gray-300">#mysidequest</span>. Selesaikan via WhatsApp dengan format <span className="text-gray-300">#lapor sidequest &lt;kegiatan&gt; &lt;jumlah&gt;</span>.
+                Sama seperti <span className="text-gray-300">/lapor sidequest</span>. Selesaikan via WhatsApp dengan format <span className="text-gray-300">/lapor sidequest &lt;kegiatan&gt; &lt;jumlah&gt;</span>.
               </p>
             </div>
             <div className="text-right shrink-0">
@@ -159,7 +159,7 @@ export function PersonalPage({ user, onLogout }: PersonalPageProps) {
           {sideQuests.length === 0 ? (
             <div className="rounded-2xl border border-gray-800/50 bg-gray-950/50 p-4 text-center">
               <p className="text-sm text-gray-400 font-mono">Side quest belum terbuka.</p>
-              <p className="text-xs text-gray-600 font-mono mt-1">Pilih job dulu di WhatsApp dengan #jobs dan #job &lt;id&gt;.</p>
+              <p className="text-xs text-gray-600 font-mono mt-1">Side quest tersedia untuk profil yang sudah punya job.</p>
             </div>
           ) : (
             <div className="space-y-3">

--- a/internal/app/usecase/broadcast_update_usecase.go
+++ b/internal/app/usecase/broadcast_update_usecase.go
@@ -41,7 +41,7 @@ Season %d sedang berjalan. Setelah season berjalan selesai, bot akan otomatis la
 💡 *Artinya:*
 Seasonal ranking mulai dari awal, tapi progres lifetime tetap lanjut. Ini kesempatan baru untuk berburu rank tanpa kehilangan level! 🎯
 
-📌 Manfaatkan Season %d ini sebaik mungkin. Laporkan aktivitasmu dengan #lapor!
+📌 Manfaatkan Season %d ini sebaik mungkin. Laporkan aktivitasmu dengan /lapor!
 
 *Semangat Season %d!* 🚀🔥`, seasonNumber, nextSeason, seasonNumber, nextSeason, seasonNumber, seasonNumber)
 }

--- a/internal/app/usecase/cancel_report_usecase.go
+++ b/internal/app/usecase/cancel_report_usecase.go
@@ -80,7 +80,7 @@ func (uc *CancelReportUsecase) cancelToday(ctx context.Context, userID, name str
 		msg += fmt.Sprintf("📌 Sisa laporan hari ini: %d/%d\n", remainingReports, MaxDailyReports)
 		msg += fmt.Sprintf("📅 Total hari aktif tetap: %d\n", report.ActivityCount)
 		msg += fmt.Sprintf("⭐ Total poin sekarang: %d\n", report.TotalPoints)
-		msg += "\nKalau ingin menghapus semua laporan hari ini, ketik #cancel-all."
+		msg += "\nKalau ingin menghapus semua laporan hari ini, ketik /cancel-all."
 		return msg, nil
 	}
 
@@ -128,7 +128,7 @@ func (uc *CancelReportUsecase) cancelToday(ctx context.Context, userID, name str
 		msg += fmt.Sprintf("🔄 Comeback streak: %d minggu\n", newReport.ComebackStreak)
 	}
 
-	msg += "\n_Kamu bisa lapor lagi hari ini dengan #lapor._"
+	msg += "\n_Kamu bisa lapor lagi hari ini dengan /lapor._"
 	return msg, nil
 }
 

--- a/internal/app/usecase/comeback_challenge_usecase.go
+++ b/internal/app/usecase/comeback_challenge_usecase.go
@@ -23,7 +23,7 @@ func (uc *ComebackChallengeUsecase) Execute(ctx context.Context, userID, name st
 	}
 
 	if report == nil {
-		return fmt.Sprintf("Halo %s, kamu belum pernah laporan aktivitas. Yuk mulai dengan ketik #lapor!", name), nil
+		return fmt.Sprintf("Halo %s, kamu belum pernah laporan aktivitas. Yuk mulai dengan ketik /lapor!", name), nil
 	}
 
 	sb := strings.Builder{}

--- a/internal/app/usecase/daily_quest_usecase.go
+++ b/internal/app/usecase/daily_quest_usecase.go
@@ -87,7 +87,7 @@ func (u *DailyQuestUsecase) SendDailyQuests(ctx context.Context, now time.Time, 
 	}
 
 	dateStr := domain.GetToday(now).Format("02 Jan 2006")
-	msgText := fmt.Sprintf("🌅 *Selamat pagi, Hunters!*\n\nSide quest hari ini sudah terbuka untuk %d hunter yang sudah memilih job. Buka `#mysidequest` untuk lihat pilihan easy, medium, dan hard hari ini.\n\nPilih yang ringan dulu juga boleh—minimal jalan kaki 4.000 langkah atau sepeda 5 km, atau gerakan singkat di rumah/kantor. Side quest cuma bonus kecil; misi utama tetap konsisten olahraga dan lapor di grup. ✨\n\n📅 %s\n📝 Lapor side quest: `#lapor sidequest <kegiatan> <jumlah>`\n\n🌐 Lihat klasemen & stats: https://lapor-bot.web.id/", eligibleCount, dateStr)
+	msgText := fmt.Sprintf("🌅 *Selamat pagi, Hunters!*\n\nSide quest hari ini sudah terbuka untuk %d hunter yang sudah memilih job. Buka `/lapor sidequest` untuk lihat pilihan easy, medium, dan hard hari ini.\n\nPilih yang ringan dulu juga boleh—minimal jalan kaki 4.000 langkah atau sepeda 5 km, atau gerakan singkat di rumah/kantor. Side quest cuma bonus kecil; misi utama tetap konsisten olahraga dan lapor di grup. ✨\n\n📅 %s\n📝 Lapor side quest: `/lapor sidequest <kegiatan> <jumlah>`\n\n🌐 Lihat klasemen & stats: https://lapor-bot.web.id/", eligibleCount, dateStr)
 
 	targetJID, err := types.ParseJID(groupID)
 	if err != nil {
@@ -114,10 +114,10 @@ func (u *DailyQuestUsecase) ViewQuest(ctx context.Context, userID, name string, 
 	}
 
 	if report == nil {
-		return fmt.Sprintf("Halo %s, kamu belum terdaftar di database. Silakan lakukan laporan pertama dengan `#lapor` terlebih dahulu! 💪", name), nil
+		return fmt.Sprintf("Halo %s, kamu belum terdaftar di database. Silakan lakukan laporan pertama dengan `/lapor` terlebih dahulu! 💪", name), nil
 	}
 	if strings.TrimSpace(report.JobClass) == "" {
-		return "🔒 *Side quest belum terbuka.*\n\nKamu perlu memilih job dulu agar bisa mendapat side quest harian. Cek `#jobs`, lalu pilih dengan `#job <id>` setelah syarat poin terpenuhi.", nil
+		return "🔒 *Side quest belum terbuka.*\n\nSide quest tersedia untuk profil yang sudah punya job. Untuk sementara, cek progres dan info profil di web: https://lapor-bot.web.id/", nil
 	}
 
 	tasks, err := u.GetOrGenerateQuestList(ctx, userID, report.JobClass, report.Level, now)
@@ -128,7 +128,7 @@ func (u *DailyQuestUsecase) ViewQuest(ctx context.Context, userID, name string, 
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("📜 *Side Quest Hari Ini - %s* 🏹\n", report.Name))
 	sb.WriteString(fmt.Sprintf("Job: %s (Lv.%d)\n", domain.FormatJobClass(report.JobClass), report.Level))
-	sb.WriteString("Reward: XP bonus per side quest yang valid (easy/medium/hard). #lapor utama tetap prioritas.\n\n")
+	sb.WriteString("Reward: XP bonus per side quest yang valid (easy/medium/hard). /lapor utama tetap prioritas.\n\n")
 
 	completed := 0
 	for i, t := range tasks {
@@ -142,16 +142,16 @@ func (u *DailyQuestUsecase) ViewQuest(ctx context.Context, userID, name string, 
 
 	sb.WriteString(fmt.Sprintf("\nProgress hari ini: %s\n", formatQuestProgressBar(tasks)))
 	sb.WriteString(fmt.Sprintf("Total side quest selesai: %d lifetime • %d season\n\n", report.TotalSideQuests, report.SeasonalSideQuests))
-	sb.WriteString("Cara lapor: `#lapor sidequest <nama kegiatan> <jumlah>`\n")
+	sb.WriteString("Cara lapor: `/lapor sidequest <nama kegiatan> <jumlah>`\n")
 	sb.WriteString("Gunakan nama kegiatan sesuai yang tertera di atas.\n")
 	sb.WriteString("Contoh:\n")
-	sb.WriteString("#lapor sidequest jalan kaki 4000\n")
-	sb.WriteString("#lapor sidequest sepeda 5 km\n")
+	sb.WriteString("/lapor sidequest jalan kaki 4000\n")
+	sb.WriteString("/lapor sidequest sepeda 5 km\n")
 	for _, task := range tasks {
 		if task.ID == "easycardio" {
 			continue
 		}
-		sb.WriteString(fmt.Sprintf("#lapor sidequest %s %s\n", strings.ToLower(task.Name), formatQuestTarget(task)))
+		sb.WriteString(fmt.Sprintf("/lapor sidequest %s %s\n", strings.ToLower(task.Name), formatQuestTarget(task)))
 	}
 
 	return sb.String(), nil
@@ -165,10 +165,10 @@ func (u *DailyQuestUsecase) UpdateProgress(ctx context.Context, userID, name str
 	}
 
 	if report == nil {
-		return fmt.Sprintf("Halo %s, kamu belum terdaftar di database. Silakan lakukan laporan pertama dengan `#lapor` terlebih dahulu! 💪", name), nil
+		return fmt.Sprintf("Halo %s, kamu belum terdaftar di database. Silakan lakukan laporan pertama dengan `/lapor` terlebih dahulu! 💪", name), nil
 	}
 	if strings.TrimSpace(report.JobClass) == "" {
-		return "🔒 Side quest hanya tersedia setelah kamu memilih job. Cek `#jobs`, lalu pilih dengan `#job <id>` saat syarat poin sudah terpenuhi.", nil
+		return "🔒 Side quest tersedia untuk profil yang sudah punya job. Untuk sementara, cek progres dan info profil di web: https://lapor-bot.web.id/", nil
 	}
 	today := domain.GetToday(now)
 	dailyCount, err := u.repo.GetDailyActivityCount(ctx, userID, today)
@@ -176,7 +176,7 @@ func (u *DailyQuestUsecase) UpdateProgress(ctx context.Context, userID, name str
 		return "", err
 	}
 	if dailyCount >= MaxDailyReports {
-		return fmt.Sprintf("Batas laporan harian sudah penuh (%dx). Side quest belum diterima agar progres quest tidak kepisah dari stats. Kalau salah input, pakai #cancel dulu lalu lapor ulang. 🙏", MaxDailyReports), nil
+		return fmt.Sprintf("Batas laporan harian sudah penuh (%dx). Side quest belum diterima agar progres quest tidak kepisah dari stats. Kalau salah input, pakai /cancel dulu lalu lapor ulang. 🙏", MaxDailyReports), nil
 	}
 
 	tasks, err := u.GetOrGenerateQuestList(ctx, userID, report.JobClass, report.Level, now)
@@ -216,7 +216,7 @@ func (u *DailyQuestUsecase) UpdateProgress(ctx context.Context, userID, name str
 				}
 
 				if task.Progress >= task.Target {
-					return fmt.Sprintf("%s sudah selesai hari ini. Pilih side quest lain di `#mysidequest` kalau masih mau lanjut. ✅", task.Name), nil
+					return fmt.Sprintf("%s sudah selesai hari ini. Pilih side quest lain di `/lapor sidequest` kalau masih mau lanjut. ✅", task.Name), nil
 				}
 				if added < task.Target {
 					rejected = append(rejected, fmt.Sprintf("%s butuh minimal %s, laporanmu baru %s", task.Name, formatQuestTarget(task), formatQuestValue(task, added)))
@@ -235,9 +235,9 @@ func (u *DailyQuestUsecase) UpdateProgress(ctx context.Context, userID, name str
 
 	if len(completedTasks) == 0 {
 		if len(rejected) > 0 {
-			return "💪 *Semangat! Tinggal sedikit lagi...* 🔥\n\n" + strings.Join(rejected, "\n") + "\n\nAyo lanjutkan sampai target lalu lapor ulang ya! Kamu pasti bisa! ✨\n\n📜 Cek detail target: `#mysidequest`\n📝 Lapor ulang: `#lapor sidequest <kegiatan> <jumlah>`", nil
+			return "💪 *Semangat! Tinggal sedikit lagi...* 🔥\n\n" + strings.Join(rejected, "\n") + "\n\nAyo lanjutkan sampai target lalu lapor ulang ya! Kamu pasti bisa! ✨\n\n📜 Cek detail target: `/lapor sidequest`\n📝 Lapor ulang: `/lapor sidequest <kegiatan> <jumlah>`", nil
 		}
-		return "Gagal membaca laporan side quest. Contoh: `#lapor sidequest jalan 4000` atau `#lapor sidequest sepeda 5 km`", nil
+		return "Gagal membaca laporan side quest. Contoh: `/lapor sidequest jalan 4000` atau `/lapor sidequest sepeda 5 km`", nil
 	}
 
 	// Save updated tasks list

--- a/internal/app/usecase/daily_quest_usecase_test.go
+++ b/internal/app/usecase/daily_quest_usecase_test.go
@@ -228,8 +228,8 @@ func TestSendDailyQuests(t *testing.T) {
 	if !strings.Contains(text, "Selamat pagi, Hunters") {
 		t.Errorf("expected text to contain title, got: %s", text)
 	}
-	if !strings.Contains(text, "#mysidequest") {
-		t.Errorf("expected text to prompt #mysidequest, got: %s", text)
+	if !strings.Contains(text, "/lapor sidequest") {
+		t.Errorf("expected text to prompt /lapor sidequest, got: %s", text)
 	}
 	if strings.Contains(text, "@") || strings.Contains(text, "Alice") || strings.Contains(text, "Bob") || strings.Contains(text, "Charlie") {
 		t.Errorf("daily side quest prompt should not mention or name users, got: %s", text)

--- a/internal/app/usecase/get_help_usecase.go
+++ b/internal/app/usecase/get_help_usecase.go
@@ -10,62 +10,32 @@ var helpSections = []struct {
 	{
 		emoji:   "📝",
 		title:   "Melaporkan Aktivitas",
-		content: "*#lapor* — Laporkan workout atau aktivitas harianmu.\nContoh: `#lapor` atau `#lapor Push Day`\n\n*#lapor sidequest [kegiatan] [jumlah]* — Laporkan side quest dari `#mysidequest`. Gunakan nama kegiatan sesuai yang tertera di daftar quest. Contoh: `#lapor sidequest jalan kaki 4000`. Side quest memberi XP bonus kecil, tapi tetap dihitung untuk streak, stats, leaderboard, dan goal.\n\n🔄 Setiap laporan yang valid akan menambah streak mingguanmu dan total hari aktif.\n❄️ *Streak Freeze* — kamu punya 1 freeze gratis per season. Freeze otomatis melindungi 1 minggu absen. Dapatkan +1 freeze lagi saat kamu mencapai 4 minggu streak!\n\n📌 *Max 3x laporan per hari*: Kamu bisa lapor maksimal 3x dalam sehari. Laporan ke-2 dan ke-3 tetap dihitung 1 hari tapi XP dibagi 2.\n📌 *#lapor-kemarin* — Laporan khusus untuk hari kemarin. Sama seperti #lapor, XP dibagi 2. Max 3x per hari.",
+		content: "*/lapor* — Laporkan workout atau aktivitas harianmu.\nContoh: `/lapor` atau `/lapor Push Day`\n\n🔄 Setiap laporan yang valid akan menambah streak mingguanmu dan total hari aktif.\n❄️ *Streak Freeze* — kamu punya 1 freeze gratis per season. Freeze otomatis melindungi 1 minggu absen. Dapatkan +1 freeze lagi saat kamu mencapai 4 minggu streak!\n\n📌 *Max 3x laporan per hari*: Kamu bisa lapor maksimal 3x dalam sehari. Laporan ke-2 dan ke-3 tetap dihitung 1 hari tapi XP dibagi 2.\n📌 */lapor-kemarin* — Laporan khusus untuk hari kemarin. Sama seperti /lapor, XP dibagi 2. Max 3x per hari.",
 	},
 	{
 		emoji:   "✨",
 		title:   "Side Quest Harian",
-		content: "*#mysidequest* — Lihat side quest easy, medium, dan hard hari ini. Wajib pilih job dulu lewat `#job <id>` agar mendapat side quest.\n\nEasy: jalan kaki minimal 4.000 langkah atau sepeda 5 km (pilih salah satu). Medium/hard berisi latihan ringan yang bisa dilakukan di rumah/kantor, dan naik sedikit sesuai level job. XP bonus bervariasi per difficulty, dihitung otomatis di belakang.\n\nLapor dengan `#lapor sidequest [kegiatan] [jumlah]`. Nama kegiatan harus sesuai yang tertera di `#mysidequest`. Target harus tercapai dulu; kalau kurang, laporan ditolak dan kamu bisa ulang setelah menambah aktivitas.",
+		content: "*/lapor sidequest* — Lihat side quest easy, medium, dan hard hari ini untuk profil yang sudah punya job.\n\nEasy: jalan kaki minimal 4.000 langkah atau sepeda 5 km (pilih salah satu). Medium/hard berisi latihan ringan yang bisa dilakukan di rumah/kantor, dan naik sedikit sesuai level job. XP bonus bervariasi per difficulty, dihitung otomatis di belakang.\n\nLapor dengan `/lapor sidequest [kegiatan] [jumlah]`. Nama kegiatan harus sesuai yang tertera di daftar quest. Contoh: `/lapor sidequest jalan kaki 4000`. Target harus tercapai dulu; kalau kurang, laporan ditolak dan kamu bisa ulang setelah menambah aktivitas.",
 	},
 	{
 		emoji:   "❌",
 		title:   "Membatalkan Laporan",
-		content: "*#cancel* — Batalkan laporan terakhir hari ini jika kamu salah input. Kalau hari ini ada 2-3 laporan, hanya laporan paling akhir yang dihapus.\n*#cancel-all* — Hapus semua laporan hari ini dan hitung ulang progresmu.\nHanya bisa digunakan pada hari yang sama dengan laporan.",
+		content: "*/cancel* — Batalkan laporan terakhir hari ini jika kamu salah input. Kalau hari ini ada 2-3 laporan, hanya laporan paling akhir yang dihapus.\n*/cancel-all* — Hapus semua laporan hari ini dan hitung ulang progresmu.\nHanya bisa digunakan pada hari yang sama dengan laporan.",
 	},
 	{
 		emoji:   "🏆",
 		title:   "Leaderboard & Statistik",
-		content: "*#leaderboard* — Lihat klasemen lifetime (total hari aktif).\n*#leaderboard-weekly* — Lihat klasemen total hari aktif minggu ini (Senin—Minggu).\n*#leaderboard-seasonal* — Lihat klasemen seasonal points.\n*#ranks* — Lihat ranking hunter selama season ini.\n*#mystats* — Cek statistik personal ringkas.",
-	},
-	{
-		emoji:   "🎯",
-		title:   "Goal Mingguan",
-		content: "*#goal set [1-7] [aktivitas]* — Tetapkan target hari aktif untuk 7 hari ke depan sejak command dikirim. Contoh: `#goal set 3 Olahraga`.\n*#goal* — Lihat progress, waktu mulai, dan waktu berakhir goal aktif.\n*#goal reset* — Hapus goal aktif kalau ingin set ulang.\n\nAlur: set goal → lapor aktivitas dengan #lapor → cek progress dengan #goal → jika target tercapai, total goals di #mystats bertambah.\nLaporan dobel di hari yang sama tetap dihitung 1. Data goal yang sudah lewat dibersihkan otomatis setiap 00:10.",
-	},
-	{
-		emoji:   "🎖️",
-		title:   "Achievements",
-		content: "*#achievements* — Lihat daftar badge season yang tersedia. Badge reset tiap season; level dan EXP lifetime tetap aman.\n*#comeback* — Cek progress comeback challenge-mu setelah absen.\n\n🏅 Kumpulkan badge dengan menjaga streak dan total hari aktif selama season!",
-	},
-	{
-		emoji:   "🧭",
-		title:   "Hunter Jobs",
-		content: "*#jobs* — Lihat daftar job yang bisa dipilih.\n*#job [id]* — Pilih job untuk profilmu. Contoh: `#job ranger`\n\nJob tersedia: fighter, tank, assassin, mage, ranger, healer, necromancer. Job tampil di #mystats dan laporan #lapor.",
-	},
-	{
-		emoji:   "✨",
-		title:   "Motivasi",
-		content: "*#motivasi* — Dapatkan quote motivasi acak untuk semangat berolahraga!",
-	},
-	{
-		emoji:   "🏃‍♂️",
-		title:   "Integrasi Strava",
-		content: "*#strava* — Hubungkan akun Strava untuk laporan otomatis.\nAktivitas lari dan bersepedamu akan tercatat secara otomatis!",
-	},
-	{
-		emoji:   "✏️",
-		title:   "Pengaturan Profil",
-		content: "*#setname [nama]* — Ubah nama yang tampil di leaderboard.\nContoh: `#setname Budi`",
+		content: "Command leaderboard dan stats di WhatsApp sudah dipindah ke web supaya grup tidak ramai.\n\n🌐 Buka https://lapor-bot.web.id/ untuk cek klasemen, stats personal, ranking season, achievement, dan progres lain.",
 	},
 	{
 		emoji:   "❓",
 		title:   "Bantuan",
-		content: "*#help* — Tampilkan panduan ini kapan saja!",
+		content: "*/help* — Tampilkan list command ringkas.\n*/tutorial* — Tampilkan panduan lengkap penggunaan bot.",
 	},
 	{
 		emoji:   "⚔️",
 		title:   "Status RPG (Attributes)",
-		content: "Bot akan membaca laporanmu dan menaikkan status tertentu berdasarkan kata kunci aktivitas.\n\n💪 *STR (Strength)*: beban, weight, strength, gym, angkat, powerlifting, push, pull, leg\n🏃‍♂️ *STA (Stamina)*: lari, run, running, sepeda, cycle, hiit, kardio, cardio, renang, swim\n⚡ *AGI (Agility)*: bola, futsal, basket, bulutangkis, tenis, sprint, muaythai, boxing, calisthenics, padel, padle\n🧘‍♂️ *VIT (Vitality)*: yoga, pilates, stretching, recovery, jalan, walk, meditasi\n\nJika tidak ada kata kunci spesifik, laporan akan otomatis meningkatkan *VIT*.",
+		content: "Bot akan membaca laporan `/lapor` dan menaikkan status tertentu berdasarkan kata kunci aktivitas.\n\n💪 *STR (Strength)*: beban, weight, strength, gym, angkat, powerlifting, push, pull, leg\n🏃‍♂️ *STA (Stamina)*: lari, run, running, sepeda, cycle, hiit, kardio, cardio, renang, swim\n⚡ *AGI (Agility)*: bola, futsal, basket, bulutangkis, tenis, sprint, muaythai, boxing, calisthenics, padel, padle\n🧘‍♂️ *VIT (Vitality)*: yoga, pilates, stretching, recovery, jalan, walk, meditasi\n\nJika tidak ada kata kunci spesifik, laporan akan otomatis meningkatkan *VIT*.",
 	},
 }
 
@@ -78,20 +48,21 @@ func NewGetHelpUsecase() *GetHelpUsecase {
 func (uc *GetHelpUsecase) Execute() string {
 	return `🤖 *Command Lapor Bot*
 
-📝 #lapor — laporan aktivitas harian (max 3x/hari)
-✨ #lapor sidequest [kegiatan] [jumlah] — lapor side quest
-📌 #lapor-kemarin — laporan khusus hari kemarin (max 3x/hari)
-❌ #cancel — batalkan laporan hari ini
-🧹 #cancel-all — batalkan semua laporan hari ini
-📚 #tutorial — panduan lengkap penggunaan bot
-❓ #help — list command ini
+📝 /lapor — laporan aktivitas harian (max 3x/hari)
+✨ /lapor sidequest — lihat side quest hari ini
+✨ /lapor sidequest [kegiatan] [jumlah] — lapor side quest
+📌 /lapor-kemarin — laporan khusus hari kemarin (max 3x/hari)
+❌ /cancel — batalkan laporan terakhir hari ini
+🧹 /cancel-all — batalkan semua laporan hari ini
+📚 /tutorial — panduan lengkap penggunaan bot
+❓ /help — list command ini
 
 🌐 Klasemen & stats personal: https://lapor-bot.web.id/`
 }
 
 func (uc *GetHelpUsecase) ExecuteAttributes() string {
 	msg := "⚔️ *Status RPG (Attributes)* ⚔️\n\n"
-	msg += "Setiap kali kamu `#lapor`, bot akan membaca kata kunci dari laporanmu dan memberikan atribut ke status tertentu. Berikut daftar kata kuncinya:\n\n"
+	msg += "Setiap kali kamu `/lapor`, bot akan membaca kata kunci dari laporanmu dan memberikan atribut ke status tertentu. Berikut daftar kata kuncinya:\n\n"
 	msg += "💪 *STR (Strength)*: beban, weight, strength, gym, angkat, powerlifting, push, pull, leg\n"
 	msg += "🏃‍♂️ *STA (Stamina)*: lari, run, running, sepeda, cycle, hiit, kardio, cardio, renang, swim\n"
 	msg += "⚡ *AGI (Agility)*: bola, futsal, basket, bulutangkis, tenis, sprint, muaythai, boxing, calisthenics, padel, padle\n"
@@ -112,19 +83,13 @@ func (uc *GetHelpUsecase) ExecuteTutorial() string {
 	msg += "⚔️ *Level Numerik*\n"
 	msg += "Level lifetime dimulai dari Lv.0 dan naik dari total points/EXP. Semakin tinggi level, semakin banyak EXP yang dibutuhkan untuk naik level. Season boleh reset, tapi level lifetime tetap lanjut.\n\n"
 	msg += "🏅 *Badge*\n"
-	msg += "Notifikasi #lapor hanya menampilkan badge terbaru supaya ringkas. Untuk syarat, poin, dan cerita unlock lengkap, buka #achievements.\n\n"
-	msg += "🎯 *Flow Goal Mingguan*\n"
-	msg += "1. Set target: `#goal set 3 Olahraga` (maksimal 7).\n"
-	msg += "2. Window goal berjalan 7 hari dari waktu kamu set, bukan kalender Senin—Minggu.\n"
-	msg += "3. Lapor aktivitas dengan `#lapor`; laporan dobel di hari yang sama tetap dihitung 1 untuk goal.\n"
-	msg += "4. Cek progress kapan saja dengan `#goal`. Jika ingin ganti target saat masih aktif, pakai `#goal reset` dulu.\n"
-	msg += "5. Saat target tercapai, total goals di `#mystats` dan `#achievements` bertambah.\n\n"
+	msg += "Notifikasi /lapor hanya menampilkan badge terbaru supaya ringkas. Detail lengkap bisa dicek di web.\n\n"
 	msg += "✨ *Flow Side Quest Harian*\n"
-	msg += "1. Pilih job dulu dengan `#job <id>` agar side quest terbuka.\n"
-	msg += "2. Setiap pagi bot memberi reminder di grup; cek detail quest kamu dengan `#mysidequest`.\n"
+	msg += "1. Setiap pagi bot memberi reminder di grup untuk hunter yang sudah punya job.\n"
+	msg += "2. Cek detail quest kamu dengan `/lapor sidequest`.\n"
 	msg += "3. Pilih easy (jalan kaki atau sepeda), medium, hard, atau beberapa sekaligus.\n"
-	msg += "4. Lapor dengan format `#lapor sidequest <kegiatan> <jumlah>`, gunakan nama kegiatan yang tertera di `#mysidequest`. Contoh: `#lapor sidequest jalan kaki 4000`, `#lapor sidequest sepeda 5 km`, `#lapor sidequest chair squat 18`.\n"
-	msg += "5. Side quest memberi XP bonus kecil (bervariasi per difficulty), tetap masuk streak, stats, leaderboard, goal, dan total side quest di `#mystats`/`#achievements`.\n\n"
+	msg += "4. Lapor dengan format `/lapor sidequest <kegiatan> <jumlah>`, gunakan nama kegiatan yang tertera di daftar quest. Contoh: `/lapor sidequest jalan kaki 4000`, `/lapor sidequest sepeda 5 km`, `/lapor sidequest chair squat 18`.\n"
+	msg += "5. Side quest memberi XP bonus kecil (bervariasi per difficulty), tetap masuk streak, stats, leaderboard, dan total side quest di web.\n\n"
 	msg += "_Catatan: Bot hanya merespon di grup yang sudah dikonfigurasi. Semangat terus! 💪_\n\n" +
 		"🌐 Klasemen & stats personal: https://lapor-bot.web.id/"
 	return msg

--- a/internal/app/usecase/handle_message_usecase.go
+++ b/internal/app/usecase/handle_message_usecase.go
@@ -4,9 +4,17 @@ import (
 	"context"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/fardannozami/whatsapp-gateway/internal/domain"
 )
+
+const commandPrefix = "/"
+
+const unknownCommandMessage = "📋 Maaf, command yang kamu kirim belum tersedia nih! 😅\n\n" +
+	"Coba cek command yang bisa dipakai dengan `/help` atau langsung kunjungi:\n" +
+	"🌐 https://lapor-bot.web.id/\n\n" +
+	"Di sana kamu bisa lihat klasemen, stats personal, dan info lainnya! ✨"
 
 type MessageResponse struct {
 	Text      string
@@ -64,39 +72,44 @@ func NewHandleMessageUsecase(
 }
 
 func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, message string) (MessageResponse, error) {
-	msg := strings.ToLower(strings.TrimSpace(message))
+	trimmedMessage := strings.TrimSpace(message)
+	msg := strings.ToLower(trimmedMessage)
 
 	if msg == "" {
 		return MessageResponse{}, nil
 	}
 
-	if strings.Contains(msg, "#tutorial") {
+	if !strings.HasPrefix(msg, commandPrefix) {
+		return MessageResponse{}, nil
+	}
+
+	if hasCommand(msg, "/tutorial") {
 		text := uc.helpUC.ExecuteTutorial()
 		return MessageResponse{Text: text}, nil
 	}
 
-	if strings.Contains(msg, "#help") {
+	if hasCommand(msg, "/help") {
 		text := uc.helpUC.Execute()
 		return MessageResponse{Text: text}, nil
 	}
 
-	// if strings.Contains(msg, "#attributes") || strings.Contains(msg, "#attributs") || strings.Contains(msg, "#atributs") {
+	// if hasCommand(msg, "/attributes") || hasCommand(msg, "/attributs") || hasCommand(msg, "/atributs") {
 	// 	text := uc.helpUC.ExecuteAttributes()
 	// 	return MessageResponse{Text: text}, nil
 	// }
 
-	if strings.Contains(msg, "#lapor-kemarin") {
-		workout := domain.ParseHevy(message)
-		text, err := uc.reportUC.ExecuteYesterdayWithMessage(ctx, userID, name, message, workout)
+	if hasCommand(msg, "/lapor-kemarin") {
+		workout := domain.ParseHevy(trimmedMessage)
+		text, err := uc.reportUC.ExecuteYesterdayWithMessage(ctx, userID, name, trimmedMessage, workout)
 		return MessageResponse{Text: text}, err
 	}
 
-	// if strings.Contains(msg, "#mysidequest") {
+	// if hasCommand(msg, "/mysidequest") {
 	// 	text, err := uc.dailyQuestUC.ViewQuest(ctx, userID, name, time.Now())
 	// 	return MessageResponse{Text: text}, err
 	// }
 
-	if arg, ok := extractSideQuestReport(message); ok {
+	if arg, ok := extractSideQuestReport(trimmedMessage); ok {
 		if arg == "" {
 			text, err := uc.dailyQuestUC.ViewQuest(ctx, userID, name, time.Now())
 			return MessageResponse{Text: text}, err
@@ -105,89 +118,89 @@ func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, messa
 		return MessageResponse{Text: text}, err
 	}
 
-	if strings.Contains(msg, "#lapor") {
-		workout := domain.ParseHevy(message)
-		text, err := uc.reportUC.ExecuteWithMessage(ctx, userID, name, message, workout)
+	if hasCommand(msg, "/lapor") {
+		workout := domain.ParseHevy(trimmedMessage)
+		text, err := uc.reportUC.ExecuteWithMessage(ctx, userID, name, trimmedMessage, workout)
 		return MessageResponse{Text: text}, err
 	}
 
-	if strings.Contains(msg, "#cancel-all") {
+	if hasCommand(msg, "/cancel-all") {
 		text, err := uc.cancelUC.ExecuteAll(ctx, userID, name)
 		return MessageResponse{Text: text}, err
 	}
 
-	if strings.Contains(msg, "#cancel") {
+	if hasCommand(msg, "/cancel") {
 		text, err := uc.cancelUC.Execute(ctx, userID, name)
 		return MessageResponse{Text: text}, err
 	}
 
-	// if strings.Contains(msg, "#motivasi") {
+	// if hasCommand(msg, "/motivasi") {
 	// 	text := uc.motivationUC.Execute()
 	// 	return MessageResponse{Text: text}, nil
 	// }
 
-	// if strings.Contains(msg, "#jobs") {
+	// if hasCommand(msg, "/jobs") {
 	// 	return MessageResponse{Text: uc.jobUC.List()}, nil
 	// }
 
-	// if strings.Contains(msg, "#goal") {
+	// if hasCommand(msg, "/goal") {
 	// 	text, err := uc.goalUC.Execute(ctx, userID, name, message)
 	// 	return MessageResponse{Text: text}, err
 	// }
 
-	// if strings.Contains(msg, "#job") {
-	// 	idx := strings.Index(msg, "#job")
-	// 	jobID := strings.TrimSpace(msg[idx+len("#job"):])
+	// if hasCommand(msg, "/job") {
+	// 	idx := strings.Index(msg, "/job")
+	// 	jobID := strings.TrimSpace(msg[idx+len("/job"):])
 	// 	if jobID == "" {
-	// 		return MessageResponse{Text: "Pilih job dengan format: #job <id>. Cek daftar job dengan #jobs."}, nil
+	// 		return MessageResponse{Text: "Pilih job dengan format: /job <id>. Cek daftar job dengan /jobs."}, nil
 	// 	}
 	// 	text, err := uc.jobUC.Select(ctx, userID, name, jobID)
 	// 	return MessageResponse{Text: text}, err
 	// }
 
-	// if strings.Contains(msg, "#setname") {
-	// 	idx := strings.Index(msg, "#setname")
-	// 	newName := strings.TrimSpace(message[idx+len("#setname"):])
+	// if hasCommand(msg, "/setname") {
+	// 	idx := strings.Index(msg, "/setname")
+	// 	newName := strings.TrimSpace(message[idx+len("/setname"):])
 	// 	text, err := uc.updateNameUC.Execute(ctx, userID, newName)
 	// 	return MessageResponse{Text: text}, err
 	// }
 
-	// if strings.Contains(msg, "#leaderboard-weekly") {
+	// if hasCommand(msg, "/leaderboard-weekly") {
 	// 	text, err := uc.weeklyLeaderboardUC.Execute(ctx)
 	// 	return MessageResponse{Text: text}, err
 	// }
 
-	// if strings.Contains(msg, "#leaderboard-seasonal") {
+	// if hasCommand(msg, "/leaderboard-seasonal") {
 	// 	text, err := uc.leaderboardUC.ExecuteSeasonal(ctx)
 	// 	return MessageResponse{Text: text}, err
 	// }
 
-	// if strings.Contains(msg, "#ranks") {
+	// if hasCommand(msg, "/ranks") {
 	// 	text, err := uc.leaderboardUC.ExecuteRanks(ctx)
 	// 	return MessageResponse{Text: text}, err
 	// }
 
-	// if strings.Contains(msg, "#leaderboard") {
+	// if hasCommand(msg, "/leaderboard") {
 	// 	text, err := uc.leaderboardUC.Execute(ctx)
 	// 	return MessageResponse{Text: text}, err
 	// }
 
-	// if strings.Contains(msg, "#mystats") {
+	// if hasCommand(msg, "/mystats") {
 	// 	text, err := uc.myStatsUC.Execute(ctx, userID, name)
 	// 	return MessageResponse{Text: text}, err
 	// }
 
-	// if strings.Contains(msg, "#achievements") {
+	// if hasCommand(msg, "/achievements") {
 	// 	text, err := uc.achievementsUC.Execute(ctx)
 	// 	return MessageResponse{Text: text}, err
 	// }
 
-	// if strings.Contains(msg, "#comeback") {
+	// if hasCommand(msg, "/comeback") {
 	// 	text, err := uc.comebackUC.Execute(ctx, userID, name)
 	// 	return MessageResponse{Text: text}, err
 	// }
 
-	// if strings.Contains(msg, "#strava") {
+	// if hasCommand(msg, "/strava") {
 	// 	authURL := uc.linkStravaUC.GetAuthURL(userID, name)
 	// 	text := fmt.Sprintf("🚴‍♂️ *Integrasi Strava* 🏃‍♂️\n\nKlik link di bawah ini untuk menghubungkan akun Strava kamu:\n\n%s\n\nSetelah berhasil, aktivitas larimu akan otomatis dilaporkan! 🎉", authURL)
 	// 	return MessageResponse{Text: text, IsPrivate: true}, nil
@@ -198,22 +211,26 @@ func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, messa
 	// 	return MessageResponse{Text: text}, nil
 	// }
 
-	return MessageResponse{
-		Text: "📋 Maaf, command yang kamu kirim belum tersedia nih! 😅\n\n" +
-			"Coba cek command yang bisa dipakai dengan `#help` atau langsung kunjungi:\n" +
-			"🌐 https://lapor-bot.web.id/\n\n" +
-			"Di sana kamu bisa lihat klasemen, stats personal, dan info lainnya! ✨",
-	}, nil
+	return MessageResponse{Text: unknownCommandMessage}, nil
 }
 
 func extractSideQuestReport(message string) (string, bool) {
 	lower := strings.ToLower(message)
-	for _, command := range []string{"#lapor sidequest", "#lapor-sidequest"} {
-		idx := strings.Index(lower, command)
-		if idx == -1 {
+	for _, command := range []string{"/lapor sidequest", "/lapor-sidequest"} {
+		if !hasCommand(lower, command) {
 			continue
 		}
-		return strings.TrimSpace(message[idx+len(command):]), true
+		return strings.TrimSpace(message[len(command):]), true
 	}
 	return "", false
+}
+
+func hasCommand(message, command string) bool {
+	if !strings.HasPrefix(message, command) {
+		return false
+	}
+	if len(message) == len(command) {
+		return true
+	}
+	return unicode.IsSpace(rune(message[len(command)]))
 }

--- a/internal/app/usecase/handle_message_usecase_test.go
+++ b/internal/app/usecase/handle_message_usecase_test.go
@@ -14,9 +14,10 @@ import (
 // =============================================================================
 //
 // Tests command routing logic:
-// - #lapor → routes to ReportActivityUsecase
-// - #leaderboard → routes to GetLeaderboardUsecase
-// - Unknown commands → returns empty string (no response)
+// - /lapor → routes to ReportActivityUsecase
+// - /leaderboard → disabled command fallback
+// - regular chat messages → returns empty string (no response)
+// - unknown slash commands → fallback response
 //
 // =============================================================================
 
@@ -197,8 +198,8 @@ func TestHandleMessage_LaporCommand(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Test #lapor command
-	msg, err := handleUC.Execute(ctx, "user123", "TestUser", "#lapor")
+	// Test /lapor command
+	msg, err := handleUC.Execute(ctx, "user123", "TestUser", "/lapor")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -230,7 +231,7 @@ func TestHandleMessage_LaporCaseInsensitive(t *testing.T) {
 
 	ctx := context.Background()
 
-	testCases := []string{"#LAPOR", "#Lapor", "#LaPor", "#lapor"}
+	testCases := []string{"/LAPOR", "/Lapor", "/LaPor", "/lapor"}
 	for _, cmd := range testCases {
 		// Reset repo for each test
 		repo.reports = make(map[string]*domain.Report)
@@ -258,12 +259,12 @@ func TestHandleMessage_LaporWithTrailingText(t *testing.T) {
 	ctx := context.Background()
 
 	// Command with trailing text should still work
-	msg, err := handleUC.Execute(ctx, "user1", "User", "#lapor hari ini olahraga lari")
+	msg, err := handleUC.Execute(ctx, "user1", "User", "/lapor hari ini olahraga lari")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	if msg.Text == "" {
-		t.Error("#lapor with trailing text should still be recognized")
+		t.Error("/lapor with trailing text should still be recognized")
 	}
 }
 
@@ -287,8 +288,8 @@ func TestHandleMessage_LeaderboardCommand(t *testing.T) {
 		ActivityCount: 5,
 	}
 
-	// #leaderboard command is currently disabled — should get fallback message
-	msg, err := handleUC.Execute(ctx, "user1", "User", "#leaderboard")
+	// /leaderboard command is currently disabled — should get fallback message
+	msg, err := handleUC.Execute(ctx, "user1", "User", "/leaderboard")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -310,7 +311,7 @@ func TestHandleMessage_LeaderboardCaseInsensitive(t *testing.T) {
 
 	ctx := context.Background()
 
-	testCases := []string{"#LEADERBOARD", "#Leaderboard", "#LeaderBoard", "#leaderboard"}
+	testCases := []string{"/LEADERBOARD", "/Leaderboard", "/LeaderBoard", "/leaderboard"}
 	for _, cmd := range testCases {
 		msg, err := handleUC.Execute(ctx, "user1", "User", cmd)
 		if err != nil {
@@ -340,7 +341,7 @@ func TestHandleMessage_WeeklyLeaderboardCommand(t *testing.T) {
 
 	ctx := context.Background()
 
-	msg, err := handleUC.Execute(ctx, "user1", "User", "#leaderboard-weekly")
+	msg, err := handleUC.Execute(ctx, "user1", "User", "/leaderboard-weekly")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -349,7 +350,7 @@ func TestHandleMessage_WeeklyLeaderboardCommand(t *testing.T) {
 	}
 }
 
-func TestHandleMessage_UnknownCommand_ReturnsFallback(t *testing.T) {
+func TestHandleMessage_NonCommand_ReturnsNoResponse(t *testing.T) {
 	repo := &mockReportRepo{reports: make(map[string]*domain.Report)}
 	reportUC := usecase.NewReportActivityUsecase(repo)
 	leaderboardUC := usecase.NewGetLeaderboardUsecase(repo)
@@ -364,9 +365,10 @@ func TestHandleMessage_UnknownCommand_ReturnsFallback(t *testing.T) {
 	testCases := []string{
 		"hello",
 		"random message",
-		"#invalid",
 		"lapor",
 		"leaderboard",
+		"#invalid",
+		"#lapor",
 	}
 
 	for _, msgText := range testCases {
@@ -374,8 +376,32 @@ func TestHandleMessage_UnknownCommand_ReturnsFallback(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unexpected error for '%s': %v", msgText, err)
 		}
+		if result.Text != "" {
+			t.Errorf("Non-command message '%s' should not return a response, got '%s'", msgText, result.Text)
+		}
+	}
+}
+
+func TestHandleMessage_UnknownSlashCommand_ReturnsFallback(t *testing.T) {
+	repo := &mockReportRepo{reports: make(map[string]*domain.Report)}
+	reportUC := usecase.NewReportActivityUsecase(repo)
+	leaderboardUC := usecase.NewGetLeaderboardUsecase(repo)
+	myStatsUC := usecase.NewGetMyStatsUsecase(repo)
+	achievementsUC := usecase.NewGetAchievementsUsecase(repo)
+	comebackUC := usecase.NewComebackChallengeUsecase(repo)
+	updateNameUC := usecase.NewUpdateNameUsecase(repo)
+	handleUC := usecase.NewHandleMessageUsecase(reportUC, leaderboardUC, myStatsUC, achievementsUC, comebackUC, usecase.NewCancelReportUsecase(repo), updateNameUC, nil, usecase.NewBroadcastUpdateUsecase(), usecase.NewGetMotivationUsecase(), usecase.NewGetHelpUsecase())
+
+	ctx := context.Background()
+
+	testCases := []string{"/invalid", "/mystats", "/laporhalo"}
+	for _, msgText := range testCases {
+		result, err := handleUC.Execute(ctx, "user1", "User", msgText)
+		if err != nil {
+			t.Fatalf("Unexpected error for '%s': %v", msgText, err)
+		}
 		if !containsSubstring(result.Text, "https://lapor-bot.web.id/") {
-			t.Errorf("Unknown command '%s' should return fallback with website URL, got '%s'", msgText, result.Text)
+			t.Errorf("Unknown slash command '%s' should return fallback with website URL, got '%s'", msgText, result.Text)
 		}
 	}
 }
@@ -394,11 +420,11 @@ func TestHandleMessage_WhitespaceHandling(t *testing.T) {
 
 	// Test with leading/trailing whitespace
 	testCases := []string{
-		"  #lapor",
-		"#lapor  ",
-		"  #lapor  ",
-		"\t#lapor",
-		"\n#lapor\n",
+		"  /lapor",
+		"/lapor  ",
+		"  /lapor  ",
+		"\t/lapor",
+		"\n/lapor\n",
 	}
 
 	for i, cmd := range testCases {
@@ -457,22 +483,22 @@ func TestHandleMessage_GamificationCommands(t *testing.T) {
 		Achievements:  "first_report",
 	}
 
-	// #mystats is now disabled — should get fallback
-	msg, err := handleUC.Execute(ctx, "user1", "Gamer", "#mystats")
+	// /mystats is now disabled — should get fallback
+	msg, err := handleUC.Execute(ctx, "user1", "Gamer", "/mystats")
 	if err != nil {
-		t.Fatalf("Unexpected error for #mystats: %v", err)
+		t.Fatalf("Unexpected error for /mystats: %v", err)
 	}
 	if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
-		t.Errorf("Disabled #mystats should return fallback with website URL, got: %s", msg.Text)
+		t.Errorf("Disabled /mystats should return fallback with website URL, got: %s", msg.Text)
 	}
 
-	// #achievements is now disabled — should get fallback
-	msg, err = handleUC.Execute(ctx, "user1", "Gamer", "#achievements")
+	// /achievements is now disabled — should get fallback
+	msg, err = handleUC.Execute(ctx, "user1", "Gamer", "/achievements")
 	if err != nil {
-		t.Fatalf("Unexpected error for #achievements: %v", err)
+		t.Fatalf("Unexpected error for /achievements: %v", err)
 	}
 	if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
-		t.Errorf("Disabled #achievements should return fallback with website URL, got: %s", msg.Text)
+		t.Errorf("Disabled /achievements should return fallback with website URL, got: %s", msg.Text)
 	}
 }
 
@@ -488,13 +514,13 @@ func TestHandleMessage_JobCommands(t *testing.T) {
 
 	ctx := context.Background()
 
-	// #jobs command is now disabled — should get fallback
-	msg, err := handleUC.Execute(ctx, "user1", "Hunter", "#jobs")
+	// /jobs command is now disabled — should get fallback
+	msg, err := handleUC.Execute(ctx, "user1", "Hunter", "/jobs")
 	if err != nil {
-		t.Fatalf("unexpected error for #jobs: %v", err)
+		t.Fatalf("unexpected error for /jobs: %v", err)
 	}
 	if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
-		t.Fatalf("Disabled #jobs should return fallback with website URL, got %q", msg.Text)
+		t.Fatalf("Disabled /jobs should return fallback with website URL, got %q", msg.Text)
 	}
 
 	repo.reports["user1"] = &domain.Report{
@@ -503,34 +529,34 @@ func TestHandleMessage_JobCommands(t *testing.T) {
 		TotalPoints: 100,
 	}
 
-	// #job command is now disabled — should get fallback
-	msg, err = handleUC.Execute(ctx, "user1", "Hunter", "#job ranger")
+	// /job command is now disabled — should get fallback
+	msg, err = handleUC.Execute(ctx, "user1", "Hunter", "/job ranger")
 	if err != nil {
-		t.Fatalf("unexpected error for #job: %v", err)
+		t.Fatalf("unexpected error for /job: %v", err)
 	}
 	if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
-		t.Fatalf("Disabled #job should return fallback with website URL, got %q", msg.Text)
+		t.Fatalf("Disabled /job should return fallback with website URL, got %q", msg.Text)
 	}
 
-	// #job command is now disabled — set job directly in repo for lapor test
+	// /job command is now disabled — set job directly in repo for lapor test
 	repo.reports["user1"].JobClass = "ranger"
 
-	// #mystats doesn't show job anymore since mystats is disabled
-	msg, err = handleUC.Execute(ctx, "user1", "Hunter", "#mystats")
+	// /mystats doesn't show job anymore since mystats is disabled
+	msg, err = handleUC.Execute(ctx, "user1", "Hunter", "/mystats")
 	if err != nil {
-		t.Fatalf("unexpected error for #mystats: %v", err)
+		t.Fatalf("unexpected error for /mystats: %v", err)
 	}
 	if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
-		t.Fatalf("Disabled #mystats should return fallback with website URL, got %q", msg.Text)
+		t.Fatalf("Disabled /mystats should return fallback with website URL, got %q", msg.Text)
 	}
 
-	// #lapor still works and should show the job
-	msg, err = handleUC.Execute(ctx, "user1", "Hunter", "#lapor")
+	// /lapor still works and should show the job
+	msg, err = handleUC.Execute(ctx, "user1", "Hunter", "/lapor")
 	if err != nil {
-		t.Fatalf("unexpected error for #lapor: %v", err)
+		t.Fatalf("unexpected error for /lapor: %v", err)
 	}
 	if !containsSubstring(msg.Text, "Job: Ranger") {
-		t.Fatalf("#lapor should include selected job, got %q", msg.Text)
+		t.Fatalf("/lapor should include selected job, got %q", msg.Text)
 	}
 }
 
@@ -546,21 +572,21 @@ func TestHandleMessage_SetNameCommand(t *testing.T) {
 
 	ctx := context.Background()
 
-	// #setname command is now disabled — should get fallback
-	msg, err := handleUC.Execute(ctx, "userVip", "OldName", "#setname King Budi")
+	// /setname command is now disabled — should get fallback
+	msg, err := handleUC.Execute(ctx, "userVip", "OldName", "/setname King Budi")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
-		t.Errorf("Disabled #setname should return fallback, got: %s", msg.Text)
+		t.Errorf("Disabled /setname should return fallback, got: %s", msg.Text)
 	}
 
-	msg, err = handleUC.Execute(ctx, "userVip", "King Budi", "#setname Budi Solo")
+	msg, err = handleUC.Execute(ctx, "userVip", "King Budi", "/setname Budi Solo")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
-		t.Errorf("Disabled #setname should return fallback, got: %s", msg.Text)
+		t.Errorf("Disabled /setname should return fallback, got: %s", msg.Text)
 	}
 }
 
@@ -576,8 +602,8 @@ func TestHandleMessage_LaporDoesNotUpdateName(t *testing.T) {
 
 	ctx := context.Background()
 
-	// setname is disabled — PushName is used directly in #lapor instead
-	_, _ = handleUC.Execute(ctx, "user1", "InitialPushName", "#lapor")
+	// setname is disabled — PushName is used directly in /lapor instead
+	_, _ = handleUC.Execute(ctx, "user1", "InitialPushName", "/lapor")
 
 	r := repo.reports["user1"]
 	if r == nil || r.Name != "InitialPushName" {
@@ -585,7 +611,7 @@ func TestHandleMessage_LaporDoesNotUpdateName(t *testing.T) {
 	}
 
 	// Report again with different PushName — names don't auto-update either
-	_, err := handleUC.Execute(ctx, "user1", "DifferentPushName", "#lapor")
+	_, err := handleUC.Execute(ctx, "user1", "DifferentPushName", "/lapor")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -596,10 +622,9 @@ func TestHandleMessage_LaporDoesNotUpdateName(t *testing.T) {
 	}
 }
 
-func TestHandleMessage_LaporWithNonWhitespaceChars(t *testing.T) {
-	// Regression test: #lapor must trigger even when non-whitespace characters
-	// follow it (e.g., #laporhalo, #lapor123). This was broken by the old
-	// containsCommand function which required whitespace or EOS after the command.
+func TestHandleMessage_LaporWithNonWhitespaceChars_ReturnsFallback(t *testing.T) {
+	// /lapor must match a real command token so accidental slash words do not
+	// create activity reports.
 	repo := &mockReportRepo{reports: make(map[string]*domain.Report)}
 	reportUC := usecase.NewReportActivityUsecase(repo)
 	leaderboardUC := usecase.NewGetLeaderboardUsecase(repo)
@@ -612,11 +637,10 @@ func TestHandleMessage_LaporWithNonWhitespaceChars(t *testing.T) {
 	ctx := context.Background()
 
 	testCases := []string{
-		"#laporhalo",              // non-whitespace right after command
-		"#lapor123",               // numbers after command
-		"#lapor.hari.ini",         // dots after command
-		"halo#laporhalo",          // text before AND after
-		"sebelum #lapor-hari-ini", // dash-separated with preceding text
+		"/laporhalo",
+		"/lapor123",
+		"/lapor.hari.ini",
+		"/lapor-hari-ini",
 	}
 
 	for i, cmd := range testCases {
@@ -625,15 +649,18 @@ func TestHandleMessage_LaporWithNonWhitespaceChars(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test %d: unexpected error for %q: %v", i, cmd, err)
 		}
-		if msg.Text == "" {
-			t.Errorf("Test %d: %q should trigger #lapor, got empty response", i, cmd)
+		if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
+			t.Errorf("Test %d: %q should return fallback, got %q", i, cmd, msg.Text)
+		}
+		if repo.reports["user1"] != nil {
+			t.Errorf("Test %d: %q should not create an activity report", i, cmd)
 		}
 	}
 }
 
 func TestHandleMessage_LaporCommandPriority(t *testing.T) {
 	// Ensure that more specific commands (kemarin, sidequest) take priority
-	// over the generic #lapor handler even with the relaxed matching.
+	// over the generic /lapor handler.
 	repo := &mockReportRepo{reports: make(map[string]*domain.Report)}
 	reportUC := usecase.NewReportActivityUsecase(repo)
 	leaderboardUC := usecase.NewGetLeaderboardUsecase(repo)
@@ -653,27 +680,27 @@ func TestHandleMessage_LaporCommandPriority(t *testing.T) {
 		ActivityCount: 3,
 	}
 
-	t.Run("#lapor-kemarin still routes to yesterday handler", func(t *testing.T) {
-		msg, err := handleUC.Execute(ctx, "user1", "User", "#lapor-kemarin lari pagi")
+	t.Run("/lapor-kemarin still routes to yesterday handler", func(t *testing.T) {
+		msg, err := handleUC.Execute(ctx, "user1", "User", "/lapor-kemarin lari pagi")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		// Ensure the message was routed somewhere (non-empty) and is NOT the
-		// standard #lapor response. The kemarin handler produces a comeback/
+		// standard /lapor response. The kemarin handler produces a comeback/
 		// streak-based response that differs from the regular lapor output.
 		if msg.Text == "" {
-			t.Errorf("expected #lapor-kemarin to produce a response, got empty")
+			t.Errorf("expected /lapor-kemarin to produce a response, got empty")
 		}
 	})
 
-	t.Run("#lapor sidequest still routes to sidequest handler", func(t *testing.T) {
-		msg, err := handleUC.Execute(ctx, "user1", "User", "#lapor sidequest push up 20x")
+	t.Run("/lapor sidequest still routes to sidequest handler", func(t *testing.T) {
+		msg, err := handleUC.Execute(ctx, "user1", "User", "/lapor sidequest push up 20x")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		// Side quest handler returns quest-related message, NOT lapor report
 		if containsSubstring(msg.Text, "Laporan diterima") {
-			t.Errorf("expected #lapor sidequest to route to sidequest handler, not lapor, got: %q", msg.Text)
+			t.Errorf("expected /lapor sidequest to route to sidequest handler, not lapor, got: %q", msg.Text)
 		}
 	})
 }
@@ -699,13 +726,13 @@ func TestHandleMessage_MySideQuestCommand(t *testing.T) {
 		Level:       1,
 	}
 
-	// #mysidequest command is now disabled — should get fallback
-	msg, err := handleUC.Execute(ctx, "user123", "TestUser", "#mysidequest")
+	// /mysidequest command is now disabled — should get fallback
+	msg, err := handleUC.Execute(ctx, "user123", "TestUser", "/mysidequest")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
 	if !containsSubstring(msg.Text, "https://lapor-bot.web.id/") {
-		t.Errorf("Disabled #mysidequest should return fallback with website URL, got '%s'", msg.Text)
+		t.Errorf("Disabled /mysidequest should return fallback with website URL, got '%s'", msg.Text)
 	}
 }

--- a/internal/app/usecase/morning_workout_checkpoint_usecase.go
+++ b/internal/app/usecase/morning_workout_checkpoint_usecase.go
@@ -56,12 +56,12 @@ func BuildMorningWorkoutCheckpointMessage(activeToday, pendingToday []*domain.Re
 	}
 
 	if len(pendingToday) > 0 {
-		sb.WriteString("Masih pagi — ambil 10–30 menit buat jalan kaki, stretching, bodyweight workout, atau olahraga favoritmu. Setelah itu lapor di grup dengan `#lapor`. 🚀")
+		sb.WriteString("Masih pagi — ambil 10–30 menit buat jalan kaki, stretching, bodyweight workout, atau olahraga favoritmu. Setelah itu lapor di grup dengan `/lapor`. 🚀")
 	} else {
 		sb.WriteString("Mantap, semua sudah lapor hari ini. Grup sehat full power! 🏆")
 	}
 
-	sb.WriteString("\n\n✨ Kalau sudah punya job, cek bonus gerak harian dengan `#mysidequest`.")
+	sb.WriteString("\n\n✨ Kalau sudah punya job, cek bonus gerak harian dengan `/lapor sidequest`.")
 	sb.WriteString("\n\n🌐 Lihat klasemen & stats: https://lapor-bot.web.id/")
 
 	return sb.String()

--- a/internal/app/usecase/morning_workout_checkpoint_usecase_test.go
+++ b/internal/app/usecase/morning_workout_checkpoint_usecase_test.go
@@ -35,8 +35,8 @@ func TestBuildMorningWorkoutCheckpointMessage(t *testing.T) {
 	for _, want := range []string{
 		"09:09 Workout Checkpoint",
 		"sudah ada 1 laporan olahraga",
-		"#lapor",
-		"#mysidequest",
+		"/lapor",
+		"/lapor sidequest",
 	} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("expected message to contain %q, got %q", want, msg)

--- a/internal/app/usecase/remind_inactive_users_usecase.go
+++ b/internal/app/usecase/remind_inactive_users_usecase.go
@@ -192,7 +192,7 @@ func BuildReminderMessage(
 
 	// Append health pillar reminders (olahraga, makanan, istirahat, kelola stres)
 	sb.WriteString(BuildWellnessReminder())
-	sb.WriteString("\n\n✨ Sudah punya job? Cek side quest hari ini dengan `#mysidequest` untuk bonus gerak ringan sebelum hari selesai.")
+	sb.WriteString("\n\n✨ Sudah punya job? Cek side quest hari ini dengan `/lapor sidequest` untuk bonus gerak ringan sebelum hari selesai.")
 	sb.WriteString("\n\n🌐 Lihat klasemen & stats: https://lapor-bot.web.id/")
 
 	mentions = deduplicateMentions(mentions)

--- a/internal/app/usecase/remind_inactive_users_usecase_test.go
+++ b/internal/app/usecase/remind_inactive_users_usecase_test.go
@@ -144,8 +144,8 @@ func TestBuildReminderMessage(t *testing.T) {
 	if !strings.Contains(msg, "Ada *2 orang* yang sudah bergerak") {
 		t.Error("expected reminder to appreciate active users collectively")
 	}
-	if !strings.Contains(msg, "#mysidequest") {
-		t.Error("expected 15:15 reminder to include #mysidequest info")
+	if !strings.Contains(msg, "/lapor sidequest") {
+		t.Error("expected 15:15 reminder to include /lapor sidequest info")
 	}
 	for _, active := range activeToday {
 		if strings.Contains(msg, active.Name) || strings.Contains(msg, active.UserID) {

--- a/internal/app/usecase/report_activity_usecase.go
+++ b/internal/app/usecase/report_activity_usecase.go
@@ -82,7 +82,7 @@ func (uc *ReportActivityUsecase) execute(ctx context.Context, userID, name strin
 	}
 
 	if dailyCount >= MaxDailyReports {
-		msg := fmt.Sprintf("%s sudah laporan %dx hari ini, ayo jangan curang! 😉\n\nBatas harian adalah %d laporan: laporan pertama untuk progres utama, laporan ke-2 dan ke-3 hanya bonus ½ XP. Kalau tadi salah input, pakai #cancel untuk hapus laporan terakhir atau #cancel-all untuk hapus semua laporan hari ini. 🙏", report.Name, MaxDailyReports, MaxDailyReports)
+		msg := fmt.Sprintf("%s sudah laporan %dx hari ini, ayo jangan curang! 😉\n\nBatas harian adalah %d laporan: laporan pertama untuk progres utama, laporan ke-2 dan ke-3 hanya bonus ½ XP. Kalau tadi salah input, pakai /cancel untuk hapus laporan terakhir atau /cancel-all untuk hapus semua laporan hari ini. 🙏", report.Name, MaxDailyReports, MaxDailyReports)
 		msg += fmt.Sprintf("\n\n💬 _\"%s\"_", RandomQuote())
 		return msg, nil
 	}
@@ -223,13 +223,13 @@ func (uc *ReportActivityUsecase) execute(ctx context.Context, userID, name strin
 	var statGains []string
 	if reportPoints > 0 && len(attrs) > 0 {
 		statPoints := reportPoints / len(attrs)
-		
+
 		scalingLevel := oldNumericLevel
 		if scalingLevel < 1 {
 			scalingLevel = 1
 		}
 		statPoints = statPoints / scalingLevel
-		
+
 		if statPoints == 0 {
 			statPoints = 1 // Ensure at least 1 point if it divided down to 0
 		}
@@ -398,7 +398,7 @@ func (uc *ReportActivityUsecase) execute(ctx context.Context, userID, name strin
 			response += fmt.Sprintf("\n\n❄️ Bonus: +1 Streak Freeze! (Total: %d)", report.StreakFreezes)
 		}
 
-		response += "\nDetail badge & cerita unlock: #achievements"
+		response += "\nDetail badge & cerita unlock: https://lapor-bot.web.id/"
 	}
 
 	response += fmt.Sprintf("\n\n💬 _\"%s\"_", RandomQuote())
@@ -446,7 +446,7 @@ func (uc *ReportActivityUsecase) executeYesterday(ctx context.Context, userID, n
 	}
 
 	if report != nil && domain.GetToday(report.LastReportDate).Equal(today) {
-		return fmt.Sprintf("%s sudah laporan hari ini. Gunakan #lapor untuk laporan tambahan hari ini. 💪", report.Name), nil
+		return fmt.Sprintf("%s sudah laporan hari ini. Gunakan /lapor untuk laporan tambahan hari ini. 💪", report.Name), nil
 	}
 
 	if report != nil {
@@ -560,13 +560,13 @@ func (uc *ReportActivityUsecase) executeYesterday(ctx context.Context, userID, n
 	var statGains []string
 	if reportPoints > 0 && len(attrs) > 0 {
 		statPoints := reportPoints / len(attrs)
-		
+
 		scalingLevel := oldNumericLevel
 		if scalingLevel < 1 {
 			scalingLevel = 1
 		}
 		statPoints = statPoints / scalingLevel
-		
+
 		if statPoints == 0 {
 			statPoints = 1 // Ensure at least 1 point
 		}
@@ -717,7 +717,7 @@ func (uc *ReportActivityUsecase) executeYesterday(ctx context.Context, userID, n
 			response += fmt.Sprintf("\n\n❄️ Bonus: +1 Streak Freeze! (Total: %d)", report.StreakFreezes)
 		}
 
-		response += "\nDetail badge & cerita unlock: #achievements"
+		response += "\nDetail badge & cerita unlock: https://lapor-bot.web.id/"
 	}
 
 	response += fmt.Sprintf("\n\n💬 _\"%s\"_", RandomQuote())
@@ -787,12 +787,20 @@ func (uc *ReportActivityUsecase) getNextComebackTarget(report *domain.Report) *d
 
 func formatCurrentAttributes(report *domain.Report) string {
 	str := report.Str
-	if str < 1 { str = 1 }
+	if str < 1 {
+		str = 1
+	}
 	sta := report.Sta
-	if sta < 1 { sta = 1 }
+	if sta < 1 {
+		sta = 1
+	}
 	agi := report.Agi
-	if agi < 1 { agi = 1 }
+	if agi < 1 {
+		agi = 1
+	}
 	vit := report.Vit
-	if vit < 1 { vit = 1 }
+	if vit < 1 {
+		vit = 1
+	}
 	return fmt.Sprintf("🛡️ Stats: STR %d | STA %d | AGI %d | VIT %d", str, sta, agi, vit)
 }

--- a/internal/app/usecase/reset_session_usecase.go
+++ b/internal/app/usecase/reset_session_usecase.go
@@ -161,7 +161,7 @@ Halo para pejuang keringat! 🏋️‍♂️
 🆕 *Season %d dimulai SEKARANG!*
 Semua peserta mulai dari titik yang sama untuk seasonal ranking. Tapi level dan EXP lifetime kamu tetap ada! 💪
 
-📌 Langsung laporkan aktivitas pertamamu di Season %d dengan mengirim #lapor!
+📌 Langsung laporkan aktivitas pertamamu di Season %d dengan mengirim /lapor!
 
 *Semangat Season %d!* 🚀🔥`, sessionNumber, seasonTransition, sessionNumber, sessionNumber, sessionNumber)
 }


### PR DESCRIPTION
- Move all WhatsApp commands from  prefix to  to better align with common chat app patterns.
- Consolidate all leaderboard and stats-related commands to the web dashboard (https://lapor-bot.web.id/) to reduce group chat clutter.
- Update all command references in the  and internal messages to reflect the new  prefix and web dashboard.