### PR TITLE
feat(leaderboard): add daily streaks and stable user IDs

### DIFF
--- a/frontend/apps/web/src/components/LeaderboardTable.tsx
+++ b/frontend/apps/web/src/components/LeaderboardTable.tsx
@@ -1,6 +1,19 @@
 import React, { useCallback } from "react";
-import { Search, SlidersHorizontal, Flame, Trophy, Award, CalendarDays, Swords } from "lucide-react";
-import type { EnrichedReport, LeaderboardTab, AttributeTab } from "@lapor-bot/shared";
+import {
+  Search,
+  SlidersHorizontal,
+  Flame,
+  Trophy,
+  Award,
+  CalendarDays,
+  Swords,
+} from "lucide-react";
+import type {
+  EnrichedReport,
+  LeaderboardTab,
+  AttributeTab,
+  StreakTab,
+} from "@lapor-bot/shared";
 
 import { SeasonalRow } from "./leaderboard/rows/SeasonalRow";
 import { LifetimeRow } from "./leaderboard/rows/LifetimeRow";
@@ -25,7 +38,11 @@ const JOB_FILTER_OPTIONS = [
   { id: "necromancer", name: "Necromancer 🌑" },
 ] as const;
 
-const LEADERBOARD_TABS: { id: LeaderboardTab; label: string; icon: typeof Trophy }[] = [
+const LEADERBOARD_TABS: {
+  id: LeaderboardTab;
+  label: string;
+  icon: typeof Trophy;
+}[] = [
   { id: "seasonal", label: "Season Rank", icon: Trophy },
   { id: "lifetime", label: "Lifetime XP", icon: Award },
   { id: "streak", label: "Streak Masters", icon: Flame },
@@ -41,50 +58,178 @@ const ATTRIBUTE_SUB_TABS: { id: AttributeTab; label: string }[] = [
   { id: "vit", label: "VIT" },
 ];
 
+const STREAK_SUB_TABS: { id: StreakTab; label: string }[] = [
+  { id: "weekly", label: "Mingguan" },
+  { id: "daily", label: "Harian" },
+];
+
 const TABLE_HEADERS: Record<LeaderboardTab, string[]> = {
-  seasonal: ["Rank", "Hunter", "Job", "Season Rank", "Streak", "Active Days", "Best Season Streak", "Freezes", "Season Points + Progress"],
-  lifetime: ["Rank", "Hunter", "Job", "Level Tier", "Level", "XP Progress", "Lifetime Days", "Best Streak", "Quests Done"],
-  streak: ["Rank", "Hunter", "Job", "Current Streak", "Best Streak", "Comeback", "Centurion", "Status"],
-  week: ["Rank", "Hunter", "Job", "Active Days", "Week Dots", "Streak", "Est. Points"],
-  attributes: ["Rank", "Hunter", "Job", "Attribute", "STR", "STA", "AGI", "VIT", "Level"],
+  seasonal: [
+    "Rank",
+    "Hunter",
+    "Job",
+    "Season Rank",
+    "Streak",
+    "Active Days",
+    "Best Season Streak",
+    "Freezes",
+    "Season Points + Progress",
+  ],
+  lifetime: [
+    "Rank",
+    "Hunter",
+    "Job",
+    "Level Tier",
+    "Level",
+    "XP Progress",
+    "Lifetime Days",
+    "Best Streak",
+    "Quests Done",
+  ],
+  streak: [
+    "Rank",
+    "Hunter",
+    "Job",
+    "Current Streak",
+    "Best Streak",
+    "Lifetime Days",
+    "Comeback",
+    "Centurion",
+    "Status",
+  ],
+  week: [
+    "Rank",
+    "Hunter",
+    "Job",
+    "Active Days",
+    "Week Dots",
+    "Streak",
+    "Est. Points",
+  ],
+  attributes: [
+    "Rank",
+    "Hunter",
+    "Job",
+    "Attribute",
+    "STR",
+    "STA",
+    "AGI",
+    "VIT",
+    "Level",
+  ],
 };
 
 const rowClass = (rank: number) =>
   `group transition-all hover:bg-gray-800/20 cursor-pointer ${rank < 3 ? "bg-gradient-to-r from-gray-950/20 to-transparent" : ""}`;
 
-export const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ hunters, onSelectHunter }) => {
+export const LeaderboardTable: React.FC<LeaderboardTableProps> = ({
+  hunters,
+  onSelectHunter,
+}) => {
   const {
-    search, setSearch,
-    selectedJob, setSelectedJob,
-    activeTab, setActiveTab,
-    attributeTab, setAttributeTab,
-    safePage, totalPages, pageStartRank, totalCount,
-    visibleHunters, goToPage,
+    search,
+    setSearch,
+    selectedJob,
+    setSelectedJob,
+    activeTab,
+    setActiveTab,
+    attributeTab,
+    setAttributeTab,
+    streakTab,
+    setStreakTab,
+    safePage,
+    totalPages,
+    pageStartRank,
+    totalCount,
+    visibleHunters,
+    goToPage,
   } = useLeaderboardData(hunters);
 
-  const handleTabChange = useCallback((tab: LeaderboardTab) => {
-    setActiveTab(tab);
-    setSearch("");
-    setSelectedJob("all");
-    goToPage(1);
-  }, [setActiveTab, setSearch, setSelectedJob, goToPage]);
+  const handleTabChange = useCallback(
+    (tab: LeaderboardTab) => {
+      setActiveTab(tab);
+      setSearch("");
+      setSelectedJob("all");
+      goToPage(1);
+    },
+    [setActiveTab, setSearch, setSelectedJob, goToPage],
+  );
 
-  const handleAttributeSubTabChange = useCallback((sub: AttributeTab) => {
-    setAttributeTab(sub);
-    goToPage(1);
-  }, [setAttributeTab, goToPage]);
+  const handleAttributeSubTabChange = useCallback(
+    (sub: AttributeTab) => {
+      setAttributeTab(sub);
+      goToPage(1);
+    },
+    [setAttributeTab, goToPage],
+  );
+
+  const handleStreakSubTabChange = useCallback(
+    (sub: StreakTab) => {
+      setStreakTab(sub);
+      goToPage(1);
+    },
+    [setStreakTab, goToPage],
+  );
 
   const renderRows = () =>
     visibleHunters.map((hunter, idx) => {
       const rank = pageStartRank + idx;
       const rc = rowClass(rank);
       switch (activeTab) {
-        case "seasonal": return <SeasonalRow key={hunter.user_id} hunter={hunter} rank={rank} rowClass={rc} onSelectHunter={onSelectHunter} />;
-        case "lifetime": return <LifetimeRow key={hunter.user_id} hunter={hunter} rank={rank} rowClass={rc} onSelectHunter={onSelectHunter} />;
-        case "streak": return <StreakRow key={hunter.user_id} hunter={hunter} rank={rank} rowClass={rc} onSelectHunter={onSelectHunter} />;
-        case "week": return <WeekRow key={hunter.user_id} hunter={hunter} rank={rank} rowClass={rc} onSelectHunter={onSelectHunter} />;
-        case "attributes": return <AttributeRow key={hunter.user_id} hunter={hunter} rank={rank} rowClass={rc} attributeTab={attributeTab} onSelectHunter={onSelectHunter} />;
-        default: return null;
+        case "seasonal":
+          return (
+            <SeasonalRow
+              key={hunter.user_id}
+              hunter={hunter}
+              rank={rank}
+              rowClass={rc}
+              onSelectHunter={onSelectHunter}
+            />
+          );
+        case "lifetime":
+          return (
+            <LifetimeRow
+              key={hunter.user_id}
+              hunter={hunter}
+              rank={rank}
+              rowClass={rc}
+              onSelectHunter={onSelectHunter}
+            />
+          );
+        case "streak":
+          return (
+            <StreakRow
+              key={hunter.user_id}
+              hunter={hunter}
+              rank={rank}
+              rowClass={rc}
+              streakTab={streakTab}
+              onSelectHunter={onSelectHunter}
+            />
+          );
+        case "week":
+          return (
+            <WeekRow
+              key={hunter.user_id}
+              hunter={hunter}
+              rank={rank}
+              rowClass={rc}
+              onSelectHunter={onSelectHunter}
+            />
+          );
+        case "attributes":
+          return (
+            <AttributeRow
+              key={hunter.user_id}
+              hunter={hunter}
+              rank={rank}
+              rowClass={rc}
+              attributeTab={attributeTab}
+              onSelectHunter={onSelectHunter}
+            />
+          );
+        default:
+          return null;
       }
     });
 
@@ -116,7 +261,10 @@ export const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ hunters, onS
 
         <div className="flex gap-2 items-center">
           <div className="relative">
-            <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" />
+            <Search
+              size={14}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500"
+            />
             <input
               value={search}
               onChange={(e) => setSearch(e.target.value)}
@@ -125,7 +273,10 @@ export const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ hunters, onS
             />
           </div>
           <div className="relative">
-            <SlidersHorizontal size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" />
+            <SlidersHorizontal
+              size={14}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500"
+            />
             <select
               value={selectedJob}
               onChange={(e) => setSelectedJob(e.target.value)}
@@ -162,6 +313,27 @@ export const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ hunters, onS
         </div>
       )}
 
