### PR TITLE
feat(commands): nudge users from hash to slash commands

### DIFF
--- a/internal/app/usecase/get_leaderboard_usecase.go
+++ b/internal/app/usecase/get_leaderboard_usecase.go
@@ -123,7 +123,7 @@ func (uc *GetLeaderboardUsecase) ExecuteSeasonal(ctx context.Context) (string, e
 
 	if len(reports) == 0 {
 		sb.WriteString("Belum ada yang aktif di season ini.\n")
-		sb.WriteString("Jadilah yang pertama dengan #lapor! 💪")
+		sb.WriteString("Jadilah yang pertama dengan /lapor! 💪")
 		return sb.String(), nil
 	}
 
@@ -209,7 +209,7 @@ func (uc *GetLeaderboardUsecase) ExecuteRanks(ctx context.Context) (string, erro
 	}
 
 	if rank == 1 {
-		sb.WriteString("Belum ada hunter aktif season ini. Mulai dengan #lapor 💪")
+		sb.WriteString("Belum ada hunter aktif season ini. Mulai dengan /lapor 💪")
 		return sb.String(), nil
 	}
 

--- a/internal/app/usecase/handle_message_usecase.go
+++ b/internal/app/usecase/handle_message_usecase.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 	"unicode"
@@ -11,10 +12,50 @@ import (
 
 const commandPrefix = "/"
 
+// legacyCommandPrefix is the old "#" trigger. Users still sending "#lapor" get
+// a friendly nudge to switch to "/" so they become aware of the change.
+const legacyCommandPrefix = "#"
+
+// activeCommands lists every command currently wired in Execute, longest first
+// so "#lapor sidequest" matches before "#lapor".
+var activeCommands = []string{
+	"/lapor sidequest",
+	"/lapor-kemarin",
+	"/lapor",
+	"/cancel-all",
+	"/cancel",
+	"/tutorial",
+	"/help",
+}
+
 const unknownCommandMessage = "📋 Maaf, command yang kamu kirim belum tersedia nih! 😅\n\n" +
 	"Coba cek command yang bisa dipakai dengan `/help` atau langsung kunjungi:\n" +
 	"🌐 https://lapor-bot.web.id/\n\n" +
 	"Di sana kamu bisa lihat klasemen, stats personal, dan info lainnya! ✨"
+
+const legacyHashCommandMessage = "😅 Ups, command pakai *#* sudah pensiun nih!\n\n" +
+	"Waktu perubahan: semua command sekarang pakai */* (slash) ya, biar lebih gampang dan konsisten. " +
+	"Coba kirim ulang:\n\n" +
+	"👉 %s\n\n" +
+	"✨ Mau lihat semua command? Ketik /help"
+
+// legacyHashCommandSuggestion returns a friendly nudge when a user triggers an
+// active command with the old "#" prefix. Returns "" when the message is not a
+// legacy # command or does not match any active command, so ordinary hashtags
+// stay silent and don't spam the group.
+func legacyHashCommandSuggestion(loweredMsg, originalMsg string) string {
+	if !strings.HasPrefix(loweredMsg, legacyCommandPrefix) {
+		return ""
+	}
+	slashed := commandPrefix + loweredMsg[len(legacyCommandPrefix):]
+	for _, cmd := range activeCommands {
+		if hasCommand(slashed, cmd) {
+			suggested := commandPrefix + strings.TrimSpace(originalMsg[len(legacyCommandPrefix):])
+			return fmt.Sprintf(legacyHashCommandMessage, suggested)
+		}
+	}
+	return ""
+}
 
 type MessageResponse struct {
 	Text      string
@@ -76,6 +117,16 @@ func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, messa
 	msg := strings.ToLower(trimmedMessage)
 
 	if msg == "" {
+		return MessageResponse{}, nil
+	}
+
+	// Nudge users who still trigger commands with the legacy "#" prefix (e.g.
+	// "#lapor") to switch to the active "/" prefix. Only matches active
+	// commands; other hashtags stay silent.
+	if strings.HasPrefix(msg, legacyCommandPrefix) {
+		if suggestion := legacyHashCommandSuggestion(msg, trimmedMessage); suggestion != "" {
+			return MessageResponse{Text: suggestion}, nil
+		}
 		return MessageResponse{}, nil
 	}
 

--- a/internal/app/usecase/handle_message_usecase_test.go
+++ b/internal/app/usecase/handle_message_usecase_test.go
@@ -368,7 +368,6 @@ func TestHandleMessage_NonCommand_ReturnsNoResponse(t *testing.T) {
 		"lapor",
 		"leaderboard",
 		"#invalid",
-		"#lapor",
 	}
 
 	for _, msgText := range testCases {
@@ -378,6 +377,53 @@ func TestHandleMessage_NonCommand_ReturnsNoResponse(t *testing.T) {
 		}
 		if result.Text != "" {
 			t.Errorf("Non-command message '%s' should not return a response, got '%s'", msgText, result.Text)
+		}
+	}
+}
+
+func TestHandleMessage_LegacyHashCommand_ReturnsNudge(t *testing.T) {
+	repo := &mockReportRepo{reports: make(map[string]*domain.Report)}
+	reportUC := usecase.NewReportActivityUsecase(repo)
+	leaderboardUC := usecase.NewGetLeaderboardUsecase(repo)
+	myStatsUC := usecase.NewGetMyStatsUsecase(repo)
+	achievementsUC := usecase.NewGetAchievementsUsecase(repo)
+	comebackUC := usecase.NewComebackChallengeUsecase(repo)
+	updateNameUC := usecase.NewUpdateNameUsecase(repo)
+	handleUC := usecase.NewHandleMessageUsecase(reportUC, leaderboardUC, myStatsUC, achievementsUC, comebackUC, usecase.NewCancelReportUsecase(repo), updateNameUC, nil, usecase.NewBroadcastUpdateUsecase(), usecase.NewGetMotivationUsecase(), usecase.NewGetHelpUsecase())
+
+	ctx := context.Background()
+
+	// Active commands triggered with the legacy "#" prefix should nudge the
+	// user to switch to "/", preserving the original arguments.
+	tests := []struct {
+		input        string
+		wantContains string
+	}{
+		{"#lapor", "/lapor"},
+		{"#lapor Push Day", "/lapor Push Day"},
+		{"#lapor sidequest", "/lapor sidequest"},
+		{"#lapor sidequest jalan kaki 4000", "/lapor sidequest jalan kaki 4000"},
+		{"#lapor-kemarin", "/lapor-kemarin"},
+		{"#cancel", "/cancel"},
+		{"#cancel-all", "/cancel-all"},
+		{"#help", "/help"},
+		{"#tutorial", "/tutorial"},
+		{"#LAPOR", "/LAPOR"},
+	}
+	for _, tt := range tests {
+		result, err := handleUC.Execute(ctx, "user1", "User", tt.input)
+		if err != nil {
+			t.Fatalf("Unexpected error for '%s': %v", tt.input, err)
+		}
+		if result.Text == "" {
+			t.Errorf("Legacy command '%s' should return a nudge, got empty", tt.input)
+			continue
+		}
+		if !containsSubstring(result.Text, tt.wantContains) {
+			t.Errorf("Legacy command '%s': expected nudge to contain '%s', got '%s'", tt.input, tt.wantContains, result.Text)
+		}
+		if !containsSubstring(result.Text, "pensiu") && !containsSubstring(result.Text, "pensiun") {
+			t.Errorf("Legacy command '%s': nudge should mention the # retirement, got '%s'", tt.input, result.Text)
 		}
 	}
 }

--- a/internal/app/usecase/weekly_hunter_ranks_announcement_usecase.go
+++ b/internal/app/usecase/weekly_hunter_ranks_announcement_usecase.go
@@ -64,7 +64,7 @@ func (u *WeeklyHunterRanksAnnouncementUsecase) Execute(ctx context.Context, now 
 	}
 
 	if rank == 1 {
-		sb.WriteString("Belum ada hunter aktif season ini. Mulai dengan #lapor 💪")
+		sb.WriteString("Belum ada hunter aktif season ini. Mulai dengan /lapor 💪")
 		return sb.String(), nil
 	}
 

--- a/internal/infra/http/handler.go
+++ b/internal/infra/http/handler.go
@@ -201,11 +201,16 @@ type GlobalSummary struct {
 	CurrentDay          int            `json:"current_day"`
 }
 
+// maskPhone hides all but the last 2 digits of a phone number so the public
+// leaderboard cannot be used to reconstruct real numbers.
+// ponytail: fixed-width mask (9 stars + 2 suffix) — no information about
+// prefix length leaks; ceiling: 2-digit suffix means 100 candidates per masked
+// value, acceptable for a public gamification dashboard.
 func maskPhone(phone string) string {
-	if len(phone) < 7 {
-		return "****"
+	if len(phone) <= 2 {
+		return "*********"
 	}
-	return phone[:5] + "****" + phone[len(phone)-3:]
+	return "*********" + phone[len(phone)-2:]
 }
 
 func buildTierProgress(value, currentMin int, nextMin int, nextName, nextIcon string, isMax bool) TierProgress {


### PR DESCRIPTION
- Introduce a nudge message for users attempting to trigger commands with the legacy '#' prefix, guiding them to use the '/' prefix.
- Update leaderboard and announcement messages to consistently display '/' as the command prefix, improving UX and command consistency.
- Implement a more robust phone number masking strategy in the HTTP handler, ensuring user privacy by obscuring all but the last two digits.