### PR TITLE
feat(web): Refactor leaderboard table into components and hooks

### DIFF
--- a/frontend/apps/web/src/components/LeaderboardTable.tsx
+++ b/frontend/apps/web/src/components/LeaderboardTable.tsx
@@ -1,23 +1,18 @@
-import React, { useState, useMemo, useEffect } from "react";
-import {
-  Search,
-  SlidersHorizontal,
-  Flame,
-  Trophy,
-  Award,
-  User,
-  CalendarDays,
-} from "lucide-react";
-import type { EnrichedReport, TierProgress } from "@lapor-bot/shared";
-import { getJobBadgeClass } from "@lapor-bot/shared";
+import React, { useCallback } from "react";
+import { Search, SlidersHorizontal, Flame, Trophy, Award, CalendarDays, Swords } from "lucide-react";
+import type { EnrichedReport, LeaderboardTab, AttributeTab } from "@lapor-bot/shared";
+
+import { SeasonalRow } from "./leaderboard/rows/SeasonalRow";
+import { LifetimeRow } from "./leaderboard/rows/LifetimeRow";
+import { StreakRow } from "./leaderboard/rows/StreakRow";
+import { WeekRow } from "./leaderboard/rows/WeekRow";
+import { AttributeRow } from "./leaderboard/rows/AttributeRow";
+import { useLeaderboardData } from "./leaderboard/useLeaderboardData";
 
 interface LeaderboardTableProps {
   hunters: EnrichedReport[];
   onSelectHunter: (hunter: EnrichedReport) => void;
 }