+      {activeTab === "streak" && (
+        <div className="flex flex-wrap gap-1.5 mb-4 p-1.5 bg-gray-950/60 rounded-xl border border-gray-800/40 max-w-fit">
+          {STREAK_SUB_TABS.map((sub) => {
+            const active = streakTab === sub.id;
+            return (
+              <button
+                key={sub.id}
+                onClick={() => handleStreakSubTabChange(sub.id)}
+                className={`px-3 py-1.5 rounded-lg text-[10px] font-bold font-mono tracking-wider transition-all uppercase ${
+                  active
+                    ? "bg-gradient-to-r from-system-gold to-system-red text-white"
+                    : "text-gray-400 hover:text-white hover:bg-gray-800/60"
+                }`}
+              >
+                {sub.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
       <div className="overflow-x-auto">
         <table className="w-full">
           <thead>
@@ -170,7 +342,11 @@ export const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ hunters, onS
                 <th
                   key={`${activeTab}-${i}`}
                   className={`py-3 px-4 text-[10px] font-mono font-bold uppercase tracking-wider text-gray-500 ${
-                    i === 0 ? "text-center" : i === 1 ? "text-left" : "text-center"
+                    i === 0
+                      ? "text-center"
+                      : i === 1
+                        ? "text-left"
+                        : "text-center"
                   }`}
                 >
                   {header}
@@ -193,7 +369,9 @@ export const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ hunters, onS
       {totalPages > 1 && (
         <nav className="flex items-center justify-between mt-6 pt-4 border-t border-gray-800/60">
           <p className="text-xs font-mono text-gray-500">
-            Menampilkan {pageStartRank + 1}–{Math.min(pageStartRank + visibleHunters.length, totalCount)} dari {totalCount} hunters
+            Menampilkan {pageStartRank + 1}–
+            {Math.min(pageStartRank + visibleHunters.length, totalCount)} dari{" "}
+            {totalCount} hunters
           </p>
           <div className="flex items-center gap-2">
             <button

--- a/frontend/apps/web/src/components/leaderboard/rows/StreakRow.tsx
+++ b/frontend/apps/web/src/components/leaderboard/rows/StreakRow.tsx
@@ -1,15 +1,16 @@
 import React from "react";
-import type { EnrichedReport } from "@lapor-bot/shared";
+import type { EnrichedReport, StreakTab } from "@lapor-bot/shared";
+import { currentDailyStreak, longestDailyStreak } from "@lapor-bot/shared";
 import { RankBadge } from "../RankBadge";
 import { HunterCell } from "../HunterCell";
 import { JobCell } from "../JobCell";
-import { StreakCell } from "../StreakCell";
 import { getStreakStatus } from "@lapor-bot/shared";
 
 interface StreakRowProps {
   hunter: EnrichedReport;
   rank: number;
   rowClass: string;
+  streakTab: StreakTab;
   onSelectHunter: (hunter: EnrichedReport) => void;
 }
 
@@ -17,42 +18,58 @@ export const StreakRow: React.FC<StreakRowProps> = ({
   hunter,
   rank,
   rowClass,
+  streakTab,
   onSelectHunter,
-}) => (
-  <tr key={hunter.user_id} onClick={() => onSelectHunter(hunter)} className={rowClass}>
-    <td className="py-4 pl-4 text-center font-mono align-middle">
-      <div className="flex justify-center">
-        <RankBadge rank={rank} />
-      </div>
-    </td>
-    <HunterCell hunter={hunter} />
-    <JobCell hunter={hunter} />
-    <td className="py-4 pl-4 text-center align-middle text-sm">
-      <StreakCell weeks={hunter.streak} />
-    </td>
-    <td className="py-4 pl-4 text-center align-middle text-sm">
-      <StreakCell weeks={hunter.max_streak} />
-    </td>
-    <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
-      <span className="font-bold">{hunter.total_active_days}</span>
-      <span className="text-[10px] text-gray-500"> hari lifetime</span>
-    </td>
-    <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
-      <span className="font-bold text-system-purple">{hunter.comeback_streak}</span>
-      <span className="text-[10px] text-gray-500"> comeback</span>
-    </td>
-    <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
-      {hunter.centurion_cycles > 0 && (
-        <span className="font-bold text-system-gold">
-          {hunter.centurion_cycles}x 💯
+}) => {
+  const daily = streakTab === "daily";
+  const current = daily ? currentDailyStreak(hunter) : hunter.streak;
+  const best = daily ? longestDailyStreak(hunter) : hunter.max_streak;
+  const unit = daily ? "hari" : "minggu";
+
+  return (
+    <tr
+      key={hunter.user_id}
+      onClick={() => onSelectHunter(hunter)}
+      className={rowClass}
+    >
+      <td className="py-4 pl-4 text-center font-mono align-middle">
+        <div className="flex justify-center">
+          <RankBadge rank={rank} />
+        </div>
+      </td>
+      <HunterCell hunter={hunter} />
+      <JobCell hunter={hunter} />
+      <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+        <span className="font-bold text-system-gold">{current}</span>
+        <span className="text-[10px] text-gray-500"> {unit} streak</span>
+      </td>
+      <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+        <span className="font-bold">{best}</span>
+        <span className="text-[10px] text-gray-500"> best {unit}</span>
+      </td>
+      <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+        <span className="font-bold">{hunter.total_active_days}</span>
+        <span className="text-[10px] text-gray-500"> hari lifetime</span>
+      </td>
+      <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+        <span className="font-bold text-system-purple">
+          {hunter.comeback_streak}
         </span>
-      )}
-      {hunter.centurion_cycles === 0 && (
-        <span className="text-gray-600">—</span>
-      )}
-    </td>
-    <td className="py-4 pl-4 pr-4 text-center align-middle font-mono text-sm">
-      {getStreakStatus(hunter)}
-    </td>
-  </tr>
-);
+        <span className="text-[10px] text-gray-500"> comeback</span>
+      </td>
+      <td className="py-4 pl-4 text-center align-middle font-mono text-sm text-gray-300">
+        {hunter.centurion_cycles > 0 && (
+          <span className="font-bold text-system-gold">
+            {hunter.centurion_cycles}x 💯
+          </span>
+        )}
+        {hunter.centurion_cycles === 0 && (
+          <span className="text-gray-600">—</span>
+        )}
+      </td>
+      <td className="py-4 pl-4 pr-4 text-center align-middle font-mono text-sm">
+        {getStreakStatus(hunter)}
+      </td>
+    </tr>
+  );
+};

--- a/frontend/apps/web/src/components/leaderboard/useLeaderboardData.ts
+++ b/frontend/apps/web/src/components/leaderboard/useLeaderboardData.ts
@@ -3,6 +3,7 @@ import type {
   EnrichedReport,
   LeaderboardTab,
   AttributeTab,
+  StreakTab,
   LeaderboardSortKey,
 } from "@lapor-bot/shared";
 import {
@@ -11,6 +12,7 @@ import {
   hasAnyActivity,
   hasStreakActivity,
   hasAttributeActivity,
+  currentDailyStreak,
   ATTRIBUTE_TAB_TO_SORT_KEY,
 } from "@lapor-bot/shared";
 
@@ -41,6 +43,8 @@ export interface LeaderboardData {
   setActiveTab: (tab: LeaderboardTab) => void;
   attributeTab: AttributeTab;
   setAttributeTab: (tab: AttributeTab) => void;
+  streakTab: StreakTab;
+  setStreakTab: (tab: StreakTab) => void;
   safePage: number;
   totalPages: number;
   pageStartRank: number;
@@ -54,6 +58,7 @@ export function useLeaderboardData(hunters: EnrichedReport[]): LeaderboardData {
   const [selectedJob, setSelectedJob] = useState("all");
   const [activeTab, setActiveTab] = useState<LeaderboardTab>("seasonal");
   const [attributeTab, setAttributeTab] = useState<AttributeTab>("overall");
+  const [streakTab, setStreakTab] = useState<StreakTab>("weekly");
   const [page, setPage] = useState(1);
 
   const filteredAndSorted = useMemo(() => {
@@ -66,19 +71,23 @@ export function useLeaderboardData(hunters: EnrichedReport[]): LeaderboardData {
     const matchesJob = (h: EnrichedReport) =>
       jobFilter === "all" || h.job_class?.toLowerCase() === jobFilter;
 
-    const passesTabFilter = TAB_FILTER[activeTab];
+    const sortKey =
+      activeTab === "attributes"
+        ? ATTRIBUTE_TAB_TO_SORT_KEY[attributeTab]
+        : activeTab === "streak" && streakTab === "daily"
+          ? "daily_streak"
+          : TAB_SORT_KEY[activeTab];
 
+    const passesTabFilter =
+      activeTab === "streak" && streakTab === "daily"
+        ? (h: EnrichedReport) => currentDailyStreak(h) > 0
+        : TAB_FILTER[activeTab];
     const filtered = hunters.filter(
       (h) => passesTabFilter(h) && matchesSearch(h) && matchesJob(h),
     );
 
-    const sortKey =
-      activeTab === "attributes"
-        ? ATTRIBUTE_TAB_TO_SORT_KEY[attributeTab]
-        : TAB_SORT_KEY[activeTab];
-
     return sortLeaderboard(filtered, sortKey);
-  }, [hunters, activeTab, attributeTab, search, selectedJob]);
+  }, [hunters, activeTab, attributeTab, streakTab, search, selectedJob]);
 
   const totalPages = Math.max(
     1,
@@ -103,6 +112,8 @@ export function useLeaderboardData(hunters: EnrichedReport[]): LeaderboardData {
     setActiveTab,
     attributeTab,
     setAttributeTab,
+    streakTab,
+    setStreakTab,
     safePage,
     totalPages,
     totalCount: filteredAndSorted.length,

--- a/frontend/packages/shared/src/index.ts
+++ b/frontend/packages/shared/src/index.ts
@@ -1,8 +1,8 @@
-export * from './types';
-export * from './domain/repositories';
-export * from './providers/RepositoryProvider';
-export * from './hooks/useReports';
-export * from './hooks/useAuth';
+export * from "./types";
+export * from "./domain/repositories";
+export * from "./providers/RepositoryProvider";
+export * from "./hooks/useReports";
+export * from "./hooks/useAuth";
 
 export { getJobColor, getJobBadgeClass } from "./job-utils";
 export { ATTRIBUTE_MIN, clampAttribute, attributeBarWidth } from "./attributes";
@@ -20,6 +20,8 @@ export {
   hasStreakActivity,
   hasAttributeActivity,
   totalActiveDays,
+  currentDailyStreak,
+  longestDailyStreak,
   attributeAverage,
   attributeValueByKey,
 } from "./leaderboard-sort";

--- a/frontend/packages/shared/src/leaderboard-filter.ts
+++ b/frontend/packages/shared/src/leaderboard-filter.ts
@@ -1,4 +1,5 @@
 import type { EnrichedReport } from "./types";
+import { currentDailyStreak, longestDailyStreak } from "./leaderboard-sort";
 
 /**
  * Filter helpers — mirror domain.HasSeasonActivity / HasAnyActivity /
@@ -20,7 +21,12 @@ export function hasAnyActivity(h: EnrichedReport): boolean {
 
 /** User has a meaningful streak (current or historical best). */
 export function hasStreakActivity(h: EnrichedReport): boolean {
-  return h.streak > 0 || h.max_streak > 0;
+  return (
+    h.streak > 0 ||
+    h.max_streak > 0 ||
+    currentDailyStreak(h) > 0 ||
+    longestDailyStreak(h) > 0
+  );
 }
 
 /** User has at least one attribute above the minimum baseline (1). */

--- a/frontend/packages/shared/src/leaderboard-sort.ts
+++ b/frontend/packages/shared/src/leaderboard-sort.ts
@@ -21,7 +21,10 @@ export const ATTRIBUTE_SORT_KEYS: LeaderboardSortKey[] = [
   "attribute_vit",
 ];
 
-export const ATTRIBUTE_TAB_TO_SORT_KEY: Record<AttributeTab, LeaderboardSortKey> = {
+export const ATTRIBUTE_TAB_TO_SORT_KEY: Record<
+  AttributeTab,
+  LeaderboardSortKey
+> = {
   overall: "attribute_overall",
   str: "attribute_str",
   sta: "attribute_sta",
@@ -31,16 +34,29 @@ export const ATTRIBUTE_TAB_TO_SORT_KEY: Record<AttributeTab, LeaderboardSortKey>
 
 export function getActiveAttributeTab(key: LeaderboardSortKey): AttributeTab {
   switch (key) {
-    case "attribute_str": return "str";
-    case "attribute_sta": return "sta";
-    case "attribute_agi": return "agi";
-    case "attribute_vit": return "vit";
-    default: return "overall";
+    case "attribute_str":
+      return "str";
+    case "attribute_sta":
+      return "sta";
+    case "attribute_agi":
+      return "agi";
+    case "attribute_vit":
+      return "vit";
+    default:
+      return "overall";
   }
 }
 
 export function totalActiveDays(r: EnrichedReport): number {
-  return r.centurion_cycles * 100 + r.activity_count;
+  return r.total_active_days ?? r.centurion_cycles * 100 + r.activity_count;
+}
+
+export function currentDailyStreak(r: EnrichedReport): number {
+  return r.current_daily_streak ?? 0;
+}
+
+export function longestDailyStreak(r: EnrichedReport): number {
+  return r.longest_daily_streak ?? currentDailyStreak(r);
 }
 
 function clampAttr(v: number): number {
@@ -58,11 +74,16 @@ export function attributeValueByKey(
   key: LeaderboardSortKey,
 ): number {
   switch (key) {
-    case "attribute_str": return clampAttr(r.str);
-    case "attribute_sta": return clampAttr(r.sta);
-    case "attribute_agi": return clampAttr(r.agi);
-    case "attribute_vit": return clampAttr(r.vit);
-    default: return attributeAverage(r);
+    case "attribute_str":
+      return clampAttr(r.str);
+    case "attribute_sta":
+      return clampAttr(r.sta);
+    case "attribute_agi":
+      return clampAttr(r.agi);
+    case "attribute_vit":
+      return clampAttr(r.vit);
+    default:
+      return attributeAverage(r);
   }
 }
 
@@ -79,6 +100,8 @@ export function hasStreakActivity(r: EnrichedReport): boolean {
     r.streak > 0 ||
     r.max_streak > 0 ||
     r.seasonal_max_streak > 0 ||
+    currentDailyStreak(r) > 0 ||
+    longestDailyStreak(r) > 0 ||
     r.activity_count > 0
   );
 }
@@ -93,18 +116,25 @@ export function compareReports(
   key: LeaderboardSortKey,
 ): boolean {
   switch (key) {
-    case "season_rank": return compareSeasonRank(a, b);
-    case "lifetime_xp": return compareLifetimeXP(a, b);
-    case "weekly_streak": return compareWeeklyStreak(a, b);
-    case "daily_streak": return compareDailyStreak(a, b);
-    case "weekly_activity": return compareWeeklyActivity(a, b);
-    case "attribute_overall": return compareAttributeOverall(a, b);
+    case "season_rank":
+      return compareSeasonRank(a, b);
+    case "lifetime_xp":
+      return compareLifetimeXP(a, b);
+    case "weekly_streak":
+      return compareWeeklyStreak(a, b);
+    case "daily_streak":
+      return compareDailyStreak(a, b);
+    case "weekly_activity":
+      return compareWeeklyActivity(a, b);
+    case "attribute_overall":
+      return compareAttributeOverall(a, b);
     case "attribute_str":
     case "attribute_sta":
     case "attribute_agi":
     case "attribute_vit":
       return compareAttribute(a, b, key);
-    default: return compareSeasonRank(a, b);
+    default:
+      return compareSeasonRank(a, b);
   }
 }
 
@@ -116,16 +146,15 @@ function compareSeasonRank(a: EnrichedReport, b: EnrichedReport): boolean {
   if (a.streak !== b.streak) return a.streak > b.streak;
   if (totalActiveDays(a) !== totalActiveDays(b))
     return totalActiveDays(a) > totalActiveDays(b);
-  return a.name < b.name;
+  return compareNameThenUserID(a, b);
 }
 
 function compareLifetimeXP(a: EnrichedReport, b: EnrichedReport): boolean {
-  if (a.total_points !== b.total_points)
-    return a.total_points > b.total_points;
+  if (a.total_points !== b.total_points) return a.total_points > b.total_points;
   if (totalActiveDays(a) !== totalActiveDays(b))
     return totalActiveDays(a) > totalActiveDays(b);
   if (a.max_streak !== b.max_streak) return a.max_streak > b.max_streak;
-  return a.name < b.name;
+  return compareNameThenUserID(a, b);
 }
 
 function compareWeeklyStreak(a: EnrichedReport, b: EnrichedReport): boolean {
@@ -133,16 +162,18 @@ function compareWeeklyStreak(a: EnrichedReport, b: EnrichedReport): boolean {
   if (a.max_streak !== b.max_streak) return a.max_streak > b.max_streak;
   if (a.seasonal_points !== b.seasonal_points)
     return a.seasonal_points > b.seasonal_points;
-  return a.name < b.name;
+  return compareNameThenUserID(a, b);
 }
 
 function compareDailyStreak(a: EnrichedReport, b: EnrichedReport): boolean {
-  const aDaily = totalActiveDays(a);
-  const bDaily = totalActiveDays(b);
+  const aDaily = currentDailyStreak(a);
+  const bDaily = currentDailyStreak(b);
   if (aDaily !== bDaily) return aDaily > bDaily;
-  if (a.max_streak !== b.max_streak) return a.max_streak > b.max_streak;
+  const aLongest = longestDailyStreak(a);
+  const bLongest = longestDailyStreak(b);
+  if (aLongest !== bLongest) return aLongest > bLongest;
   if (a.total_points !== b.total_points) return a.total_points > b.total_points;
-  return a.name < b.name;
+  return compareNameThenUserID(a, b);
 }
 
 function compareWeeklyActivity(a: EnrichedReport, b: EnrichedReport): boolean {
@@ -151,15 +182,18 @@ function compareWeeklyActivity(a: EnrichedReport, b: EnrichedReport): boolean {
   if (a.streak !== b.streak) return a.streak > b.streak;
   if (a.seasonal_points !== b.seasonal_points)
     return a.seasonal_points > b.seasonal_points;
-  return a.name < b.name;
+  return compareNameThenUserID(a, b);
 }
 
-function compareAttributeOverall(a: EnrichedReport, b: EnrichedReport): boolean {
+function compareAttributeOverall(
+  a: EnrichedReport,
+  b: EnrichedReport,
+): boolean {
   const aAvg = attributeAverage(a);
   const bAvg = attributeAverage(b);
   if (aAvg !== bAvg) return aAvg > bAvg;
   if (a.total_points !== b.total_points) return a.total_points > b.total_points;
-  return a.name < b.name;
+  return compareNameThenUserID(a, b);
 }
 
 function compareAttribute(
@@ -171,14 +205,23 @@ function compareAttribute(
   const bVal = attributeValueByKey(b, key);
   if (aVal !== bVal) return aVal > bVal;
   if (a.total_points !== b.total_points) return a.total_points > b.total_points;
-  return a.name < b.name;
+  return compareNameThenUserID(a, b);
+}
+
+function compareNameThenUserID(a: EnrichedReport, b: EnrichedReport): boolean {
+  if (a.name !== b.name) return a.name < b.name;
+  return a.user_id < b.user_id;
 }
 
 export function sortLeaderboard(
   reports: readonly EnrichedReport[],
   key: LeaderboardSortKey,
 ): EnrichedReport[] {
-  return [...reports].sort((a, b) => (compareReports(a, b, key) ? -1 : 1));
+  return [...reports].sort((a, b) => {
+    if (compareReports(a, b, key)) return -1;
+    if (compareReports(b, a, key)) return 1;
+    return 0;
+  });
 }
 
 export interface FilterOptions {

--- a/frontend/packages/shared/src/types.ts
+++ b/frontend/packages/shared/src/types.ts
@@ -131,6 +131,8 @@ export type LeaderboardTab =
 
 export type AttributeTab = "overall" | "str" | "sta" | "agi" | "vit";
 
+export type StreakTab = "weekly" | "daily";
+
 export type LeaderboardSortKey =
   | "season_rank"
   | "lifetime_xp"

--- a/internal/app/usecase/get_leaderboard_usecase.go
+++ b/internal/app/usecase/get_leaderboard_usecase.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -23,6 +24,7 @@ func (uc *GetLeaderboardUsecase) Execute(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	reports = domain.DedupReportsByUserID(reports, domain.SortBySeasonRank)
 
 	now := time.Now()
 	displayDate := domain.GetToday(now)
@@ -81,6 +83,7 @@ func (uc *GetLeaderboardUsecase) ExecuteSeasonal(ctx context.Context) (string, e
 	if err != nil {
 		return "", err
 	}
+	reports = domain.DedupReportsByUserID(reports, domain.SortBySeasonRank)
 
 	now := time.Now()
 	seasonNumber, _ := GetCurrentSessionInfo(now)
@@ -118,6 +121,7 @@ func (uc *GetLeaderboardUsecase) ExecuteRanks(ctx context.Context) (string, erro
 	if err != nil {
 		return "", err
 	}
+	reports = domain.DedupReportsByUserID(reports, domain.SortBySeasonRank)
 
 	now := time.Now()
 	seasonNumber, _ := GetCurrentSessionInfo(now)
@@ -167,6 +171,7 @@ func (uc *GetLeaderboardUsecase) ExecuteLifetime(ctx context.Context) (string, e
 	if err != nil {
 		return "", err
 	}
+	reports = domain.DedupReportsByUserID(reports, domain.SortByLifetimeXP)
 
 	seasonNumber, _ := GetCurrentSessionInfo(time.Now())
 
@@ -219,7 +224,8 @@ func (uc *GetLeaderboardUsecase) ExecuteStreakMasters(ctx context.Context, strea
 	var key domain.LeaderboardSortKey
 	var title, icon, metricLabel string
 
-	switch strings.ToLower(streakType) {
+	normalizedType := strings.ToLower(streakType)
+	switch normalizedType {
 	case "daily":
 		key = domain.SortByDailyStreak
 		title = "Streak Masters — Daily"
@@ -232,6 +238,10 @@ func (uc *GetLeaderboardUsecase) ExecuteStreakMasters(ctx context.Context, strea
 		metricLabel = "minggu beruntun"
 	default:
 		return "", fmt.Errorf("invalid streak type %q: expected daily or weekly", streakType)
+	}
+	reports = domain.DedupReportsByUserID(reports, key)
+	if normalizedType == "daily" {
+		return uc.executeDailyStreakMasters(ctx, reports, seasonNumber, title, icon, metricLabel)
 	}
 
 	domain.SortReports(reports, key)
@@ -253,7 +263,7 @@ func (uc *GetLeaderboardUsecase) ExecuteStreakMasters(ctx context.Context, strea
 
 	for rank := 0; rank < maxRank; rank++ {
 		r := active[rank]
-		sb.WriteString(formatStreakEntry(rank+1, r, strings.ToLower(streakType), metricLabel))
+		sb.WriteString(formatStreakEntry(rank+1, r, normalizedType, metricLabel))
 	}
 
 	sb.WriteString("\nStreak dihitung dari konsistensi laporan. Jangan sampai putus! 🔥")
@@ -275,6 +285,7 @@ func (uc *GetLeaderboardUsecase) ExecuteAttribute(ctx context.Context, attrType 
 	if err != nil {
 		return "", err
 	}
+	reports = domain.DedupReportsByUserID(reports, key)
 
 	domain.SortReports(reports, key)
 	active := domain.FilterReports(reports, domain.HasAttributeActivity)
@@ -324,6 +335,105 @@ func (uc *GetLeaderboardUsecase) ExecuteAttribute(ctx context.Context, attrType 
 	sb.WriteString("\nAttribute naik dari laporan aktivitas. Variasikan latihanmu! ⚔️")
 
 	return sb.String(), nil
+}
+
+type dailyStreakEntry struct {
+	report  *domain.Report
+	current int
+	longest int
+}
+
+func (uc *GetLeaderboardUsecase) executeDailyStreakMasters(ctx context.Context, reports []*domain.Report, seasonNumber int, title, icon, metricLabel string) (string, error) {
+	today := domain.GetToday(time.Now())
+	entries := make([]dailyStreakEntry, 0, len(reports))
+	for _, report := range reports {
+		dates, err := uc.repo.GetUserActivityDates(ctx, report.UserID)
+		if err != nil {
+			return "", err
+		}
+		current, longest := calculateDailyStreaks(dates, today)
+		if current > 0 {
+			entries = append(entries, dailyStreakEntry{report: report, current: current, longest: longest})
+		}
+	}
+
+	sort.SliceStable(entries, func(i, j int) bool {
+		a, b := entries[i], entries[j]
+		if a.current != b.current {
+			return a.current > b.current
+		}
+		if a.longest != b.longest {
+			return a.longest > b.longest
+		}
+		if a.report.TotalPoints != b.report.TotalPoints {
+			return a.report.TotalPoints > b.report.TotalPoints
+		}
+		return domain.CompareReports(a.report, b.report, domain.SortByLifetimeXP)
+	})
+
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf("%s *%s*\n", icon, title))
+	sb.WriteString(fmt.Sprintf("Season %d\n\n", seasonNumber))
+
+	if len(entries) == 0 {
+		sb.WriteString("Belum ada hunter dengan streak harian aktif. Mulai dengan /lapor! 💪")
+		return sb.String(), nil
+	}
+
+	maxRank := 10
+	if len(entries) < maxRank {
+		maxRank = len(entries)
+	}
+
+	for rank := 0; rank < maxRank; rank++ {
+		entry := entries[rank]
+		sb.WriteString(fmt.Sprintf(
+			"%d. %s — %d %s (best %d hari, %d pts)\n",
+			rank+1,
+			entry.report.Name,
+			entry.current,
+			metricLabel,
+			entry.longest,
+			entry.report.TotalPoints,
+		))
+	}
+
+	sb.WriteString("\nStreak harian dihitung dari laporan beruntun per hari. Jangan sampai putus! 🔥")
+
+	return sb.String(), nil
+}
+
+func calculateDailyStreaks(activityDates []time.Time, today time.Time) (int, int) {
+	activeDates := make(map[string]bool, len(activityDates))
+	for _, date := range activityDates {
+		activeDates[domain.GetToday(date).Format(time.DateOnly)] = true
+	}
+
+	current := 0
+	for date := today; activeDates[date.Format(time.DateOnly)]; date = date.AddDate(0, 0, -1) {
+		current++
+	}
+
+	longest := 0
+	running := 0
+	var previous time.Time
+	for _, date := range activityDates {
+		day := domain.GetToday(date)
+		if !previous.IsZero() && day.Equal(previous) {
+			continue
+		}
+		if !previous.IsZero() && day.Equal(previous.AddDate(0, 0, 1)) {
+			running++
+		} else {
+			running = 1
+		}
+		if running > longest {
+			longest = running
+		}
+		previous = day
+	}
+
+	return current, longest
 }
 
 func countStreakStatus(reports []*domain.Report, now time.Time) (active, lost int) {

--- a/internal/app/usecase/get_weekly_leaderboard_usecase.go
+++ b/internal/app/usecase/get_weekly_leaderboard_usecase.go
@@ -26,9 +26,9 @@ func NewGetWeeklyLeaderboardUsecase(repo domain.ReportRepository) *GetWeeklyLead
 // so the leaderboard can apply the full tie-break chain:
 // laporan duluan (activity count) → streak → poin.
 type weeklyEntry struct {
-	Name          string
-	ActivityCount int
-	Streak        int
+	Name           string
+	ActivityCount  int
+	Streak         int
 	SeasonalPoints int
 }
 
@@ -46,10 +46,11 @@ func (uc *GetWeeklyLeaderboardUsecase) Execute(ctx context.Context) (string, err
 	if err != nil {
 		return "", err
 	}
+	reports = domain.DedupReportsByUserID(reports, domain.SortByWeeklyActivity)
 
 	enriched := enrichWeeklyEntries(entries, reports)
 
-	sort.Slice(enriched, func(i, j int) bool {
+	sort.SliceStable(enriched, func(i, j int) bool {
 		if enriched[i].ActivityCount != enriched[j].ActivityCount {
 			return enriched[i].ActivityCount > enriched[j].ActivityCount
 		}

--- a/internal/domain/leaderboard_comparator.go
+++ b/internal/domain/leaderboard_comparator.go
@@ -109,9 +109,41 @@ func CompareReports(a, b *Report, key LeaderboardSortKey) bool {
 
 // SortReports sorts a slice of reports in-place using the given sort key.
 func SortReports(reports []*Report, key LeaderboardSortKey) {
-	sort.Slice(reports, func(i, j int) bool {
+	sort.SliceStable(reports, func(i, j int) bool {
 		return CompareReports(reports[i], reports[j], key)
 	})
+}
+
+// DedupReportsByUserID returns one report per canonical user ID while keeping
+// the highest-ranking row for the requested leaderboard. This protects callers
+// that aggregate from multiple sources before sorting.
+func DedupReportsByUserID(reports []*Report, key LeaderboardSortKey) []*Report {
+	seenIndex := make(map[string]int, len(reports))
+	result := make([]*Report, 0, len(reports))
+
+	for _, report := range reports {
+		if report == nil {
+			continue
+		}
+		if report.UserID == "" {
+			result = append(result, report)
+			continue
+		}
+
+		index, ok := seenIndex[report.UserID]
+		if !ok {
+			seenIndex[report.UserID] = len(result)
+			result = append(result, report)
+			continue
+		}
+
+		current := result[index]
+		if CompareReports(report, current, key) {
+			result[index] = report
+		}
+	}
+
+	return result
 }
 
 // HasSeasonActivity returns true if a report has any seasonal engagement.
@@ -165,7 +197,7 @@ func compareSeasonRank(a, b *Report) bool {
 	if a.TotalActiveDays() != b.TotalActiveDays() {
 		return a.TotalActiveDays() > b.TotalActiveDays()
 	}
-	return a.Name < b.Name
+	return compareNameThenUserID(a, b)
 }
 
 func compareLifetimeXP(a, b *Report) bool {
@@ -178,7 +210,7 @@ func compareLifetimeXP(a, b *Report) bool {
 	if a.MaxStreak != b.MaxStreak {
 		return a.MaxStreak > b.MaxStreak
 	}
-	return a.Name < b.Name
+	return compareNameThenUserID(a, b)
 }
 
 func compareWeeklyStreak(a, b *Report) bool {
@@ -191,7 +223,7 @@ func compareWeeklyStreak(a, b *Report) bool {
 	if a.SeasonalPoints != b.SeasonalPoints {
 		return a.SeasonalPoints > b.SeasonalPoints
 	}
-	return a.Name < b.Name
+	return compareNameThenUserID(a, b)
 }
 
 func compareDailyStreak(a, b *Report) bool {
@@ -207,7 +239,7 @@ func compareDailyStreak(a, b *Report) bool {
 	if a.TotalPoints != b.TotalPoints {
 		return a.TotalPoints > b.TotalPoints
 	}
-	return a.Name < b.Name
+	return compareNameThenUserID(a, b)
 }
 
 func compareWeeklyActivity(a, b *Report) bool {
@@ -221,7 +253,7 @@ func compareWeeklyActivity(a, b *Report) bool {
 	if a.SeasonalPoints != b.SeasonalPoints {
 		return a.SeasonalPoints > b.SeasonalPoints
 	}
-	return a.Name < b.Name
+	return compareNameThenUserID(a, b)
 }
 
 func compareAttributeOverall(a, b *Report) bool {
@@ -233,7 +265,7 @@ func compareAttributeOverall(a, b *Report) bool {
 	if a.TotalPoints != b.TotalPoints {
 		return a.TotalPoints > b.TotalPoints
 	}
-	return a.Name < b.Name
+	return compareNameThenUserID(a, b)
 }
 
 func compareAttribute(a, b *Report, key LeaderboardSortKey) bool {
@@ -259,7 +291,14 @@ func compareAttribute(a, b *Report, key LeaderboardSortKey) bool {
 	if a.TotalPoints != b.TotalPoints {
 		return a.TotalPoints > b.TotalPoints
 	}
-	return a.Name < b.Name
+	return compareNameThenUserID(a, b)
+}
+
+func compareNameThenUserID(a, b *Report) bool {
+	if a.Name != b.Name {
+		return a.Name < b.Name
+	}
+	return a.UserID < b.UserID
 }
 
 // AttributeSortKeyFromType converts an AttributeType to its corresponding

--- a/internal/domain/leaderboard_comparator_test.go
+++ b/internal/domain/leaderboard_comparator_test.go
@@ -6,6 +6,7 @@ import (
 
 func makeReport(name string, seasonalPoints, seasonalActivity, streak, totalPoints, maxStreak, activityCount, centurionCycles, str, sta, agi, vit int) *Report {
 	return &Report{
+		UserID:                name,
 		Name:                  name,
 		SeasonalPoints:        seasonalPoints,
 		SeasonalActivityCount: seasonalActivity,
@@ -203,6 +204,37 @@ func TestSortReports_SortsInPlace(t *testing.T) {
 	}
 }
 
+func TestDedupReportsByUserID_KeepsBestReportForSortKey(t *testing.T) {
+	reports := []*Report{
+		{UserID: "u1", Name: "Alice", SeasonalPoints: 10, SeasonalActivityCount: 1},
+		{UserID: "u2", Name: "Bob", SeasonalPoints: 20, SeasonalActivityCount: 1},
+		{UserID: "u1", Name: "Alice", SeasonalPoints: 30, SeasonalActivityCount: 2},
+	}
+
+	got := DedupReportsByUserID(reports, SortBySeasonRank)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 reports after dedupe, got %d", len(got))
+	}
+	if got[0].UserID != "u1" || got[0].SeasonalPoints != 30 {
+		t.Fatalf("expected best u1 row kept in original user order, got %+v", got[0])
+	}
+	if got[1].UserID != "u2" {
+		t.Fatalf("expected u2 second, got %+v", got[1])
+	}
+}
+
+func TestCompareReports_NameTieBreaksByUserID(t *testing.T) {
+	a := makeReport("Same", 100, 1, 1, 100, 1, 1, 0, 1, 1, 1, 1)
+	b := makeReport("Same", 100, 1, 1, 100, 1, 1, 0, 1, 1, 1, 1)
+	a.UserID = "1"
+	b.UserID = "2"
+
+	if !CompareReports(a, b, SortBySeasonRank) {
+		t.Errorf("with equal name and metrics, lower user_id should rank first")
+	}
+}
+
 func TestHasSeasonActivity(t *testing.T) {
 	tests := []struct {
 		name string
@@ -307,9 +339,9 @@ func TestReport_TotalActiveDays(t *testing.T) {
 
 func TestReport_AttributeAverage(t *testing.T) {
 	tests := []struct {
-		name      string
+		name               string
 		str, sta, agi, vit int
-		want      int
+		want               int
 	}{
 		{"all zero clamps to 1", 0, 0, 0, 0, 1},
 		{"all ten", 10, 10, 10, 10, 10},

--- a/internal/infra/http/handler.go
+++ b/internal/infra/http/handler.go
@@ -2,6 +2,8 @@ package http
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -241,16 +243,16 @@ type GlobalSummary struct {
 	CurrentDay          int            `json:"current_day"`
 }
 
-// maskPhone hides all but the last 2 digits of a phone number so the public
-// leaderboard cannot be used to reconstruct real numbers.
-// ponytail: fixed-width mask (9 stars + 2 suffix) — no information about
-// prefix length leaks; ceiling: 2-digit suffix means 100 candidates per masked
-// value, acceptable for a public gamification dashboard.
+// maskPhone returns a stable, non-reversible public identifier. The hash keeps
+// React keys and leaderboard tie-breakers unique without exposing the real
+// phone number; the two-digit suffix is only a familiar visual hint.
 func maskPhone(phone string) string {
+	sum := sha256.Sum256([]byte(phone))
+	digest := hex.EncodeToString(sum[:])[:10]
 	if len(phone) <= 2 {
-		return "*********"
+		return "hunter-" + digest
 	}
-	return "*********" + phone[len(phone)-2:]
+	return "hunter-" + digest + "-" + phone[len(phone)-2:]
 }
 
 func buildTierProgress(value, currentMin int, nextMin int, nextName, nextIcon string, isMax bool) TierProgress {
@@ -373,6 +375,11 @@ func buildDailyActivity(activityDates []time.Time, today time.Time, days int) ([
 	return activity, activeDays, currentStreak, longestStreak
 }
 
+func buildDailyStreaks(activityDates []time.Time, today time.Time) (int, int) {
+	_, _, currentStreak, longestStreak := buildDailyActivity(activityDates, today, 1)
+	return currentStreak, longestStreak
+}
+
 var profileDayLabels = []string{"Minggu", "Senin", "Selasa", "Rabu", "Kamis", "Jumat", "Sabtu"}
 
 func buildPersonalGoal(goal *domain.WeeklyGoal, activities []domain.GoalActivity) *PersonalGoal {
@@ -447,7 +454,7 @@ func buildPersonalGoal(goal *domain.WeeklyGoal, activities []domain.GoalActivity
 }
 
 func sortEnrichedReportsBySeason(reports []EnrichedReport) {
-	sort.Slice(reports, func(i, j int) bool {
+	sort.SliceStable(reports, func(i, j int) bool {
 		a, b := reports[i], reports[j]
 		if a.SeasonalPoints != b.SeasonalPoints {
 			return a.SeasonalPoints > b.SeasonalPoints
@@ -461,7 +468,10 @@ func sortEnrichedReportsBySeason(reports []EnrichedReport) {
 		if a.TotalActiveDays != b.TotalActiveDays {
 			return a.TotalActiveDays > b.TotalActiveDays
 		}
-		return a.Name < b.Name
+		if a.Name != b.Name {
+			return a.Name < b.Name
+		}
+		return a.UserID < b.UserID
 	})
 }
 
@@ -586,6 +596,7 @@ func (s *Server) AssemblePublicLeaderboard(ctx context.Context) ([]EnrichedRepor
 	if err != nil {
 		return nil, err
 	}
+	reports = domain.DedupReportsByUserID(reports, domain.SortBySeasonRank)
 
 	now := time.Now()
 	today := domain.GetToday(now)
@@ -605,7 +616,9 @@ func (s *Server) AssemblePublicLeaderboard(ctx context.Context) ([]EnrichedRepor
 			return nil, err
 		}
 		weekAct, weekDays := buildWeekActivity(dates, weekStart)
-		enriched = append(enriched, enrichReport(rep, today, weekAct, weekDays))
+		row := enrichReport(rep, today, weekAct, weekDays)
+		row.CurrentDailyStreak, row.LongestDailyStreak = buildDailyStreaks(dates, today)
+		enriched = append(enriched, row)
 	}
 
 	// Season sort is our canonical order (mirrors WA leaderboard ordering).


### PR DESCRIPTION
- `feat(web): add daily streak leaderboard tab`
- Introduce `StreakTab` type (`weekly` | `daily`) and display corresponding streak metrics in `StreakRow`
- Backend: Implement stable deduplication for reports by user ID, prioritizing highest-ranking entries
- Hash phone numbers for public display, ensuring stable and unique user IDs across leaderboards