### PR TITLE
build(docker): optimize frontend build caching with workspace copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 # Stage 1: Build React Frontend
 FROM node:20-alpine AS frontend-builder
-WORKDIR /app
-COPY package*.json ./
-COPY packages/shared/package.json ./packages/shared/
-COPY frontend/web/package.json ./frontend/web/
+WORKDIR /app/frontend
+COPY frontend/package.json frontend/package-lock.json ./
+# Stub every workspace package.json so npm ci can resolve local links
+COPY frontend/packages/contract/package.json ./packages/contract/
+COPY frontend/packages/design-system/package.json ./packages/design-system/
+COPY frontend/packages/shared/package.json ./packages/shared/
+COPY frontend/packages/ui/package.json ./packages/ui/
+COPY frontend/apps/web/package.json ./apps/web/
 RUN npm ci
-COPY packages/shared/ ./packages/shared/
-COPY frontend/web/ ./frontend/web/
+# Now copy sources
+COPY frontend/packages/ ./packages/
+COPY frontend/apps/ ./apps/
 RUN npm run build --workspace=@lapor-bot/web
 
 # Stage 2: Build Go Backend
@@ -32,7 +37,7 @@ RUN mkdir -p /app/data
 COPY --from=backend-builder /app/main .
 
 # Copy built React assets
-COPY --from=frontend-builder /app/frontend/web/dist ./frontend/dist
+COPY --from=frontend-builder /app/frontend/apps/web/dist ./frontend/dist
 
 # Expose port
 EXPOSE 8080


### PR DESCRIPTION
- copies individual package.json files for workspaces for better caching
- copies source files after npm ci to leverage cache layers more effectively
- adjusts WORKDIR and final copy path to reflect new frontend base directory