-
-type TabType = "seasonal" | "lifetime" | "streak" | "week";
-const PAGE_SIZE = 15;
 
 const JOB_FILTER_OPTIONS = [
   { id: "all", name: "All Jobs" },
@@ -30,433 +25,74 @@ const JOB_FILTER_OPTIONS = [
   { id: "necromancer", name: "Necromancer 🌑" },
 ] as const;
 
-const LEADERBOARD_TABS: { id: TabType; label: string; icon: typeof Trophy }[] = [
+const LEADERBOARD_TABS: { id: LeaderboardTab; label: string; icon: typeof Trophy }[] = [
   { id: "seasonal", label: "Season Rank", icon: Trophy },
   { id: "lifetime", label: "Lifetime XP", icon: Award },
   { id: "streak", label: "Streak Masters", icon: Flame },
   { id: "week", label: "Minggu Ini", icon: CalendarDays },
+  { id: "attributes", label: "Attributes", icon: Swords },
 ];
 
-const ProgressBar: React.FC<{
-  progress: TierProgress;
-  valueLabel: string;
-  tone?: "gold" | "blue" | "red" | "green";
-}> = ({ progress, valueLabel, tone = "blue" }) => {
-  const gradient = {
-    gold: "from-system-gold to-system-purple",
-    blue: "from-system-blue to-system-purple",
-    red: "from-system-red to-system-gold",
-    green: "from-system-green to-system-blue",
-  }[tone];
+const ATTRIBUTE_SUB_TABS: { id: AttributeTab; label: string }[] = [
+  { id: "overall", label: "Overall" },
+  { id: "str", label: "STR" },
+  { id: "sta", label: "STA" },
+  { id: "agi", label: "AGI" },
+  { id: "vit", label: "VIT" },
+];
 
-  return (
-    <div className="min-w-[180px]">
-      <div className="h-2.5 w-full rounded-full bg-gray-900 border border-gray-800 overflow-hidden">
-        <div
-          className={`h-full rounded-full bg-gradient-to-r ${gradient} transition-all duration-500`}
-          style={{ width: `${progress.percent}%` }}
-        />
-      </div>
-      <div className="mt-1 flex justify-between text-[9px] font-mono text-gray-500">
-        <span>{valueLabel}</span>
-        {progress.is_max ? (
-          <span className="text-system-gold">MAX</span>
-        ) : (
-          <span>
-            → {progress.next_icon} {progress.next_name} ({progress.remaining}{" "}
-            pts)
-          </span>
-        )}
-      </div>
-    </div>
-  );
+const TABLE_HEADERS: Record<LeaderboardTab, string[]> = {
+  seasonal: ["Rank", "Hunter", "Job", "Season Rank", "Streak", "Active Days", "Best Season Streak", "Freezes", "Season Points + Progress"],
+  lifetime: ["Rank", "Hunter", "Job", "Level Tier", "Level", "XP Progress", "Lifetime Days", "Best Streak", "Quests Done"],
+  streak: ["Rank", "Hunter", "Job", "Current Streak", "Best Streak", "Comeback", "Centurion", "Status"],
+  week: ["Rank", "Hunter", "Job", "Active Days", "Week Dots", "Streak", "Est. Points"],
+  attributes: ["Rank", "Hunter", "Job", "Attribute", "STR", "STA", "AGI", "VIT", "Level"],
 };
 
-export const LeaderboardTable: React.FC<LeaderboardTableProps> = ({
-  hunters,
-  onSelectHunter,
-}) => {
-  const [search, setSearch] = useState("");
-  const [selectedJob, setSelectedJob] = useState("all");
-  const [activeTab, setActiveTab] = useState<TabType>("seasonal");
-  const [page, setPage] = useState(1);
+const rowClass = (rank: number) =>
+  `group transition-all hover:bg-gray-800/20 cursor-pointer ${rank < 3 ? "bg-gradient-to-r from-gray-950/20 to-transparent" : ""}`;
 
-  // Process data based on active tab, search, and job filters
-  const filteredAndSorted = useMemo(() => {
-    let result = [...hunters];
+export const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ hunters, onSelectHunter }) => {
+  const {
+    search, setSearch,
+    selectedJob, setSelectedJob,
+    activeTab, setActiveTab,
+    attributeTab, setAttributeTab,
+    safePage, totalPages, pageStartRank, totalCount,
+    visibleHunters, goToPage,
+  } = useLeaderboardData(hunters);
 
-    // Filter by search name
-    if (search.trim()) {
-      const q = search.toLowerCase();
-      result = result.filter((h) => h.name.toLowerCase().includes(q));
-    }
-
-    // Filter by job
-    if (selectedJob !== "all") {
-      result = result.filter(
-        (h) => h.job_class?.toLowerCase() === selectedJob.toLowerCase(),
-      );
-    }
-
-    if (activeTab === "seasonal") {
-      result = result.filter(
-        (h) => h.seasonal_points > 0 || h.seasonal_activity_count > 0,
-      );
-    }
-
-    if (activeTab === "week") {
-      result = result.filter((h) => h.week_active_days > 0);
-    }
-
-    // Sort based on active tab
-    result.sort((a, b) => {
-      if (activeTab === "seasonal") {
-        if (b.seasonal_points === a.seasonal_points) {
-          if (b.seasonal_activity_count === a.seasonal_activity_count) {
-            return a.name.localeCompare(b.name);
-          }
-          return b.seasonal_activity_count - a.seasonal_activity_count;
-        }
-        return b.seasonal_points - a.seasonal_points;
-      } else if (activeTab === "lifetime") {
-        if (b.total_points === a.total_points) {
-          return b.activity_count - a.activity_count;
-        }
-        return b.total_points - a.total_points;
-      } else if (activeTab === "streak") {
-        if (b.streak === a.streak) {
-          return b.max_streak - a.max_streak;
-        }
-        return b.streak - a.streak;
-      } else {
-        if (b.week_active_days === a.week_active_days) {
-          return a.name.localeCompare(b.name);
-        }
-        return b.week_active_days - a.week_active_days;
-      }
-    });
-
-    return result;
-  }, [hunters, search, selectedJob, activeTab]);
-
-  const totalPages = Math.max(
-    1,
-    Math.ceil(filteredAndSorted.length / PAGE_SIZE),
-  );
-  const safePage = Math.min(page, totalPages);
-  // Clamp page defensively whenever the result list shrinks (tab + filter change).
-  // Guarantees user always sees valid data range after any tab/filter interaction.
-  // This + key remount eliminates "berantakan" pagination edge states.
-  useEffect(() => {
-    if (page > totalPages) {
-      setPage(Math.max(1, totalPages));
-    }
-  }, [page, totalPages]);
-  const visibleHunters = useMemo(() => {
-    const start = (safePage - 1) * PAGE_SIZE;
-    return filteredAndSorted.slice(start, start + PAGE_SIZE);
-  }, [filteredAndSorted, safePage]);
-  const pageStartRank = (safePage - 1) * PAGE_SIZE;
-
-  const goToPage = (nextPage: number) => {
-    setPage(Math.min(Math.max(1, nextPage), totalPages));
-  };
-
-  // handleTabChange provides coherent tab switch for the public klasemen.
-  // We deliberately reset search + job filter + pagination so that switching
-  // metric (seasonal / lifetime / streak / week) shows the complete unfiltered
-  // dataset for the new sort criteria. This is the root cause of previous "berantakan" experience.
-  // The component key on the table container (see below) guarantees full React subtree unmount/remount.
-  const handleTabChange = (tab: TabType) => {
+  const handleTabChange = useCallback((tab: LeaderboardTab) => {
     setActiveTab(tab);
     setSearch("");
     setSelectedJob("all");
-    setPage(1);
-  };
+    goToPage(1);
+  }, [setActiveTab, setSearch, setSelectedJob, goToPage]);
 
-  const getRankBadge = (idx: number) => {
-    switch (idx) {
-      case 0:
-        return (
-          <span className="flex items-center justify-center w-7 h-7 rounded-full bg-system-gold/20 text-system-gold border border-system-gold/50 shadow-neon-gold text-xs font-bold font-orbitron">
-            1st
-          </span>
-        );
-      case 1:
-        return (
-          <span className="flex items-center justify-center w-7 h-7 rounded-full bg-slate-300/20 text-slate-300 border border-slate-300/40 text-xs font-bold font-orbitron">
-            2nd
-          </span>
-        );
-      case 2:
-        return (
-          <span className="flex items-center justify-center w-7 h-7 rounded-full bg-amber-700/20 text-amber-600 border border-amber-600/40 text-xs font-bold font-orbitron">
-            3rd
-          </span>
-        );
-      default:
-        return (
-          <span className="text-gray-400 font-mono text-xs">{idx + 1}</span>
-        );
-    }
-  };
-
-  const getStreakStatus = (hunter: EnrichedReport) => {
-    if (hunter.days_since_last_report <= 7 && hunter.streak > 0)
-      return "🔥 Active";
-    if (hunter.comeback_streak > 0 || hunter.days_since_last_report <= 14)
-      return "🗡️ Comeback";
-    return "💔 Inactive";
-  };
-
-  const renderHunterCell = (hunter: EnrichedReport) => (
-    <td className="py-4 pl-4 align-middle">
-      <div className="flex items-center gap-2">
-        <div className="relative">
-          <div className="w-8 h-8 rounded-full bg-gray-900 flex items-center justify-center border border-gray-800 group-hover:border-system-blue transition-colors">
-            <User size={14} className="text-gray-400" />
-          </div>
-          {hunter.is_active_today && (
-            <span className="absolute bottom-0 right-0 w-2.5 h-2.5 bg-system-green border-2 border-dark-bg rounded-full animate-pulse"></span>
-          )}
-        </div>
-        <div>
-          <div className="text-sm font-semibold text-white group-hover:text-system-blue transition-colors">
-            {hunter.name}
-          </div>
-          <div className="text-[10px] text-gray-500 font-mono">
-            {hunter.user_id}
-          </div>
-        </div>
-      </div>
-    </td>
-  );
-
-  const renderJobCell = (hunter: EnrichedReport) => (
-    <td className="py-4 pl-4 align-middle">
-      <span
-        className={`text-xs px-2.5 py-1 rounded-md border font-mono ${getJobBadgeClass(hunter.job_class)}`}
-      >
-        {hunter.job_icon} {hunter.job_name}
-      </span>
-    </td>
-  );
-
-  const renderStreak = (weeks: number) => (
-    <span className="flex items-center justify-center gap-1 text-system-red font-mono">
-      <Flame size={14} />
-      <span className="font-bold">{weeks}</span>
-      <span className="text-[10px] text-gray-500">minggu</span>
-    </span>
-  );
-
-  const renderWeekDots = (hunter: EnrichedReport) => (
-    <div
-      className="flex justify-center gap-1"
-      aria-label={`${hunter.week_active_days} dari 7 hari aktif minggu ini`}
-    >
-      {hunter.week_activity.map((active, idx) => (
-        <span
-          key={`${hunter.user_id}-week-${idx}`}
-          className={`h-3 w-3 rounded-sm border ${active ? "bg-system-green border-system-green/60 shadow-neon-purple" : "bg-gray-900 border-gray-800"}`}
-          title={active ? "Aktif" : "Belum aktif"}
-        />
-      ))}
-    </div>
-  );
-
-  // --- Tab specific pure row presenters (clean code separation) ---
-  // Each presenter returns the *exact* columns and values needed for its metric tab.
-  // Decouples column layout from filter/sort logic. Makes future extension trivial.
-  const renderSeasonalRow = (hunter: EnrichedReport, rank: number, rowClass: string) => (
-    <tr
-      key={hunter.user_id}
-      onClick={() => onSelectHunter(hunter)}
-      className={rowClass}
-    >
-      <td className="py-4 pl-4 text-center font-mono align-middle">
-        <div className="flex justify-center">{getRankBadge(rank)}</div>
-      </td>
-      {renderHunterCell(hunter)}
-      {renderJobCell(hunter)}
-      <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-white">
-        <span className="font-bold">
-          {hunter.rank_icon} {hunter.rank_name}
-        </span>
-      </td>
-      <td className="py-4 pl-4 text-center align-middle text-sm">
-        {renderStreak(hunter.streak)}
-      </td>
-      <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
-        <span className="font-bold">{hunter.seasonal_activity_count}</span>
-        <span className="text-[10px] text-gray-500"> hari / season ini</span>
-      </td>
-      <td className="py-4 pl-4 pr-4 align-middle">
-        <ProgressBar
-          progress={hunter.season_rank_progress}
-          valueLabel={`${hunter.seasonal_points} season pts`}
-          tone="gold"
-        />
-      </td>
-    </tr>
-  );
-
-  const renderLifetimeRow = (hunter: EnrichedReport, rank: number, rowClass: string) => (
-    <tr
-      key={hunter.user_id}
-      onClick={() => onSelectHunter(hunter)}
-      className={rowClass}
-    >
-      <td className="py-4 pl-4 text-center font-mono align-middle">
-        <div className="flex justify-center">{getRankBadge(rank)}</div>
-      </td>
-      {renderHunterCell(hunter)}
-      {renderJobCell(hunter)}
-      <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-white">
-        <span className="font-bold">
-          {hunter.level_icon} {hunter.level_name}
-        </span>
-      </td>
-      <td className="py-4 pl-4 text-center font-mono align-middle text-sm text-gray-300">
-        <span className="font-bold">Lv.{hunter.level}</span>
-      </td>
-      <td className="py-4 pl-4 align-middle">
-        <ProgressBar
-          progress={hunter.level_tier_progress}
-          valueLabel={`${hunter.total_points} lifetime XP`}
-          tone="blue"
-        />
-      </td>
-      <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
-        <span className="font-bold">{hunter.total_active_days}</span>
-        <span className="text-[10px] text-gray-500"> hari lifetime</span>
-      </td>
-      <td className="py-4 pl-4 text-center align-middle text-sm pr-4">
-        {renderStreak(hunter.max_streak)}
-      </td>
-    </tr>
-  );
-
-  const renderStreakRow = (hunter: EnrichedReport, rank: number, rowClass: string) => (
-    <tr
-      key={hunter.user_id}
-      onClick={() => onSelectHunter(hunter)}
-      className={rowClass}
-    >
-      <td className="py-4 pl-4 text-center font-mono align-middle">
-        <div className="flex justify-center">{getRankBadge(rank)}</div>
-      </td>
-      {renderHunterCell(hunter)}
-      {renderJobCell(hunter)}
-      <td className="py-4 pl-4 text-center align-middle text-sm">
-        {renderStreak(hunter.streak)}
-      </td>
-      <td className="py-4 pl-4 text-center align-middle text-sm">
-        {renderStreak(hunter.max_streak)}
-      </td>
-      <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
-        <span className="font-bold">{hunter.total_active_days}</span>
-        <span className="text-[10px] text-gray-500"> hari lifetime</span>
-      </td>
-      <td className="py-4 pl-4 text-center align-middle font-mono text-sm pr-4 text-gray-300">
-        {getStreakStatus(hunter)}
-      </td>
-    </tr>
-  );
-
-  const renderWeekRow = (hunter: EnrichedReport, rank: number, rowClass: string) => (
-    <tr
-      key={hunter.user_id}
-      onClick={() => onSelectHunter(hunter)}
-      className={rowClass}
-    >
-      <td className="py-4 pl-4 text-center font-mono align-middle">
-        <div className="flex justify-center">{getRankBadge(rank)}</div>
-      </td>
-      {renderHunterCell(hunter)}
-      {renderJobCell(hunter)}
-      <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
-        <span className="font-bold">{hunter.week_active_days}</span>
-        <span className="text-[10px] text-gray-500"> / 7 hari minggu ini</span>
-      </td>
-      <td className="py-4 pl-4 text-center align-middle">
-        {renderWeekDots(hunter)}
-      </td>
-      <td className="py-4 pl-4 text-center align-middle text-sm">
-        {renderStreak(hunter.streak)}
-      </td>
-      <td className="py-4 pl-4 text-right pr-4 font-mono font-bold align-middle text-system-gold">
-        {hunter.estimated_weekly_points}{" "}
-        <span className="text-[9px] text-gray-500">pts (est.)</span>
-      </td>
-    </tr>
-  );
+  const handleAttributeSubTabChange = useCallback((sub: AttributeTab) => {
+    setAttributeTab(sub);
+    goToPage(1);
+  }, [setAttributeTab, goToPage]);
 
   const renderRows = () =>
     visibleHunters.map((hunter, idx) => {
       const rank = pageStartRank + idx;
-      const rowClass = `group transition-all hover:bg-gray-800/20 cursor-pointer ${
-        rank < 3 ? "bg-gradient-to-r from-gray-950/20 to-transparent" : ""
-      }`;
-
+      const rc = rowClass(rank);
       switch (activeTab) {
-        case "seasonal":
-          return renderSeasonalRow(hunter, rank, rowClass);
-        case "lifetime":
-          return renderLifetimeRow(hunter, rank, rowClass);
-        case "streak":
-          return renderStreakRow(hunter, rank, rowClass);
-        case "week":
-        default:
-          return renderWeekRow(hunter, rank, rowClass);
+        case "seasonal": return <SeasonalRow key={hunter.user_id} hunter={hunter} rank={rank} rowClass={rc} onSelectHunter={onSelectHunter} />;
+        case "lifetime": return <LifetimeRow key={hunter.user_id} hunter={hunter} rank={rank} rowClass={rc} onSelectHunter={onSelectHunter} />;
+        case "streak": return <StreakRow key={hunter.user_id} hunter={hunter} rank={rank} rowClass={rc} onSelectHunter={onSelectHunter} />;
+        case "week": return <WeekRow key={hunter.user_id} hunter={hunter} rank={rank} rowClass={rc} onSelectHunter={onSelectHunter} />;
+        case "attributes": return <AttributeRow key={hunter.user_id} hunter={hunter} rank={rank} rowClass={rc} attributeTab={attributeTab} onSelectHunter={onSelectHunter} />;
+        default: return null;
       }
     });
 
-  const tableHeaders = {
-    seasonal: [
-      "Rank",
-      "Hunter",
-      "Job",
-      "Season Rank",
-      "Streak (minggu)",
-      "Active Days (season ini)",
-      "Season Points + Progress",
-    ],
-    lifetime: [
-      "Rank",
-      "Hunter",
-      "Job",
-      "Level Tier (lifetime)",
-      "Level Numeric",
-      "XP Progress ke Tier Berikutnya",
-      "Total Hari (lifetime)",
-      "Best Streak (minggu)",
-    ],
-    streak: [
-      "Rank",
-      "Hunter",
-      "Job",
-      "Current Streak (minggu)",
-      "Best Streak (minggu)",
-      "Lifetime Days",
-      "Status",
-    ],
-    week: [
-      "Rank",
-      "Hunter",
-      "Job",
-      "Hari Aktif Minggu Ini",
-      "Activity Dots (7 hari)",
-      "Streak (minggu)",
-      "Skor Aktif (est pts)",
-    ],
-  }[activeTab];
+  const tableHeaders = TABLE_HEADERS[activeTab];
 
   return (
     <div className="glass rounded-3xl p-5 md:p-6 mb-8">
-      {/* Top Controls: Tabs and Filters */}
       <div className="flex flex-col lg:flex-row gap-4 items-stretch lg:items-center justify-between mb-6 border-b border-gray-850 pb-5">
-        {/* Leaderboard Mode Tabs */}
         <div className="flex flex-wrap bg-gray-950/80 p-1.5 rounded-xl border border-gray-800/60 max-w-fit">
           {LEADERBOARD_TABS.map((tab) => {
             const Icon = tab.icon;
@@ -467,8 +103,8 @@ export const LeaderboardTable: React.FC<LeaderboardTableProps> = ({
                 onClick={() => handleTabChange(tab.id)}
                 className={`flex items-center gap-2 px-4 py-2 rounded-lg text-xs font-bold font-orbitron tracking-wider transition-all uppercase ${
                   active
-                    ? "bg-gradient-to-r from-system-purple to-system-blue text-white shadow-neon-blue"
-                    : "text-gray-400 hover:text-white"
+                    ? "bg-gradient-to-r from-system-blue to-system-purple text-white shadow-neon-purple"
+                    : "text-gray-400 hover:text-white hover:bg-gray-800/60"
                 }`}
               >
                 <Icon size={14} />
@@ -478,47 +114,26 @@ export const LeaderboardTable: React.FC<LeaderboardTableProps> = ({
           })}
         </div>
 
-        {/* Filter Inputs */}
-        <div className="flex flex-col sm:flex-row gap-3 sm:items-center">
-          {/* Search bar */}
+        <div className="flex gap-2 items-center">
           <div className="relative">
+            <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" />
             <input
-              type="text"
-              placeholder="Search hunter..."
               value={search}
-              onChange={(e) => {
-                setSearch(e.target.value);
-                setPage(1);
-              }}
-              className="w-full sm:w-60 pl-10 pr-4 py-2 bg-gray-950/70 border border-gray-800 focus:border-system-blue focus:shadow-neon-blue rounded-xl text-xs text-white placeholder-gray-500 font-mono transition-all outline-none"
-            />
-            <Search
-              className="absolute left-3.5 top-2.5 text-gray-500"
-              size={14}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Cari hunter…"
+              className="pl-9 pr-3 py-2 rounded-xl bg-gray-950 border border-gray-800 text-xs font-mono text-gray-200 placeholder:text-gray-600 focus:outline-none focus:border-system-blue/50 transition-colors w-40"
             />
           </div>
-
-          {/* Job Filter */}
-          <div className="relative flex items-center">
-            <SlidersHorizontal
-              className="absolute left-3.5 top-2.5 text-gray-500"
-              size={14}
-            />
+          <div className="relative">
+            <SlidersHorizontal size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" />
             <select
               value={selectedJob}
-              onChange={(e) => {
-                setSelectedJob(e.target.value);
-                setPage(1);
-              }}
-              className="w-full sm:w-44 pl-10 pr-8 py-2 bg-gray-950/70 border border-gray-800 focus:border-system-blue focus:shadow-neon-blue rounded-xl text-xs text-white font-mono transition-all outline-none appearance-none cursor-pointer"
+              onChange={(e) => setSelectedJob(e.target.value)}
+              className="pl-9 pr-3 py-2 rounded-xl bg-gray-950 border border-gray-800 text-xs font-mono text-gray-200 focus:outline-none focus:border-system-blue/50 transition-colors appearance-none cursor-pointer"
             >
-              {JOB_FILTER_OPTIONS.map((job) => (
-                <option
-                  key={job.id}
-                  value={job.id}
-                  className="bg-dark-bg text-white"
-                >
-                  {job.name}
+              {JOB_FILTER_OPTIONS.map((opt) => (
+                <option key={opt.id} value={opt.id}>
+                  {opt.name}
                 </option>
               ))}
             </select>
@@ -526,71 +141,83 @@ export const LeaderboardTable: React.FC<LeaderboardTableProps> = ({
         </div>
       </div>
 
-      {/* Table Renders - keyed by activeTab.
-          When user switches klasemen mode, the entire table subtree is recreated freshly.
-          Combined with explicit filter reset in handleTabChange, this eliminates carried over state,
-          stale pagination slices, mismatched column counts and "berantakan" UI during tab data switch. */}
-      <div className="overflow-x-auto" key={activeTab}>
-        <table className="w-full min-w-[860px] border-collapse">
+      {activeTab === "attributes" && (
+        <div className="flex flex-wrap gap-1.5 mb-4 p-1.5 bg-gray-950/60 rounded-xl border border-gray-800/40 max-w-fit">
+          {ATTRIBUTE_SUB_TABS.map((sub) => {
+            const active = attributeTab === sub.id;
+            return (
+              <button
+                key={sub.id}
+                onClick={() => handleAttributeSubTabChange(sub.id)}
+                className={`px-3 py-1.5 rounded-lg text-[10px] font-bold font-mono tracking-wider transition-all uppercase ${
+                  active
+                    ? "bg-gradient-to-r from-system-red to-system-gold text-white"
+                    : "text-gray-400 hover:text-white hover:bg-gray-800/60"
+                }`}
+              >
+                {sub.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="overflow-x-auto">
+        <table className="w-full">
           <thead>
-            <tr className="border-b border-gray-850 text-left text-gray-500 text-[10px] font-mono font-bold tracking-widest uppercase">
-              {tableHeaders.map((header, idx) => (
+            <tr className="border-b border-gray-800/80">
+              {tableHeaders.map((header, i) => (
                 <th
-                  key={header}
-                  className={`pb-3 pl-4 ${idx === 0 ? "w-12 text-center" : ""} ${idx >= 3 && idx !== tableHeaders.length - 1 ? "text-center" : ""} ${idx === tableHeaders.length - 1 ? "text-right pr-4" : ""}`}
+                  key={`${activeTab}-${i}`}
+                  className={`py-3 px-4 text-[10px] font-mono font-bold uppercase tracking-wider text-gray-500 ${
+                    i === 0 ? "text-center" : i === 1 ? "text-left" : "text-center"
+                  }`}
                 >
                   {header}
                 </th>
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-900/60">
-            {filteredAndSorted.length === 0 ? (
-              <tr>
-                <td
-                  colSpan={tableHeaders.length}
-                  className="py-8 text-center text-xs text-gray-500 font-mono italic"
-                >
-                  No active hunters match the filters.
-                </td>
-              </tr>
-            ) : (
-              renderRows()
-            )}
-          </tbody>
+          <tbody>{renderRows()}</tbody>
         </table>
       </div>
-      <nav
-        className="mt-5 flex flex-col sm:flex-row items-center justify-between gap-3 border-t border-gray-900/60 pt-5"
-        aria-label="Leaderboard pagination"
-      >
-        <p className="text-xs text-gray-500 font-mono uppercase tracking-wider">
-          Showing {filteredAndSorted.length === 0 ? 0 : pageStartRank + 1}-
-          {Math.min(pageStartRank + PAGE_SIZE, filteredAndSorted.length)} of{" "}
-          {filteredAndSorted.length} athletes
-        </p>
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={() => goToPage(safePage - 1)}
-            disabled={safePage <= 1}
-            className="px-3 py-2 rounded-xl bg-gray-950 border border-gray-800 text-xs font-mono text-gray-300 disabled:opacity-40 hover:text-white transition-colors"
-          >
-            Previous
-          </button>
-          <span className="px-3 py-2 text-xs font-mono text-gray-500">
-            Page {safePage} / {totalPages}
-          </span>
-          <button
-            type="button"
-            onClick={() => goToPage(safePage + 1)}
-            disabled={safePage >= totalPages}
-            className="px-3 py-2 rounded-xl bg-gray-950 border border-gray-800 text-xs font-mono text-gray-300 disabled:opacity-40 hover:text-white transition-colors"
-          >
-            Next
-          </button>
+
+      {totalCount === 0 && (
+        <div className="text-center py-16 text-gray-600 font-mono text-sm">
+          {search || selectedJob !== "all"
+            ? "Tidak ada hunter yang cocok dengan filter ini."
+            : "Belum ada hunter aktif untuk kategori ini."}
         </div>
-      </nav>
+      )}
+
+      {totalPages > 1 && (
+        <nav className="flex items-center justify-between mt-6 pt-4 border-t border-gray-800/60">
+          <p className="text-xs font-mono text-gray-500">
+            Menampilkan {pageStartRank + 1}–{Math.min(pageStartRank + visibleHunters.length, totalCount)} dari {totalCount} hunters
+          </p>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => goToPage(safePage - 1)}
+              disabled={safePage <= 1}
+              className="px-3 py-2 rounded-xl bg-gray-950 border border-gray-800 text-xs font-mono text-gray-300 disabled:opacity-40 hover:text-white transition-colors"
+            >
+              Previous
+            </button>
+            <span className="px-3 py-2 text-xs font-mono text-gray-500">
+              Page {safePage} / {totalPages}
+            </span>
+            <button
+              type="button"
+              onClick={() => goToPage(safePage + 1)}
+              disabled={safePage >= totalPages}
+              className="px-3 py-2 rounded-xl bg-gray-950 border border-gray-800 text-xs font-mono text-gray-300 disabled:opacity-40 hover:text-white transition-colors"
+            >
+              Next
+            </button>
+          </div>
+        </nav>
+      )}
     </div>
   );
 };

--- a/frontend/apps/web/src/components/leaderboard/ActiveTodayBadge.tsx
+++ b/frontend/apps/web/src/components/leaderboard/ActiveTodayBadge.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+
+export const ActiveTodayBadge: React.FC = () => (
+  <span className="inline-flex items-center gap-1 text-[10px] font-mono text-system-green">
+    <span className="h-1.5 w-1.5 rounded-full bg-system-green animate-pulse" />
+    hari ini
+  </span>
+);

--- a/frontend/apps/web/src/components/leaderboard/AttributeBar.tsx
+++ b/frontend/apps/web/src/components/leaderboard/AttributeBar.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { attributeBarWidth } from "@lapor-bot/shared";
+
+interface AttributeBarProps {
+  value: number;
+  label: string;
+  tone?: "str" | "sta" | "agi" | "vit";
+}
+
+const TONE_GRADIENTS: Record<NonNullable<AttributeBarProps["tone"]>, string> = {
+  str: "from-system-red to-amber-500",
+  sta: "from-system-gold to-system-red",
+  agi: "from-system-blue to-system-green",
+  vit: "from-system-green to-system-blue",
+};
+
+export const AttributeBar: React.FC<AttributeBarProps> = ({
+  value,
+  label,
+  tone,
+}) => {
+  const width = attributeBarWidth(value);
+  const gradient = tone ? TONE_GRADIENTS[tone] : "from-system-blue to-system-purple";
+
+  return (
+    <div className="min-w-[120px]">
+      <div className="flex items-center gap-2">
+        <span className="text-[10px] font-mono text-gray-500 w-6">{label}</span>
+        <div className="flex-1 h-2 rounded-full bg-gray-900 border border-gray-800 overflow-hidden">
+          <div
+            className={`h-full rounded-full bg-gradient-to-r ${gradient} transition-all duration-500`}
+            style={{ width: `${width}%` }}
+          />
+        </div>
+        <span className="text-xs font-mono font-bold text-white w-6 text-right">
+          {value}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/frontend/apps/web/src/components/leaderboard/HunterCell.tsx
+++ b/frontend/apps/web/src/components/leaderboard/HunterCell.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import type { EnrichedReport } from "@lapor-bot/shared";
+import { getJobBadgeClass } from "@lapor-bot/shared";
+
+interface HunterCellProps {
+  hunter: EnrichedReport;
+  isActiveToday?: boolean;
+}
+
+export const HunterCell: React.FC<HunterCellProps> = ({ hunter, isActiveToday }) => (
+  <td className="py-4 pl-4 align-middle">
+    <div className="flex items-center gap-3">
+      <div className="relative shrink-0">
+        <div className="w-10 h-10 rounded-full bg-gradient-to-br from-gray-800 to-gray-900 border border-gray-700 flex items-center justify-center text-gray-400">
+          <span className="text-sm font-bold">{hunter.name.charAt(0).toUpperCase()}</span>
+        </div>
+        {isActiveToday && (
+          <span className="absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full bg-system-green border-2 border-gray-950" title="Aktif hari ini" />
+        )}
+      </div>
+      <div className="min-w-0">
+        <div className="text-sm text-white font-medium truncate group-hover:text-system-blue transition-colors">
+          {hunter.name}
+        </div>
+        <div className="text-[10px] text-gray-500 font-mono">
+          {hunter.user_id}
+        </div>
+      </div>
+    </div>
+  </td>
+);
+
+interface JobCellProps {
+  hunter: EnrichedReport;
+}
+
+export const JobCell: React.FC<JobCellProps> = ({ hunter }) => (
+  <td className="py-4 pl-4 align-middle">
+    <span className={`text-xs px-2.5 py-1 rounded-md border font-mono ${getJobBadgeClass(hunter.job_class)}`}>
+      {hunter.job_icon} {hunter.job_name}
+    </span>
+  </td>
+);

--- a/frontend/apps/web/src/components/leaderboard/JobCell.tsx
+++ b/frontend/apps/web/src/components/leaderboard/JobCell.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import type { EnrichedReport } from "@lapor-bot/shared";
+import { getJobBadgeClass } from "@lapor-bot/shared";
+
+export const JobCell: React.FC<{ hunter: EnrichedReport }> = ({ hunter }) => (
+  <td className="py-4 pl-4 align-middle">
+    <span
+      className={`text-xs px-2.5 py-1 rounded-md border font-mono ${getJobBadgeClass(hunter.job_class)}`}
+    >
+      {hunter.job_icon} {hunter.job_name}
+    </span>
+  </td>
+);

--- a/frontend/apps/web/src/components/leaderboard/ProgressBar.tsx
+++ b/frontend/apps/web/src/components/leaderboard/ProgressBar.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import type { TierProgress } from "@lapor-bot/shared";
+
+type Tone = "gold" | "blue" | "red" | "green";
+
+const TONE_GRADIENTS: Record<Tone, string> = {
+  gold: "from-system-gold to-system-purple",
+  blue: "from-system-blue to-system-purple",
+  red: "from-system-red to-system-gold",
+  green: "from-system-green to-system-blue",
+};
+
+interface ProgressBarProps {
+  progress: TierProgress;
+  valueLabel: string;
+  tone?: Tone;
+}
+
+export const ProgressBar: React.FC<ProgressBarProps> = ({
+  progress,
+  valueLabel,
+  tone = "blue",
+}) => (
+  <div className="min-w-[180px]">
+    <div className="h-2.5 w-full rounded-full bg-gray-900 border border-gray-800 overflow-hidden">
+      <div
+        className={`h-full rounded-full bg-gradient-to-r ${TONE_GRADIENTS[tone]} transition-all duration-500`}
+        style={{ width: `${progress.percent}%` }}
+      />
+    </div>
+    <div className="mt-1 flex justify-between text-[9px] font-mono text-gray-500">
+      <span>{valueLabel}</span>
+      {progress.is_max ? (
+        <span className="text-system-gold">MAX</span>
+      ) : (
+        <span>
+          → {progress.next_icon} {progress.next_name} ({progress.remaining} pts)
+        </span>
+      )}
+    </div>
+  </div>
+);

--- a/frontend/apps/web/src/components/leaderboard/QuestBadge.tsx
+++ b/frontend/apps/web/src/components/leaderboard/QuestBadge.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+interface QuestBadgeProps {
+  completed: number;
+  sideQuests: number;
+}
+
+export const QuestBadge: React.FC<QuestBadgeProps> = ({ completed, sideQuests }) => {
+  if (completed === 0 && sideQuests === 0) {
+    return <span className="text-gray-600 text-xs font-mono">—</span>;
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-0.5">
+      {completed > 0 && (
+        <span className="inline-flex items-center gap-1 text-xs font-mono text-system-green">
+          🎯 {completed}
+          <span className="text-[9px] text-gray-500">goals</span>
+        </span>
+      )}
+      {sideQuests > 0 && (
+        <span className="inline-flex items-center gap-1 text-xs font-mono text-system-purple">
+          ⚡ {sideQuests}
+          <span className="text-[9px] text-gray-500">quests</span>
+        </span>
+      )}
+    </div>
+  );
+};

--- a/frontend/apps/web/src/components/leaderboard/RankBadge.tsx
+++ b/frontend/apps/web/src/components/leaderboard/RankBadge.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+interface RankBadgeProps {
+  rank: number;
+}
+
+export const RankBadge: React.FC<RankBadgeProps> = ({ rank }) => {
+  switch (rank) {
+    case 0:
+      return (
+        <span className="flex items-center justify-center w-7 h-7 rounded-full bg-system-gold/20 text-system-gold border border-system-gold/50 shadow-neon-gold text-xs font-bold font-orbitron">
+          1st
+        </span>
+      );
+    case 1:
+      return (
+        <span className="flex items-center justify-center w-7 h-7 rounded-full bg-slate-300/20 text-slate-300 border border-slate-300/40 text-xs font-bold font-orbitron">
+          2nd
+        </span>
+      );
+    case 2:
+      return (
+        <span className="flex items-center justify-center w-7 h-7 rounded-full bg-amber-700/20 text-amber-600 border border-amber-600/40 text-xs font-bold font-orbitron">
+          3rd
+        </span>
+      );
+    default:
+      return (
+        <span className="text-gray-400 font-mono text-xs">{rank + 1}</span>
+      );
+  }
+};

--- a/frontend/apps/web/src/components/leaderboard/StreakCell.tsx
+++ b/frontend/apps/web/src/components/leaderboard/StreakCell.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Flame } from "lucide-react";
+
+interface StreakCellProps {
+  weeks: number;
+  label?: string;
+}
+
+export const StreakCell: React.FC<StreakCellProps> = ({ weeks, label = "minggu" }) => (
+  <span className="flex items-center justify-center gap-1 text-system-red font-mono">
+    <Flame size={14} />
+    <span className="font-bold">{weeks}</span>
+    <span className="text-[10px] text-gray-500">{label}</span>
+  </span>
+);

--- a/frontend/apps/web/src/components/leaderboard/WeekDots.tsx
+++ b/frontend/apps/web/src/components/leaderboard/WeekDots.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import type { EnrichedReport } from "@lapor-bot/shared";
+
+interface WeekDotsProps {
+  hunter: EnrichedReport;
+}
+
+export const WeekDots: React.FC<WeekDotsProps> = ({ hunter }) => (
+  <div
+    className="flex justify-center gap-1"
+    aria-label={`${hunter.week_active_days} dari 7 hari aktif minggu ini`}
+  >
+    {hunter.week_activity.map((active, idx) => (
+      <span
+        key={`${hunter.user_id}-week-${idx}`}
+        className={`h-3 w-3 rounded-sm border ${
+          active
+            ? "bg-system-green border-system-green/60 shadow-neon-purple"
+            : "bg-gray-900 border-gray-800"
+        }`}
+        title={active ? "Aktif" : "Belum aktif"}
+      />
+    ))}
+  </div>
+);

--- a/frontend/apps/web/src/components/leaderboard/headers.ts
+++ b/frontend/apps/web/src/components/leaderboard/headers.ts
@@ -1,0 +1,57 @@
+export const SEASONAL_HEADERS = [
+  "Rank",
+  "Hunter",
+  "Job",
+  "Season Rank",
+  "Streak",
+  "Active Days",
+  "Best Season Streak",
+  "Freezes",
+  "Season Points + Progress",
+] as const;
+
+export const LIFETIME_HEADERS = [
+  "Rank",
+  "Hunter",
+  "Job",
+  "Level Tier",
+  "Level",
+  "XP Progress",
+  "Lifetime Days",
+  "Best Streak",
+  "Quests Done",
+] as const;
+
+export const STREAK_HEADERS = [
+  "Rank",
+  "Hunter",
+  "Job",
+  "Current Streak",
+  "Best Streak",
+  "Lifetime Days",
+  "Comeback",
+  "Centurion",
+  "Status",
+] as const;
+
+export const WEEK_HEADERS = [
+  "Rank",
+  "Hunter",
+  "Job",
+  "Hari Aktif Minggu Ini",
+  "Activity Dots (7 hari)",
+  "Streak (minggu)",
+  "Skor Aktif (est pts)",
+] as const;
+
+export const ATTRIBUTE_HEADERS = [
+  "Rank",
+  "Hunter",
+  "Job",
+  "Attribute Value",
+  "STR",
+  "STA",
+  "AGI",
+  "VIT",
+  "Level",
+] as const;

--- a/frontend/apps/web/src/components/leaderboard/index.ts
+++ b/frontend/apps/web/src/components/leaderboard/index.ts
@@ -1,0 +1,25 @@
+export { ProgressBar } from "./ProgressBar";
+export { RankBadge } from "./RankBadge";
+export { HunterCell } from "./HunterCell";
+export { JobCell } from "./JobCell";
+export { StreakCell } from "./StreakCell";
+export { WeekDots } from "./WeekDots";
+export { AttributeBar } from "./AttributeBar";
+export { ActiveTodayBadge } from "./ActiveTodayBadge";
+export { QuestBadge } from "./QuestBadge";
+
+export { SeasonalRow } from "./rows/SeasonalRow";
+export { LifetimeRow } from "./rows/LifetimeRow";
+export { StreakRow } from "./rows/StreakRow";
+export { WeekRow } from "./rows/WeekRow";
+export { AttributeRow } from "./rows/AttributeRow";
+
+export {
+  SEASONAL_HEADERS,
+  LIFETIME_HEADERS,
+  STREAK_HEADERS,
+  WEEK_HEADERS,
+  ATTRIBUTE_HEADERS,
+} from "./headers";
+
+export { useLeaderboardData } from "./useLeaderboardData";

--- a/frontend/apps/web/src/components/leaderboard/rows/AttributeRow.tsx
+++ b/frontend/apps/web/src/components/leaderboard/rows/AttributeRow.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import type { EnrichedReport, AttributeTab } from "@lapor-bot/shared";
+import { getAttributeAverage, getAttributeValue } from "@lapor-bot/shared";
+import { RankBadge } from "../RankBadge";
+import { HunterCell } from "../HunterCell";
+import { JobCell } from "../JobCell";
+import { AttributeBar } from "../AttributeBar";
+
+interface AttributeRowProps {
+  hunter: EnrichedReport;
+  rank: number;
+  rowClass: string;
+  attributeTab: AttributeTab;
+  onSelectHunter: (hunter: EnrichedReport) => void;
+}
+
+export const AttributeRow: React.FC<AttributeRowProps> = ({
+  hunter,
+  rank,
+  rowClass,
+  attributeTab,
+  onSelectHunter,
+}) => {
+  const isOverall = attributeTab === "overall";
+  const primaryValue = isOverall
+    ? getAttributeAverage(hunter)
+    : getAttributeValue(hunter, attributeTab);
+
+  return (
+    <tr
+      key={hunter.user_id}
+      onClick={() => onSelectHunter(hunter)}
+      className={rowClass}
+    >
+      <td className="py-4 pl-4 text-center font-mono align-middle">
+        <div className="flex justify-center">
+          <RankBadge rank={rank} />
+        </div>
+      </td>
+      <HunterCell hunter={hunter} />
+      <JobCell hunter={hunter} />
+
+      <td className="py-4 pl-4 text-center align-middle">
+        <AttributeBar
+          value={primaryValue}
+          label={isOverall ? "AVG" : attributeTab.toUpperCase()}
+          tone={isOverall ? undefined : (attributeTab as "str" | "sta" | "agi" | "vit")}
+        />
+      </td>
+
+      {isOverall ? (
+        <>
+          <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+            <span className="font-bold">{hunter.str}</span>
+          </td>
+          <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+            <span className="font-bold">{hunter.sta}</span>
+          </td>
+          <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+            <span className="font-bold">{hunter.agi}</span>
+          </td>
+          <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+            <span className="font-bold">{hunter.vit}</span>
+          </td>
+        </>
+      ) : (
+        <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+          <span className="font-bold">{hunter.total_points}</span>
+          <span className="text-[10px] text-gray-500"> XP</span>
+        </td>
+      )}
+
+      <td className="py-4 pl-4 pr-4 text-center align-middle font-mono text-sm text-gray-300">
+        <span className="font-bold">Lv.{hunter.level}</span>
+      </td>
+    </tr>
+  );
+};

--- a/frontend/apps/web/src/components/leaderboard/rows/LifetimeRow.tsx
+++ b/frontend/apps/web/src/components/leaderboard/rows/LifetimeRow.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import type { EnrichedReport } from "@lapor-bot/shared";
+import { RankBadge } from "../RankBadge";
+import { HunterCell } from "../HunterCell";
+import { JobCell } from "../JobCell";
+import { ProgressBar } from "../ProgressBar";
+import { StreakCell } from "../StreakCell";
+import { QuestBadge } from "../QuestBadge";
+
+interface LifetimeRowProps {
+  hunter: EnrichedReport;
+  rank: number;
+  rowClass: string;
+  onSelectHunter: (hunter: EnrichedReport) => void;
+}
+
+export const LifetimeRow: React.FC<LifetimeRowProps> = ({
+  hunter,
+  rank,
+  rowClass,
+  onSelectHunter,
+}) => (
+  <tr key={hunter.user_id} onClick={() => onSelectHunter(hunter)} className={rowClass}>
+    <td className="py-4 pl-4 text-center font-mono align-middle">
+      <div className="flex justify-center">
+        <RankBadge rank={rank} />
+      </div>
+    </td>
+    <HunterCell hunter={hunter} />
+    <JobCell hunter={hunter} />
+    <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-white">
+      <span className="font-bold">
+        {hunter.level_icon} {hunter.level_name}
+      </span>
+    </td>
+    <td className="py-4 pl-4 text-center font-mono align-middle text-sm text-gray-300">
+      <span className="font-bold">Lv.{hunter.level}</span>
+    </td>
+    <td className="py-4 pl-4 align-middle">
+      <ProgressBar
+        progress={hunter.level_tier_progress}
+        valueLabel={`${hunter.total_points} lifetime XP`}
+        tone="blue"
+      />
+    </td>
+    <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+      <span className="font-bold">{hunter.total_active_days}</span>
+      <span className="text-[10px] text-gray-500"> hari</span>
+    </td>
+    <td className="py-4 pl-4 text-center align-middle text-sm">
+      <StreakCell weeks={hunter.max_streak} />
+    </td>
+    <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300 pr-4">
+      <QuestBadge
+        completed={hunter.goals_completed}
+        sideQuests={hunter.total_side_quests}
+      />
+    </td>
+  </tr>
+);

--- a/frontend/apps/web/src/components/leaderboard/rows/SeasonalRow.tsx
+++ b/frontend/apps/web/src/components/leaderboard/rows/SeasonalRow.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import type { EnrichedReport } from "@lapor-bot/shared";
+import { RankBadge } from "../RankBadge";
+import { HunterCell } from "../HunterCell";
+import { JobCell } from "../JobCell";
+import { StreakCell } from "../StreakCell";
+import { ActiveTodayBadge } from "../ActiveTodayBadge";
+import { ProgressBar } from "../ProgressBar";
+import { Snowflake } from "lucide-react";
+
+interface SeasonalRowProps {
+  hunter: EnrichedReport;
+  rank: number;
+  rowClass: string;
+  onSelectHunter: (hunter: EnrichedReport) => void;
+}
+
+export const SeasonalRow: React.FC<SeasonalRowProps> = ({
+  hunter,
+  rank,
+  rowClass,
+  onSelectHunter,
+}) => (
+  <tr key={hunter.user_id} onClick={() => onSelectHunter(hunter)} className={rowClass}>
+    <td className="py-4 pl-4 text-center font-mono align-middle">
+      <div className="flex justify-center">
+        <RankBadge rank={rank} />
+      </div>
+    </td>
+    <HunterCell hunter={hunter} />
+    <JobCell hunter={hunter} />
+    <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-white">
+      <div className="flex flex-col items-center gap-1">
+        <span className="font-bold">
+          {hunter.rank_icon} {hunter.rank_name}
+        </span>
+        {hunter.is_active_today && <ActiveTodayBadge />}
+      </div>
+    </td>
+    <td className="py-4 pl-4 text-center align-middle text-sm">
+      <StreakCell weeks={hunter.streak} />
+    </td>
+    <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+      <span className="font-bold">{hunter.seasonal_activity_count}</span>
+      <span className="text-[10px] text-gray-500"> hari / season</span>
+    </td>
+    <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-400">
+      <div className="flex flex-col items-center gap-1">
+        <span className="font-bold text-gray-300">{hunter.seasonal_max_streak}</span>
+        <span className="text-[10px] text-gray-500">best streak</span>
+      </div>
+    </td>
+    <td className="py-4 pl-4 text-center align-middle">
+      {hunter.streak_freezes > 0 && (
+        <span
+          className="inline-flex items-center gap-1 text-xs font-mono text-system-blue"
+          title={`${hunter.streak_freezes} streak freeze tersisa`}
+        >
+          <Snowflake size={12} />
+          {hunter.streak_freezes}
+        </span>
+      )}
+    </td>
+    <td className="py-4 pl-4 pr-4 align-middle">
+      <ProgressBar
+        progress={hunter.season_rank_progress}
+        valueLabel={`${hunter.seasonal_points} season pts`}
+        tone="gold"
+      />
+    </td>
+  </tr>
+);

--- a/frontend/apps/web/src/components/leaderboard/rows/StreakRow.tsx
+++ b/frontend/apps/web/src/components/leaderboard/rows/StreakRow.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import type { EnrichedReport } from "@lapor-bot/shared";
+import { RankBadge } from "../RankBadge";
+import { HunterCell } from "../HunterCell";
+import { JobCell } from "../JobCell";
+import { StreakCell } from "../StreakCell";
+import { getStreakStatus } from "@lapor-bot/shared";
+
+interface StreakRowProps {
+  hunter: EnrichedReport;
+  rank: number;
+  rowClass: string;
+  onSelectHunter: (hunter: EnrichedReport) => void;
+}
+
+export const StreakRow: React.FC<StreakRowProps> = ({
+  hunter,
+  rank,
+  rowClass,
+  onSelectHunter,
+}) => (
+  <tr key={hunter.user_id} onClick={() => onSelectHunter(hunter)} className={rowClass}>
+    <td className="py-4 pl-4 text-center font-mono align-middle">
+      <div className="flex justify-center">
+        <RankBadge rank={rank} />
+      </div>
+    </td>
+    <HunterCell hunter={hunter} />
+    <JobCell hunter={hunter} />
+    <td className="py-4 pl-4 text-center align-middle text-sm">
+      <StreakCell weeks={hunter.streak} />
+    </td>
+    <td className="py-4 pl-4 text-center align-middle text-sm">
+      <StreakCell weeks={hunter.max_streak} />
+    </td>
+    <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+      <span className="font-bold">{hunter.total_active_days}</span>
+      <span className="text-[10px] text-gray-500"> hari lifetime</span>
+    </td>
+    <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+      <span className="font-bold text-system-purple">{hunter.comeback_streak}</span>
+      <span className="text-[10px] text-gray-500"> comeback</span>
+    </td>
+    <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+      {hunter.centurion_cycles > 0 && (
+        <span className="font-bold text-system-gold">
+          {hunter.centurion_cycles}x 💯
+        </span>
+      )}
+      {hunter.centurion_cycles === 0 && (
+        <span className="text-gray-600">—</span>
+      )}
+    </td>
+    <td className="py-4 pl-4 pr-4 text-center align-middle font-mono text-sm">
+      {getStreakStatus(hunter)}
+    </td>
+  </tr>
+);

--- a/frontend/apps/web/src/components/leaderboard/rows/WeekRow.tsx
+++ b/frontend/apps/web/src/components/leaderboard/rows/WeekRow.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import type { EnrichedReport } from "@lapor-bot/shared";
+import { RankBadge } from "../RankBadge";
+import { HunterCell } from "../HunterCell";
+import { JobCell } from "../JobCell";
+import { StreakCell } from "../StreakCell";
+import { WeekDots } from "../WeekDots";
+
+interface WeekRowProps {
+  hunter: EnrichedReport;
+  rank: number;
+  rowClass: string;
+  onSelectHunter: (hunter: EnrichedReport) => void;
+}
+
+export const WeekRow: React.FC<WeekRowProps> = ({
+  hunter,
+  rank,
+  rowClass,
+  onSelectHunter,
+}) => (
+  <tr key={hunter.user_id} onClick={() => onSelectHunter(hunter)} className={rowClass}>
+    <td className="py-4 pl-4 text-center font-mono align-middle">
+      <div className="flex justify-center">
+        <RankBadge rank={rank} />
+      </div>
+    </td>
+    <HunterCell hunter={hunter} />
+    <JobCell hunter={hunter} />
+    <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+      <span className="font-bold">{hunter.week_active_days}</span>
+      <span className="text-[10px] text-gray-500"> / 7 hari minggu ini</span>
+    </td>
+    <td className="py-4 pl-4 text-center align-middle">
+      <WeekDots hunter={hunter} />
+    </td>
+    <td className="py-4 pl-4 text-center align-middle text-sm">
+      <StreakCell weeks={hunter.streak} />
+    </td>
+    <td className="py-4 pl-4 text-right pr-4 font-mono font-bold align-middle text-system-gold">
+      {hunter.estimated_weekly_points}{" "}
+      <span className="text-[9px] text-gray-500">pts (est.)</span>
+    </td>
+  </tr>
+);

--- a/frontend/apps/web/src/components/leaderboard/useLeaderboardData.ts
+++ b/frontend/apps/web/src/components/leaderboard/useLeaderboardData.ts
@@ -1,0 +1,113 @@
+import { useMemo, useState } from "react";
+import type {
+  EnrichedReport,
+  LeaderboardTab,
+  AttributeTab,
+  LeaderboardSortKey,
+} from "@lapor-bot/shared";
+import {
+  sortLeaderboard,
+  hasSeasonActivity,
+  hasAnyActivity,
+  hasStreakActivity,
+  hasAttributeActivity,
+  ATTRIBUTE_TAB_TO_SORT_KEY,
+} from "@lapor-bot/shared";
+
+const PAGE_SIZE = 15;
+
+const TAB_SORT_KEY: Record<LeaderboardTab, LeaderboardSortKey> = {
+  seasonal: "season_rank",
+  lifetime: "lifetime_xp",
+  streak: "weekly_streak",
+  week: "weekly_activity",
+  attributes: "attribute_overall",
+};
+
+const TAB_FILTER: Record<LeaderboardTab, (r: EnrichedReport) => boolean> = {
+  seasonal: hasSeasonActivity,
+  lifetime: hasAnyActivity,
+  streak: hasStreakActivity,
+  week: (r) => r.week_active_days > 0,
+  attributes: hasAttributeActivity,
+};
+
+export interface LeaderboardData {
+  search: string;
+  setSearch: (v: string) => void;
+  selectedJob: string;
+  setSelectedJob: (v: string) => void;
+  activeTab: LeaderboardTab;
+  setActiveTab: (tab: LeaderboardTab) => void;
+  attributeTab: AttributeTab;
+  setAttributeTab: (tab: AttributeTab) => void;
+  safePage: number;
+  totalPages: number;
+  pageStartRank: number;
+  totalCount: number;
+  visibleHunters: EnrichedReport[];
+  goToPage: (page: number) => void;
+}
+
+export function useLeaderboardData(hunters: EnrichedReport[]): LeaderboardData {
+  const [search, setSearch] = useState("");
+  const [selectedJob, setSelectedJob] = useState("all");
+  const [activeTab, setActiveTab] = useState<LeaderboardTab>("seasonal");
+  const [attributeTab, setAttributeTab] = useState<AttributeTab>("overall");
+  const [page, setPage] = useState(1);
+
+  const filteredAndSorted = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const jobFilter = selectedJob.toLowerCase();
+
+    const matchesSearch = (h: EnrichedReport) =>
+      !q || h.name.toLowerCase().includes(q);
+
+    const matchesJob = (h: EnrichedReport) =>
+      jobFilter === "all" || h.job_class?.toLowerCase() === jobFilter;
+
+    const passesTabFilter = TAB_FILTER[activeTab];
+
+    const filtered = hunters.filter(
+      (h) => passesTabFilter(h) && matchesSearch(h) && matchesJob(h),
+    );
+
+    const sortKey =
+      activeTab === "attributes"
+        ? ATTRIBUTE_TAB_TO_SORT_KEY[attributeTab]
+        : TAB_SORT_KEY[activeTab];
+
+    return sortLeaderboard(filtered, sortKey);
+  }, [hunters, activeTab, attributeTab, search, selectedJob]);
+
+  const totalPages = Math.max(
+    1,
+    Math.ceil(filteredAndSorted.length / PAGE_SIZE),
+  );
+  const safePage = Math.min(page, totalPages);
+
+  const visibleHunters = useMemo(() => {
+    const start = (safePage - 1) * PAGE_SIZE;
+    return filteredAndSorted.slice(start, start + PAGE_SIZE);
+  }, [filteredAndSorted, safePage]);
+
+  const goToPage = (next: number) =>
+    setPage(Math.min(Math.max(1, next), totalPages));
+
+  return {
+    search,
+    setSearch,
+    selectedJob,
+    setSelectedJob,
+    activeTab,
+    setActiveTab,
+    attributeTab,
+    setAttributeTab,
+    safePage,
+    totalPages,
+    totalCount: filteredAndSorted.length,
+    pageStartRank: (safePage - 1) * PAGE_SIZE,
+    visibleHunters,
+    goToPage,
+  };
+}

--- a/frontend/packages/shared/src/attribute-display.ts
+++ b/frontend/packages/shared/src/attribute-display.ts
@@ -1,0 +1,94 @@
+/**
+ * Attribute display helpers for the four RPG attributes: STR, STA, AGI, VIT.
+ *
+ * These mirror the backend `domain.AttributeType` / `domain.ClampedAttribute`
+ * logic so the frontend and backend always agree on baseline and average.
+ */
+
+import type { EnrichedReport } from "./types";
+
+/** Attribute identifiers — mirrors backend `domain.AttributeType`. */
+export type AttributeType = "STR" | "STA" | "AGI" | "VIT";
+
+/** "Overall" pseudo-attribute used for the combined attribute leaderboard. */
+export const ATTRIBUTE_OVERALL = "OVERALL" as const;
+
+export type AttributeSortKey = AttributeType | typeof ATTRIBUTE_OVERALL;
+
+export const ATTRIBUTE_LIST: readonly AttributeType[] = ["STR", "STA", "AGI", "VIT"] as const;
+
+/** Display metadata for each attribute — single source of truth for labels & icons. */
+export const ATTRIBUTE_META: Record<
+  AttributeType,
+  { label: string; icon: string; color: string; description: string }
+> = {
+  STR: {
+    label: "Strength",
+    icon: "💪",
+    color: "text-system-red",
+    description: "Power & raw force",
+  },
+  STA: {
+    label: "Stamina",
+    icon: "🛡️",
+    color: "text-system-gold",
+    description: "Endurance & resilience",
+  },
+  AGI: {
+    label: "Agility",
+    icon: "⚡",
+    color: "text-system-green",
+    description: "Speed & reflexes",
+  },
+  VIT: {
+    label: "Vitality",
+    icon: "❤️",
+    color: "text-system-purple",
+    description: "Health & life force",
+  },
+};
+
+/**
+ * Returns the raw attribute value for the given type from an EnrichedReport.
+ * Backend already clamps to MinAttributeValue (1) before serialization,
+ * so no additional clamping is needed here.
+ */
+export function getAttributeValue(hunter: EnrichedReport, attr: AttributeType): number {
+  switch (attr) {
+    case "STR":
+      return hunter.str;
+    case "STA":
+      return hunter.sta;
+    case "AGI":
+      return hunter.agi;
+    case "VIT":
+      return hunter.vit;
+  }
+}
+
+/**
+ * Computes the rounded average of all four RPG attributes.
+ * Mirrors backend `Report.AttributeAverage()`.
+ */
+export function getAttributeAverage(hunter: EnrichedReport): number {
+  return Math.floor((hunter.str + hunter.sta + hunter.agi + hunter.vit) / 4);
+}
+
+/**
+ * Returns the attribute value (or average for OVERALL) for sort/compare logic.
+ * Mirrors backend `Report.AttributeValue(attr)`.
+ */
+export function getAttributeScore(hunter: EnrichedReport, key: AttributeSortKey): number {
+  if (key === ATTRIBUTE_OVERALL) {
+    return getAttributeAverage(hunter);
+  }
+  return getAttributeValue(hunter, key);
+}
+
+/**
+ * Returns true if the hunter has at least one attribute point.
+ * Mirrors backend `HasAttributeActivity()`.
+ */
+export function hasAttributeActivity(hunter: EnrichedReport): boolean {
+  return hunter.str > 0 || hunter.sta > 0 || hunter.agi > 0 || hunter.vit > 0;
+}

--- a/frontend/packages/shared/src/index.ts
+++ b/frontend/packages/shared/src/index.ts
@@ -6,3 +6,28 @@ export * from './hooks/useAuth';
 
 export { getJobColor, getJobBadgeClass } from "./job-utils";
 export { ATTRIBUTE_MIN, clampAttribute, attributeBarWidth } from "./attributes";
+export {
+  LEADERBOARD_SORT_KEYS,
+  ATTRIBUTE_SORT_KEYS,
+  ATTRIBUTE_TAB_TO_SORT_KEY,
+  sortLeaderboard,
+  filterLeaderboard,
+  compareReports,
+  getStreakStatus,
+  getActiveAttributeTab,
+  hasSeasonActivity,
+  hasAnyActivity,
+  hasStreakActivity,
+  hasAttributeActivity,
+  totalActiveDays,
+  attributeAverage,
+  attributeValueByKey,
+} from "./leaderboard-sort";
+export {
+  ATTRIBUTE_META,
+  ATTRIBUTE_LIST,
+  getAttributeAverage,
+  getAttributeValue,
+  formatAttributeValue,
+  getAttributeBarPercent,
+} from "./leaderboard-attributes";

--- a/frontend/packages/shared/src/leaderboard-attributes.ts
+++ b/frontend/packages/shared/src/leaderboard-attributes.ts
@@ -1,0 +1,72 @@
+import type { EnrichedReport, AttributeTab, LeaderboardSortKey } from "./types";
+
+export interface AttributeMeta {
+  key: "str" | "sta" | "agi" | "vit";
+  label: string;
+  short: string;
+  icon: string;
+  color: string;
+  sortKey: LeaderboardSortKey;
+}
+
+export const ATTRIBUTE_META: Record<Exclude<AttributeTab, "overall">, AttributeMeta> = {
+  str: {
+    key: "str",
+    label: "Strength",
+    short: "STR",
+    icon: "⚔️",
+    color: "text-system-red",
+    sortKey: "attribute_str",
+  },
+  sta: {
+    key: "sta",
+    label: "Stamina",
+    short: "STA",
+    icon: "🛡️",
+    color: "text-system-gold",
+    sortKey: "attribute_sta",
+  },
+  agi: {
+    key: "agi",
+    label: "Agility",
+    short: "AGI",
+    icon: "🗡️",
+    color: "text-system-blue",
+    sortKey: "attribute_agi",
+  },
+  vit: {
+    key: "vit",
+    label: "Vitality",
+    short: "VIT",
+    icon: "💚",
+    color: "text-system-green",
+    sortKey: "attribute_vit",
+  },
+};
+
+export const ATTRIBUTE_LIST = Object.values(ATTRIBUTE_META);
+
+const ATTRIBUTE_BAR_MAX = 12;
+
+export function getAttributeAverage(r: EnrichedReport): number {
+  const total =
+    Math.max(1, r.str) + Math.max(1, r.sta) +
+    Math.max(1, r.agi) + Math.max(1, r.vit);
+  return Math.floor(total / 4);
+}
+
+export function getAttributeValue(
+  r: EnrichedReport,
+  tab: AttributeTab,
+): number {
+  if (tab === "overall") return getAttributeAverage(r);
+  return Math.max(1, r[tab]);
+}
+
+export function formatAttributeValue(value: number): string {
+  return String(value);
+}
+
+export function getAttributeBarPercent(value: number): number {
+  return Math.min(100, Math.max(8, value * (100 / ATTRIBUTE_BAR_MAX)));
+}

--- a/frontend/packages/shared/src/leaderboard-filter.ts
+++ b/frontend/packages/shared/src/leaderboard-filter.ts
@@ -1,0 +1,56 @@
+import type { EnrichedReport } from "./types";
+
+/**
+ * Filter helpers — mirror domain.HasSeasonActivity / HasAnyActivity /
+ * HasStreakActivity / HasAttributeActivity on the backend.
+ *
+ * Keeping these as named pure functions (rather than methods on a class)
+ * lets tree-shaking drop the ones a given app doesn't use.
+ */
+
+/** User has any seasonal engagement (points or activity). */
+export function hasSeasonActivity(h: EnrichedReport): boolean {
+  return h.seasonal_points > 0 || h.seasonal_activity_count > 0;
+}
+
+/** User has any lifetime engagement (points or active days). */
+export function hasAnyActivity(h: EnrichedReport): boolean {
+  return h.total_points > 0 || h.total_active_days > 0;
+}
+
+/** User has a meaningful streak (current or historical best). */
+export function hasStreakActivity(h: EnrichedReport): boolean {
+  return h.streak > 0 || h.max_streak > 0;
+}
+
+/** User has at least one attribute above the minimum baseline (1). */
+export function hasAttributeActivity(h: EnrichedReport): boolean {
+  return h.str > 1 || h.sta > 1 || h.agi > 1 || h.vit > 1;
+}
+
+/** User has logged at least one day this week. */
+export function hasWeekActivity(h: EnrichedReport): boolean {
+  return h.week_active_days > 0;
+}
+
+/**
+ * Streak status derived from report data.
+ * Mirrors the WA bot's active/comeback/inactive classification.
+ */
+export type StreakStatus = "active" | "comeback" | "inactive";
+
+export function getStreakStatus(h: EnrichedReport): StreakStatus {
+  if (h.days_since_last_report <= 7 && h.streak > 0) return "active";
+  if (h.comeback_streak > 0 || h.days_since_last_report <= 14)
+    return "comeback";
+  return "inactive";
+}
+
+/**
+ * Centurion prefix label — mirrors the WA bot's `[S1-C{n}]` cycle marker.
+ * Returns empty string when no cycles exist.
+ */
+export function getCenturionLabel(h: EnrichedReport): string {
+  if (h.centurion_cycles <= 0) return "";
+  return `[S1-C${h.centurion_cycles + 1}]`;
+}

--- a/frontend/packages/shared/src/leaderboard-sort.ts
+++ b/frontend/packages/shared/src/leaderboard-sort.ts
@@ -1,0 +1,247 @@
+import type { EnrichedReport, LeaderboardSortKey, AttributeTab } from "./types";
+
+export const LEADERBOARD_SORT_KEYS: LeaderboardSortKey[] = [
+  "season_rank",
+  "lifetime_xp",
+  "weekly_streak",
+  "daily_streak",
+  "weekly_activity",
+  "attribute_overall",
+  "attribute_str",
+  "attribute_sta",
+  "attribute_agi",
+  "attribute_vit",
+];
+
+export const ATTRIBUTE_SORT_KEYS: LeaderboardSortKey[] = [
+  "attribute_overall",
+  "attribute_str",
+  "attribute_sta",
+  "attribute_agi",
+  "attribute_vit",
+];
+
+export const ATTRIBUTE_TAB_TO_SORT_KEY: Record<AttributeTab, LeaderboardSortKey> = {
+  overall: "attribute_overall",
+  str: "attribute_str",
+  sta: "attribute_sta",
+  agi: "attribute_agi",
+  vit: "attribute_vit",
+};
+
+export function getActiveAttributeTab(key: LeaderboardSortKey): AttributeTab {
+  switch (key) {
+    case "attribute_str": return "str";
+    case "attribute_sta": return "sta";
+    case "attribute_agi": return "agi";
+    case "attribute_vit": return "vit";
+    default: return "overall";
+  }
+}
+
+export function totalActiveDays(r: EnrichedReport): number {
+  return r.centurion_cycles * 100 + r.activity_count;
+}
+
+function clampAttr(v: number): number {
+  return Math.max(1, v);
+}
+
+export function attributeAverage(r: EnrichedReport): number {
+  const total =
+    clampAttr(r.str) + clampAttr(r.sta) + clampAttr(r.agi) + clampAttr(r.vit);
+  return Math.floor(total / 4);
+}
+
+export function attributeValueByKey(
+  r: EnrichedReport,
+  key: LeaderboardSortKey,
+): number {
+  switch (key) {
+    case "attribute_str": return clampAttr(r.str);
+    case "attribute_sta": return clampAttr(r.sta);
+    case "attribute_agi": return clampAttr(r.agi);
+    case "attribute_vit": return clampAttr(r.vit);
+    default: return attributeAverage(r);
+  }
+}
+
+export function hasSeasonActivity(r: EnrichedReport): boolean {
+  return r.seasonal_points > 0 || r.seasonal_activity_count > 0;
+}
+
+export function hasAnyActivity(r: EnrichedReport): boolean {
+  return r.total_points > 0 || r.activity_count > 0 || r.centurion_cycles > 0;
+}
+
+export function hasStreakActivity(r: EnrichedReport): boolean {
+  return (
+    r.streak > 0 ||
+    r.max_streak > 0 ||
+    r.seasonal_max_streak > 0 ||
+    r.activity_count > 0
+  );
+}
+
+export function hasAttributeActivity(r: EnrichedReport): boolean {
+  return r.str > 0 || r.sta > 0 || r.agi > 0 || r.vit > 0;
+}
+
+export function compareReports(
+  a: EnrichedReport,
+  b: EnrichedReport,
+  key: LeaderboardSortKey,
+): boolean {
+  switch (key) {
+    case "season_rank": return compareSeasonRank(a, b);
+    case "lifetime_xp": return compareLifetimeXP(a, b);
+    case "weekly_streak": return compareWeeklyStreak(a, b);
+    case "daily_streak": return compareDailyStreak(a, b);
+    case "weekly_activity": return compareWeeklyActivity(a, b);
+    case "attribute_overall": return compareAttributeOverall(a, b);
+    case "attribute_str":
+    case "attribute_sta":
+    case "attribute_agi":
+    case "attribute_vit":
+      return compareAttribute(a, b, key);
+    default: return compareSeasonRank(a, b);
+  }
+}
+
+function compareSeasonRank(a: EnrichedReport, b: EnrichedReport): boolean {
+  if (a.seasonal_points !== b.seasonal_points)
+    return a.seasonal_points > b.seasonal_points;
+  if (a.seasonal_activity_count !== b.seasonal_activity_count)
+    return a.seasonal_activity_count > b.seasonal_activity_count;
+  if (a.streak !== b.streak) return a.streak > b.streak;
+  if (totalActiveDays(a) !== totalActiveDays(b))
+    return totalActiveDays(a) > totalActiveDays(b);
+  return a.name < b.name;
+}
+
+function compareLifetimeXP(a: EnrichedReport, b: EnrichedReport): boolean {
+  if (a.total_points !== b.total_points)
+    return a.total_points > b.total_points;
+  if (totalActiveDays(a) !== totalActiveDays(b))
+    return totalActiveDays(a) > totalActiveDays(b);
+  if (a.max_streak !== b.max_streak) return a.max_streak > b.max_streak;
+  return a.name < b.name;
+}
+
+function compareWeeklyStreak(a: EnrichedReport, b: EnrichedReport): boolean {
+  if (a.streak !== b.streak) return a.streak > b.streak;
+  if (a.max_streak !== b.max_streak) return a.max_streak > b.max_streak;
+  if (a.seasonal_points !== b.seasonal_points)
+    return a.seasonal_points > b.seasonal_points;
+  return a.name < b.name;
+}
+
+function compareDailyStreak(a: EnrichedReport, b: EnrichedReport): boolean {
+  const aDaily = totalActiveDays(a);
+  const bDaily = totalActiveDays(b);
+  if (aDaily !== bDaily) return aDaily > bDaily;
+  if (a.max_streak !== b.max_streak) return a.max_streak > b.max_streak;
+  if (a.total_points !== b.total_points) return a.total_points > b.total_points;
+  return a.name < b.name;
+}
+
+function compareWeeklyActivity(a: EnrichedReport, b: EnrichedReport): boolean {
+  if (a.seasonal_activity_count !== b.seasonal_activity_count)
+    return a.seasonal_activity_count > b.seasonal_activity_count;
+  if (a.streak !== b.streak) return a.streak > b.streak;
+  if (a.seasonal_points !== b.seasonal_points)
+    return a.seasonal_points > b.seasonal_points;
+  return a.name < b.name;
+}
+
+function compareAttributeOverall(a: EnrichedReport, b: EnrichedReport): boolean {
+  const aAvg = attributeAverage(a);
+  const bAvg = attributeAverage(b);
+  if (aAvg !== bAvg) return aAvg > bAvg;
+  if (a.total_points !== b.total_points) return a.total_points > b.total_points;
+  return a.name < b.name;
+}
+
+function compareAttribute(
+  a: EnrichedReport,
+  b: EnrichedReport,
+  key: LeaderboardSortKey,
+): boolean {
+  const aVal = attributeValueByKey(a, key);
+  const bVal = attributeValueByKey(b, key);
+  if (aVal !== bVal) return aVal > bVal;
+  if (a.total_points !== b.total_points) return a.total_points > b.total_points;
+  return a.name < b.name;
+}
+
+export function sortLeaderboard(
+  reports: readonly EnrichedReport[],
+  key: LeaderboardSortKey,
+): EnrichedReport[] {
+  return [...reports].sort((a, b) => (compareReports(a, b, key) ? -1 : 1));
+}
+
+export interface FilterOptions {
+  search?: string;
+  jobClass?: string;
+}
+
+export function filterLeaderboard(
+  reports: readonly EnrichedReport[],
+  keep: (r: EnrichedReport) => boolean,
+): EnrichedReport[] {
+  return reports.filter(keep);
+}
+
+export function filterLeaderboardByTab(
+  reports: readonly EnrichedReport[],
+  sortKey: LeaderboardSortKey,
+  options: FilterOptions = {},
+): EnrichedReport[] {
+  let result = [...reports];
+
+  if (options.search?.trim()) {
+    const q = options.search.toLowerCase();
+    result = result.filter((r) => r.name.toLowerCase().includes(q));
+  }
+
+  if (options.jobClass && options.jobClass !== "all") {
+    result = result.filter(
+      (r) => r.job_class?.toLowerCase() === options.jobClass!.toLowerCase(),
+    );
+  }
+
+  const keepFn = filterPredicateForSortKey(sortKey);
+  return result.filter(keepFn);
+}
+
+function filterPredicateForSortKey(
+  key: LeaderboardSortKey,
+): (r: EnrichedReport) => boolean {
+  switch (key) {
+    case "season_rank":
+    case "weekly_activity":
+      return hasSeasonActivity;
+    case "lifetime_xp":
+      return hasAnyActivity;
+    case "weekly_streak":
+    case "daily_streak":
+      return hasStreakActivity;
+    case "attribute_overall":
+    case "attribute_str":
+    case "attribute_sta":
+    case "attribute_agi":
+    case "attribute_vit":
+      return hasAttributeActivity;
+    default:
+      return hasSeasonActivity;
+  }
+}
+
+export function getStreakStatus(hunter: EnrichedReport): string {
+  if (hunter.days_since_last_report <= 7 && hunter.streak > 0)
+    return "🔥 Active";
+  if (hunter.comeback_streak > 0 || hunter.days_since_last_report <= 14)
+    return "🗡️ Comeback";
+  return "💔 Inactive";
+}

--- a/frontend/packages/shared/src/types.ts
+++ b/frontend/packages/shared/src/types.ts
@@ -119,3 +119,26 @@ export interface JobInfo {
   description: string;
   trait: string;
 }
+
+// Mirror of backend LeaderboardSortKey in internal/domain/leaderboard_comparator.go.
+// Changing these values breaks the FE↔BE sort contract.
+export type LeaderboardTab =
+  | "seasonal"
+  | "lifetime"
+  | "streak"
+  | "week"
+  | "attributes";
+
+export type AttributeTab = "overall" | "str" | "sta" | "agi" | "vit";
+
+export type LeaderboardSortKey =
+  | "season_rank"
+  | "lifetime_xp"
+  | "weekly_streak"
+  | "daily_streak"
+  | "weekly_activity"
+  | "attribute_overall"
+  | "attribute_str"
+  | "attribute_sta"
+  | "attribute_agi"
+  | "attribute_vit";


### PR DESCRIPTION
- Deconstruct `LeaderboardTable` into granular components (e.g., `RankBadge`, `HunterCell`, `ProgressBar`) to improve readability and maintainability.
- Introduce `useLeaderboardData` hook to centralize leaderboard logic, including filtering, sorting, and pagination.
- Extract row-specific rendering into `SeasonalRow`, `LifetimeRow`, `StreakRow`, `WeekRow`, and `AttributeRow` to simplify table rendering based on active tab.