### PR TITLE
feat(report): support canceling side quests

### DIFF
--- a/internal/app/usecase/cancel_report_usecase.go
+++ b/internal/app/usecase/cancel_report_usecase.go
@@ -20,14 +20,22 @@ func NewCancelReportUsecase(repo domain.ReportRepository) *CancelReportUsecase {
 }
 
 func (uc *CancelReportUsecase) Execute(ctx context.Context, userID, name string) (string, error) {
-	return uc.cancelToday(ctx, userID, name, false)
+	return uc.cancelToday(ctx, userID, name, domain.ActivityKindRegularReport, false)
 }
 
 func (uc *CancelReportUsecase) ExecuteAll(ctx context.Context, userID, name string) (string, error) {
-	return uc.cancelToday(ctx, userID, name, true)
+	return uc.cancelToday(ctx, userID, name, domain.ActivityKindRegularReport, true)
 }
 
-func (uc *CancelReportUsecase) cancelToday(ctx context.Context, userID, name string, all bool) (string, error) {
+func (uc *CancelReportUsecase) ExecuteSideQuest(ctx context.Context, userID, name string) (string, error) {
+	return uc.cancelToday(ctx, userID, name, domain.ActivityKindSideQuest, false)
+}
+
+func (uc *CancelReportUsecase) ExecuteAllSideQuest(ctx context.Context, userID, name string) (string, error) {
+	return uc.cancelToday(ctx, userID, name, domain.ActivityKindSideQuest, true)
+}
+
+func (uc *CancelReportUsecase) cancelToday(ctx context.Context, userID, name string, kind string, all bool) (string, error) {
 	report, err := uc.repo.GetReport(ctx, userID)
 	if err != nil {
 		return "", err
@@ -39,36 +47,38 @@ func (uc *CancelReportUsecase) cancelToday(ctx context.Context, userID, name str
 
 	now := time.Now()
 	today := domain.GetToday(now)
-	lastReportDate := domain.GetToday(report.LastReportDate)
 
-	if !lastReportDate.Equal(today) {
-		return fmt.Sprintf("Halo %s, kamu belum laporan hari ini. Tidak ada yang perlu dibatalkan.", report.Name), nil
-	}
-
-	dates, err := uc.repo.GetUserActivityDates(ctx, userID)
-	if err != nil {
-		return "", err
-	}
-
-	if len(dates) == 0 {
-		return fmt.Sprintf("Halo %s, tidak ada aktivitas yang tercatat.", report.Name), nil
-	}
-
-	dailyCount, err := uc.repo.GetDailyActivityCount(ctx, userID, today)
+	dailyCount, err := uc.repo.GetDailyActivityCountByKind(ctx, userID, today, kind)
 	if err != nil {
 		return "", err
 	}
 	if dailyCount == 0 {
+		return fmt.Sprintf("Halo %s, tidak menemukan %s untuk hari ini.", report.Name, cancelItemLabel(kind)), nil
+	}
+
+	if kind == domain.ActivityKindSideQuest {
+		return uc.cancelSideQuestToday(ctx, report, today, dailyCount, all)
+	}
+
+	dates, err := uc.repo.GetUserActivityDatesByKind(ctx, userID, kind)
+	if err != nil {
+		return "", err
+	}
+	if len(dates) == 0 {
+		return fmt.Sprintf("Halo %s, tidak ada aktivitas yang tercatat.", report.Name), nil
+	}
+
+	if !containsDate(dates, today) {
 		return fmt.Sprintf("Halo %s, tidak menemukan laporan untuk hari ini.", report.Name), nil
 	}
 
 	if !all && dailyCount > 1 {
-		remainingReports, err := uc.repo.DeleteLatestActivityLog(ctx, userID, today)
+		remainingReports, err := uc.repo.DeleteLatestActivityLogByKind(ctx, userID, today, kind)
 		if err != nil {
 			return "", err
 		}
 		if remainingReports == 0 {
-			return uc.cancelToday(ctx, userID, name, true)
+			return uc.cancelToday(ctx, userID, name, kind, true)
 		}
 
 		removeRepeatReportPoints(report)
@@ -89,7 +99,7 @@ func (uc *CancelReportUsecase) cancelToday(ctx context.Context, userID, name str
 		return fmt.Sprintf("Halo %s, tidak menemukan laporan untuk hari ini.", report.Name), nil
 	}
 
-	if err := uc.repo.DeleteActivityLog(ctx, userID, today); err != nil {
+	if err := uc.repo.DeleteActivityLogByKind(ctx, userID, today, kind); err != nil {
 		return "", err
 	}
 
@@ -111,6 +121,7 @@ func (uc *CancelReportUsecase) cancelToday(ctx context.Context, userID, name str
 	} else {
 		newReport = recalculateReportFromDates(userID, report.Name, remainingDates)
 	}
+	preserveNonReportFields(newReport, report)
 
 	if err := uc.repo.UpsertReport(ctx, newReport); err != nil {
 		return "", err
@@ -130,6 +141,73 @@ func (uc *CancelReportUsecase) cancelToday(ctx context.Context, userID, name str
 
 	msg += "\n_Kamu bisa lapor lagi hari ini dengan /lapor._"
 	return msg, nil
+}
+
+func (uc *CancelReportUsecase) cancelSideQuestToday(ctx context.Context, report *domain.Report, today time.Time, dailyCount int, all bool) (string, error) {
+	deletedCount := dailyCount
+	if !all && dailyCount > 1 {
+		remainingSideQuests, err := uc.repo.DeleteLatestActivityLogByKind(ctx, report.UserID, today, domain.ActivityKindSideQuest)
+		if err != nil {
+			return "", err
+		}
+		deletedCount = 1
+		decrementSideQuestCount(report, deletedCount)
+		if err := uc.repo.UpsertReport(ctx, report); err != nil {
+			return "", err
+		}
+
+		msg := fmt.Sprintf("✅ Side quest terakhir hari ini telah dibatalkan, %s.\n\n", report.Name)
+		msg += fmt.Sprintf("📌 Sisa side quest hari ini: %d/%d\n", remainingSideQuests, MaxDailySideQuests)
+		msg += fmt.Sprintf("🧩 Total side quest: %d\n", report.TotalSideQuests)
+		msg += "\nKalau ingin menghapus semua side quest hari ini, ketik /cancel-all sidequest."
+		return msg, nil
+	}
+
+	if err := uc.repo.DeleteActivityLogByKind(ctx, report.UserID, today, domain.ActivityKindSideQuest); err != nil {
+		return "", err
+	}
+	decrementSideQuestCount(report, deletedCount)
+	if err := uc.repo.UpsertReport(ctx, report); err != nil {
+		return "", err
+	}
+
+	msg := fmt.Sprintf("✅ Semua side quest hari ini telah dibatalkan, %s.\n\n", report.Name)
+	if !all {
+		msg = fmt.Sprintf("✅ Side quest hari ini telah dibatalkan, %s.\n\n", report.Name)
+	}
+	msg += fmt.Sprintf("🧩 Total side quest: %d\n", report.TotalSideQuests)
+	msg += "\n_Kamu bisa lapor side quest lagi hari ini dengan /lapor sidequest._"
+	return msg, nil
+}
+
+func decrementSideQuestCount(report *domain.Report, count int) {
+	report.TotalSideQuests -= count
+	if report.TotalSideQuests < 0 {
+		report.TotalSideQuests = 0
+	}
+	report.SeasonalSideQuests -= count
+	if report.SeasonalSideQuests < 0 {
+		report.SeasonalSideQuests = 0
+	}
+}
+
+func cancelItemLabel(kind string) string {
+	if kind == domain.ActivityKindSideQuest {
+		return "side quest"
+	}
+	return "laporan"
+}
+
+func preserveNonReportFields(next, current *domain.Report) {
+	next.JobClass = current.JobClass
+	next.StreakFreezes = current.StreakFreezes
+	next.GoalsCompleted = current.GoalsCompleted
+	next.TotalSideQuests = current.TotalSideQuests
+	next.SeasonalSideQuests = current.SeasonalSideQuests
+	next.Str = current.Str
+	next.Sta = current.Sta
+	next.Agi = current.Agi
+	next.Vit = current.Vit
 }
 
 func removeRepeatReportPoints(report *domain.Report) {
@@ -153,6 +231,15 @@ func removeDate(dates []time.Time, target time.Time) []time.Time {
 		}
 	}
 	return result
+}
+
+func containsDate(dates []time.Time, target time.Time) bool {
+	for _, d := range dates {
+		if d.Equal(target) {
+			return true
+		}
+	}
+	return false
 }
 
 func recalculateReportFromDates(userID, name string, dates []time.Time) *domain.Report {

--- a/internal/app/usecase/cancel_report_usecase_test.go
+++ b/internal/app/usecase/cancel_report_usecase_test.go
@@ -10,15 +10,18 @@ import (
 
 type cancelReportRepoStub struct {
 	domain.ReportRepository
-	report         *domain.Report
-	dates          []time.Time
-	deletedLog     bool
-	deletedLogDate time.Time
-	latestDeleted  bool
-	dailyCount     int
-	remainingCount int
-	deletedReport  bool
-	upsertedReport *domain.Report
+	report           *domain.Report
+	dates            []time.Time
+	datesByKind      map[string][]time.Time
+	deletedLog       bool
+	deletedLogDate   time.Time
+	deletedLogKind   string
+	latestDeleted    bool
+	dailyCount       int
+	dailyCountByKind map[string]int
+	remainingCount   int
+	deletedReport    bool
+	upsertedReport   *domain.Report
 }
 
 func (r *cancelReportRepoStub) GetReport(ctx context.Context, userID string) (*domain.Report, error) {
@@ -66,10 +69,29 @@ func (r *cancelReportRepoStub) GetUserActivityDates(ctx context.Context, userID 
 	return r.dates, nil
 }
 
+func (r *cancelReportRepoStub) GetUserActivityDatesByKind(ctx context.Context, userID string, kind string) ([]time.Time, error) {
+	if r.datesByKind != nil {
+		return r.datesByKind[kind], nil
+	}
+	return r.dates, nil
+}
+
 func (r *cancelReportRepoStub) DeleteActivityLog(ctx context.Context, userID string, activityDate time.Time) error {
 	r.deletedLog = true
 	r.deletedLogDate = activityDate
 	r.dailyCount = 0
+	return nil
+}
+
+func (r *cancelReportRepoStub) DeleteActivityLogByKind(ctx context.Context, userID string, activityDate time.Time, kind string) error {
+	r.deletedLog = true
+	r.deletedLogDate = activityDate
+	r.deletedLogKind = kind
+	if r.dailyCountByKind != nil {
+		r.dailyCountByKind[kind] = 0
+	} else {
+		r.dailyCount = 0
+	}
 	return nil
 }
 
@@ -80,6 +102,24 @@ func (r *cancelReportRepoStub) DeleteLatestActivityLog(ctx context.Context, user
 		r.dailyCount--
 	}
 	r.remainingCount = r.dailyCount
+	return r.remainingCount, nil
+}
+
+func (r *cancelReportRepoStub) DeleteLatestActivityLogByKind(ctx context.Context, userID string, activityDate time.Time, kind string) (int, error) {
+	r.latestDeleted = true
+	r.deletedLogDate = activityDate
+	r.deletedLogKind = kind
+	if r.dailyCountByKind != nil {
+		if r.dailyCountByKind[kind] > 0 {
+			r.dailyCountByKind[kind]--
+		}
+		r.remainingCount = r.dailyCountByKind[kind]
+	} else {
+		if r.dailyCount > 0 {
+			r.dailyCount--
+		}
+		r.remainingCount = r.dailyCount
+	}
 	return r.remainingCount, nil
 }
 
@@ -101,6 +141,13 @@ func (r *cancelReportRepoStub) GetStravaAccountByUserID(ctx context.Context, use
 }
 
 func (r *cancelReportRepoStub) GetDailyActivityCount(ctx context.Context, userID string, date time.Time) (int, error) {
+	return r.dailyCount, nil
+}
+
+func (r *cancelReportRepoStub) GetDailyActivityCountByKind(ctx context.Context, userID string, date time.Time, kind string) (int, error) {
+	if r.dailyCountByKind != nil {
+		return r.dailyCountByKind[kind], nil
+	}
 	return r.dailyCount, nil
 }
 
@@ -162,7 +209,7 @@ func TestCancelReport_NotToday(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if msg != "Halo Budi, kamu belum laporan hari ini. Tidak ada yang perlu dibatalkan." {
+	if msg != "Halo Budi, tidak menemukan laporan untuk hari ini." {
 		t.Fatalf("unexpected message: %s", msg)
 	}
 	if repo.deletedLog {
@@ -177,7 +224,8 @@ func TestCancelReport_NoActivityDates(t *testing.T) {
 			Name:           "Budi",
 			LastReportDate: time.Now(),
 		},
-		dates: []time.Time{},
+		dates:      []time.Time{},
+		dailyCount: 1,
 	}
 	uc := NewCancelReportUsecase(repo)
 
@@ -201,7 +249,8 @@ func TestCancelReport_TodayNotInDates(t *testing.T) {
 			Name:           "Budi",
 			LastReportDate: time.Now(),
 		},
-		dates: []time.Time{yesterday},
+		dates:      []time.Time{yesterday},
+		dailyCount: 1,
 	}
 	uc := NewCancelReportUsecase(repo)
 
@@ -316,5 +365,125 @@ func TestCancelReport_MultipleDays_Recalculates(t *testing.T) {
 
 	if msg == "" {
 		t.Fatal("message should not be empty")
+	}
+}
+
+func TestCancelReport_DeletesOnlyRegularReportKind(t *testing.T) {
+	today := domain.GetToday(time.Now())
+	repo := &cancelReportRepoStub{
+		report: &domain.Report{
+			UserID:             "user1",
+			Name:               "Budi",
+			JobClass:           "fighter",
+			LastReportDate:     time.Now(),
+			ActivityCount:      1,
+			TotalPoints:        10,
+			TotalSideQuests:    2,
+			SeasonalSideQuests: 2,
+			Str:                7,
+		},
+		datesByKind: map[string][]time.Time{
+			domain.ActivityKindRegularReport: {today},
+			domain.ActivityKindSideQuest:     {today},
+		},
+		dailyCountByKind: map[string]int{
+			domain.ActivityKindRegularReport: 1,
+			domain.ActivityKindSideQuest:     2,
+		},
+	}
+	uc := NewCancelReportUsecase(repo)
+
+	_, err := uc.Execute(context.Background(), "user1", "Budi")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.deletedLogKind != domain.ActivityKindRegularReport {
+		t.Fatalf("expected regular report delete, got %q", repo.deletedLogKind)
+	}
+	if repo.dailyCountByKind[domain.ActivityKindSideQuest] != 2 {
+		t.Fatalf("sidequest count should not change, got %d", repo.dailyCountByKind[domain.ActivityKindSideQuest])
+	}
+	if repo.upsertedReport.TotalSideQuests != 2 {
+		t.Fatalf("sidequest total should be preserved, got %d", repo.upsertedReport.TotalSideQuests)
+	}
+	if repo.upsertedReport.JobClass != "fighter" || repo.upsertedReport.Str != 7 {
+		t.Fatalf("non-report fields should be preserved, got job=%q str=%d", repo.upsertedReport.JobClass, repo.upsertedReport.Str)
+	}
+}
+
+func TestCancelSideQuest_DeletesOnlyLatestSideQuestKind(t *testing.T) {
+	today := domain.GetToday(time.Now())
+	repo := &cancelReportRepoStub{
+		report: &domain.Report{
+			UserID:             "user1",
+			Name:               "Budi",
+			LastReportDate:     time.Now(),
+			ActivityCount:      3,
+			TotalSideQuests:    2,
+			SeasonalSideQuests: 2,
+		},
+		dailyCountByKind: map[string]int{
+			domain.ActivityKindRegularReport: 1,
+			domain.ActivityKindSideQuest:     2,
+		},
+	}
+	uc := NewCancelReportUsecase(repo)
+
+	msg, err := uc.ExecuteSideQuest(context.Background(), "user1", "Budi")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !repo.latestDeleted {
+		t.Fatal("DeleteLatestActivityLogByKind should be called")
+	}
+	if !repo.deletedLogDate.Equal(today) {
+		t.Fatalf("expected delete date %v, got %v", today, repo.deletedLogDate)
+	}
+	if repo.deletedLogKind != domain.ActivityKindSideQuest {
+		t.Fatalf("expected sidequest delete, got %q", repo.deletedLogKind)
+	}
+	if repo.dailyCountByKind[domain.ActivityKindRegularReport] != 1 {
+		t.Fatalf("regular report count should not change, got %d", repo.dailyCountByKind[domain.ActivityKindRegularReport])
+	}
+	if repo.upsertedReport.TotalSideQuests != 1 {
+		t.Fatalf("expected TotalSideQuests=1, got %d", repo.upsertedReport.TotalSideQuests)
+	}
+	if repo.upsertedReport.ActivityCount != 3 {
+		t.Fatalf("regular ActivityCount should not change, got %d", repo.upsertedReport.ActivityCount)
+	}
+	if msg == "" {
+		t.Fatal("message should not be empty")
+	}
+}
+
+func TestCancelAllSideQuest_DeletesOnlySideQuestKind(t *testing.T) {
+	repo := &cancelReportRepoStub{
+		report: &domain.Report{
+			UserID:             "user1",
+			Name:               "Budi",
+			LastReportDate:     time.Now(),
+			ActivityCount:      3,
+			TotalSideQuests:    2,
+			SeasonalSideQuests: 2,
+		},
+		dailyCountByKind: map[string]int{
+			domain.ActivityKindRegularReport: 1,
+			domain.ActivityKindSideQuest:     2,
+		},
+	}
+	uc := NewCancelReportUsecase(repo)
+
+	_, err := uc.ExecuteAllSideQuest(context.Background(), "user1", "Budi")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.deletedLogKind != domain.ActivityKindSideQuest {
+		t.Fatalf("expected sidequest delete, got %q", repo.deletedLogKind)
+	}
+	if repo.dailyCountByKind[domain.ActivityKindRegularReport] != 1 {
+		t.Fatalf("regular report count should not change, got %d", repo.dailyCountByKind[domain.ActivityKindRegularReport])
+	}
+	if repo.upsertedReport.TotalSideQuests != 0 {
+		t.Fatalf("expected TotalSideQuests=0, got %d", repo.upsertedReport.TotalSideQuests)
 	}
 }

--- a/internal/app/usecase/get_help_usecase.go
+++ b/internal/app/usecase/get_help_usecase.go
@@ -20,7 +20,7 @@ var helpSections = []struct {
 	{
 		emoji:   "❌",
 		title:   "Membatalkan Laporan",
-		content: "*/cancel* atau *#cancel* — Batalkan laporan terakhir hari ini jika kamu salah input. Kalau hari ini ada 2-3 laporan, hanya laporan paling akhir yang dihapus.\n*/cancel-all* atau *#cancel-all* — Hapus semua laporan hari ini dan hitung ulang progresmu.\nHanya bisa digunakan pada hari yang sama dengan laporan.",
+		content: "*/cancel* atau *#cancel* — Batalkan laporan utama terakhir hari ini jika kamu salah input. Kalau hari ini ada 2-3 laporan utama, hanya laporan paling akhir yang dihapus.\n*/cancel-all* atau *#cancel-all* — Hapus semua laporan utama hari ini dan hitung ulang progresmu.\n*/cancel sidequest* atau *#cancel sidequest* — Batalkan side quest terakhir hari ini.\n*/cancel-all sidequest* atau *#cancel-all sidequest* — Hapus semua side quest hari ini.\nHanya bisa digunakan pada hari yang sama dengan laporan.",
 	},
 	{
 		emoji:   "🏆",
@@ -54,6 +54,8 @@ func (uc *GetHelpUsecase) Execute() string {
 📌 /lapor-kemarin or #lapor-kemarin — laporan khusus hari kemarin (max 3x/hari)
 ❌ /cancel or #cancel — batalkan laporan terakhir hari ini
 🧹 /cancel-all or #cancel-all — batalkan semua laporan hari ini
+❌ /cancel sidequest or #cancel sidequest — batalkan side quest terakhir hari ini
+🧹 /cancel-all sidequest or #cancel-all sidequest — batalkan semua side quest hari ini
 📚 /tutorial or #tutorial — panduan lengkap penggunaan bot
 ❓ /help or #help — list command ini
 

--- a/internal/app/usecase/handle_message_usecase.go
+++ b/internal/app/usecase/handle_message_usecase.go
@@ -126,13 +126,8 @@ func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, messa
 		return MessageResponse{Text: text}, err
 	}
 
-	if hasCommand(msg, "/cancel-all") {
-		text, err := uc.cancelUC.ExecuteAll(ctx, userID, name)
-		return MessageResponse{Text: text}, err
-	}
-
-	if hasCommand(msg, "/cancel") {
-		text, err := uc.cancelUC.Execute(ctx, userID, name)
+	if cancelCommand, ok := parseCancelCommand(msg); ok {
+		text, err := uc.executeCancelCommand(ctx, userID, name, cancelCommand)
 		return MessageResponse{Text: text}, err
 	}
 
@@ -215,6 +210,55 @@ func (uc *HandleMessageUsecase) Execute(ctx context.Context, userID, name, messa
 
 	// Unknown / command → silent (bot does not react to unrecognised commands)
 	return MessageResponse{}, nil
+}
+
+type cancelCommand struct {
+	kind string
+	all  bool
+}
+
+func (uc *HandleMessageUsecase) executeCancelCommand(ctx context.Context, userID, name string, command cancelCommand) (string, error) {
+	if command.kind == domain.ActivityKindSideQuest {
+		if command.all {
+			return uc.cancelUC.ExecuteAllSideQuest(ctx, userID, name)
+		}
+		return uc.cancelUC.ExecuteSideQuest(ctx, userID, name)
+	}
+	if command.all {
+		return uc.cancelUC.ExecuteAll(ctx, userID, name)
+	}
+	return uc.cancelUC.Execute(ctx, userID, name)
+}
+
+func parseCancelCommand(message string) (cancelCommand, bool) {
+	normalized := strings.ReplaceAll(message, "-", " ")
+	fields := strings.Fields(normalized)
+	if len(fields) == 0 || fields[0] != "/cancel" {
+		return cancelCommand{}, false
+	}
+	args := fields[1:]
+
+	isSideQuest := func(tokens []string) bool {
+		if len(tokens) == 1 {
+			return tokens[0] == "sidequest"
+		}
+		return len(tokens) == 2 && tokens[0] == "side" && tokens[1] == "quest"
+	}
+
+	switch {
+	case len(args) == 0:
+		return cancelCommand{kind: domain.ActivityKindRegularReport}, true
+	case len(args) == 1 && args[0] == "all":
+		return cancelCommand{kind: domain.ActivityKindRegularReport, all: true}, true
+	case isSideQuest(args):
+		return cancelCommand{kind: domain.ActivityKindSideQuest}, true
+	case len(args) >= 2 && args[0] == "all" && isSideQuest(args[1:]):
+		return cancelCommand{kind: domain.ActivityKindSideQuest, all: true}, true
+	case len(args) >= 2 && args[len(args)-1] == "all" && isSideQuest(args[:len(args)-1]):
+		return cancelCommand{kind: domain.ActivityKindSideQuest, all: true}, true
+	default:
+		return cancelCommand{}, false
+	}
 }
 
 func extractSideQuestReport(message string) (string, bool) {

--- a/internal/app/usecase/handle_message_usecase_test.go
+++ b/internal/app/usecase/handle_message_usecase_test.go
@@ -48,9 +48,11 @@ func (m *mockLeaderboardUsecase) Execute(ctx context.Context) (string, error) {
 // mockReportRepo implements domain.ReportRepository for testing
 type mockReportRepo struct {
 	domain.ReportRepository
-	reports        map[string]*domain.Report
-	activityCounts []domain.ActivityLeaderboardEntry
-	goals          map[string]*domain.WeeklyGoal
+	reports          map[string]*domain.Report
+	activityCounts   []domain.ActivityLeaderboardEntry
+	dailyCountByKind map[string]int
+	deletedLogKind   string
+	goals            map[string]*domain.WeeklyGoal
 }
 
 func (m *mockReportRepo) GetReport(ctx context.Context, userID string) (*domain.Report, error) {
@@ -116,11 +118,34 @@ func (m *mockReportRepo) DeleteActivityLog(ctx context.Context, userID string, a
 	return nil
 }
 
+func (m *mockReportRepo) DeleteActivityLogByKind(ctx context.Context, userID string, activityDate time.Time, kind string) error {
+	m.deletedLogKind = kind
+	if m.dailyCountByKind != nil {
+		m.dailyCountByKind[kind] = 0
+	}
+	return nil
+}
+
 func (m *mockReportRepo) DeleteLatestActivityLog(ctx context.Context, userID string, activityDate time.Time) (int, error) {
 	return 0, nil
 }
 
+func (m *mockReportRepo) DeleteLatestActivityLogByKind(ctx context.Context, userID string, activityDate time.Time, kind string) (int, error) {
+	m.deletedLogKind = kind
+	if m.dailyCountByKind == nil {
+		return 0, nil
+	}
+	if m.dailyCountByKind[kind] > 0 {
+		m.dailyCountByKind[kind]--
+	}
+	return m.dailyCountByKind[kind], nil
+}
+
 func (m *mockReportRepo) GetUserActivityDates(ctx context.Context, userID string) ([]time.Time, error) {
+	return nil, nil
+}
+
+func (m *mockReportRepo) GetUserActivityDatesByKind(ctx context.Context, userID string, kind string) ([]time.Time, error) {
 	return nil, nil
 }
 
@@ -131,6 +156,13 @@ func (m *mockReportRepo) DeleteReport(ctx context.Context, userID string) error 
 
 func (m *mockReportRepo) GetDailyActivityCount(ctx context.Context, userID string, date time.Time) (int, error) {
 	return 0, nil
+}
+
+func (m *mockReportRepo) GetDailyActivityCountByKind(ctx context.Context, userID string, date time.Time, kind string) (int, error) {
+	if m.dailyCountByKind == nil {
+		return 0, nil
+	}
+	return m.dailyCountByKind[kind], nil
 }
 
 func (m *mockReportRepo) SaveDailyQuest(ctx context.Context, userID, questDate, tasksJSON string) error {
@@ -806,5 +838,58 @@ func TestHandleMessage_MySideQuestCommand(t *testing.T) {
 
 	if msg.Text != "" {
 		t.Errorf("Disabled /mysidequest should be silently ignored, got '%s'", msg.Text)
+	}
+}
+
+func TestHandleMessage_CancelSideQuestCommandsRouteToSideQuestCancel(t *testing.T) {
+	tests := []string{
+		"/cancel sidequest",
+		"/cancel-sidequest",
+		"/cancel all sidequest",
+		"/cancel-all sidequest",
+		"/cancel sidequest all",
+		"#cancel sidequest",
+		"#cancel-all sidequest",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			repo := &mockReportRepo{
+				reports: make(map[string]*domain.Report),
+				dailyCountByKind: map[string]int{
+					domain.ActivityKindRegularReport: 1,
+					domain.ActivityKindSideQuest:     2,
+				},
+			}
+			repo.reports["user1"] = &domain.Report{
+				UserID:             "user1",
+				Name:               "User",
+				ActivityCount:      1,
+				TotalSideQuests:    2,
+				SeasonalSideQuests: 2,
+				LastReportDate:     time.Now(),
+			}
+			reportUC := usecase.NewReportActivityUsecase(repo)
+			leaderboardUC := usecase.NewGetLeaderboardUsecase(repo)
+			myStatsUC := usecase.NewGetMyStatsUsecase(repo)
+			achievementsUC := usecase.NewGetAchievementsUsecase(repo)
+			comebackUC := usecase.NewComebackChallengeUsecase(repo)
+			updateNameUC := usecase.NewUpdateNameUsecase(repo)
+			handleUC := usecase.NewHandleMessageUsecase(reportUC, leaderboardUC, myStatsUC, achievementsUC, comebackUC, usecase.NewCancelReportUsecase(repo), updateNameUC, nil, usecase.NewBroadcastUpdateUsecase(), usecase.NewGetMotivationUsecase(), usecase.NewGetHelpUsecase())
+
+			msg, err := handleUC.Execute(context.Background(), "user1", "User", input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if msg.Text == "" {
+				t.Fatal("expected cancel response")
+			}
+			if repo.deletedLogKind != domain.ActivityKindSideQuest {
+				t.Fatalf("expected sidequest cancel, got %q", repo.deletedLogKind)
+			}
+			if repo.dailyCountByKind[domain.ActivityKindRegularReport] != 1 {
+				t.Fatalf("regular report count should not change, got %d", repo.dailyCountByKind[domain.ActivityKindRegularReport])
+			}
+		})
 	}
 }

--- a/internal/domain/report.go
+++ b/internal/domain/report.go
@@ -188,10 +188,14 @@ type ReportRepository interface {
 
 	DeleteActivityLog(ctx context.Context, userID string, activityDate time.Time) error
 	DeleteLatestActivityLog(ctx context.Context, userID string, activityDate time.Time) (int, error)
+	DeleteActivityLogByKind(ctx context.Context, userID string, activityDate time.Time, kind string) error
+	DeleteLatestActivityLogByKind(ctx context.Context, userID string, activityDate time.Time, kind string) (int, error)
 	GetUserActivityDates(ctx context.Context, userID string) ([]time.Time, error)
+	GetUserActivityDatesByKind(ctx context.Context, userID string, kind string) ([]time.Time, error)
 	DeleteReport(ctx context.Context, userID string) error
 
 	GetDailyActivityCount(ctx context.Context, userID string, date time.Time) (int, error)
+	GetDailyActivityCountByKind(ctx context.Context, userID string, date time.Time, kind string) (int, error)
 
 	SetGoal(ctx context.Context, goal *WeeklyGoal) error
 	GetActiveGoal(ctx context.Context, userID string, now time.Time) (*WeeklyGoal, error)

--- a/internal/infra/sqlite/report_repository.go
+++ b/internal/infra/sqlite/report_repository.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	"github.com/fardannozami/whatsapp-gateway/internal/domain"
@@ -911,6 +912,38 @@ func (r *ReportRepository) GetUserActivityDates(ctx context.Context, userID stri
 	return dates, rows.Err()
 }
 
+func (r *ReportRepository) GetUserActivityDatesByKind(ctx context.Context, userID string, kind string) ([]time.Time, error) {
+	condition := "COALESCE(regular_report_count, 0) > 0"
+	if kind == domain.ActivityKindSideQuest {
+		condition = "COALESCE(sidequest_count, 0) > 0"
+	}
+
+	query := fmt.Sprintf(`
+		SELECT activity_date FROM activity_logs
+		WHERE user_id = ? AND %s
+		ORDER BY activity_date ASC
+	`, condition)
+	rows, err := r.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var dates []time.Time
+	for rows.Next() {
+		var dateStr string
+		if err := rows.Scan(&dateStr); err != nil {
+			return nil, err
+		}
+		date, err := time.Parse(time.DateOnly, dateStr)
+		if err != nil {
+			return nil, err
+		}
+		dates = append(dates, date)
+	}
+	return dates, rows.Err()
+}
+
 func (r *ReportRepository) DeleteActivityLog(ctx context.Context, userID string, activityDate time.Time) error {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -923,6 +956,42 @@ func (r *ReportRepository) DeleteActivityLog(ctx context.Context, userID string,
 	if err := reconcileGoalAfterActivityDelete(ctx, tx, userID, activityDate); err != nil {
 		_ = tx.Rollback()
 		return err
+	}
+	return tx.Commit()
+}
+
+func (r *ReportRepository) DeleteActivityLogByKind(ctx context.Context, userID string, activityDate time.Time, kind string) error {
+	date := activityDate.Format(time.DateOnly)
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	regularCount, sideQuestCount, err := getActivityKindCounts(ctx, tx, userID, date)
+	if err == sql.ErrNoRows {
+		_ = tx.Rollback()
+		return nil
+	}
+	if err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+
+	if kind == domain.ActivityKindSideQuest {
+		sideQuestCount = 0
+	} else {
+		regularCount = 0
+	}
+
+	if err := saveActivityKindCounts(ctx, tx, userID, date, regularCount, sideQuestCount); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if kind != domain.ActivityKindSideQuest {
+		if err := reconcileGoalAfterActivityDelete(ctx, tx, userID, activityDate); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
 	}
 	return tx.Commit()
 }
@@ -963,6 +1032,90 @@ func (r *ReportRepository) DeleteLatestActivityLog(ctx context.Context, userID s
 	}
 
 	return remaining, tx.Commit()
+}
+
+func (r *ReportRepository) DeleteLatestActivityLogByKind(ctx context.Context, userID string, activityDate time.Time, kind string) (int, error) {
+	date := activityDate.Format(time.DateOnly)
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	regularCount, sideQuestCount, err := getActivityKindCounts(ctx, tx, userID, date)
+	if err == sql.ErrNoRows {
+		_ = tx.Rollback()
+		return 0, nil
+	}
+	if err != nil {
+		_ = tx.Rollback()
+		return 0, err
+	}
+
+	remaining := 0
+	if kind == domain.ActivityKindSideQuest {
+		if sideQuestCount == 0 {
+			_ = tx.Rollback()
+			return 0, nil
+		}
+		sideQuestCount--
+		remaining = sideQuestCount
+	} else {
+		if regularCount == 0 {
+			_ = tx.Rollback()
+			return 0, nil
+		}
+		regularCount--
+		remaining = regularCount
+	}
+
+	if err := saveActivityKindCounts(ctx, tx, userID, date, regularCount, sideQuestCount); err != nil {
+		_ = tx.Rollback()
+		return 0, err
+	}
+	if kind != domain.ActivityKindSideQuest && remaining == 0 {
+		if err := reconcileGoalAfterActivityDelete(ctx, tx, userID, activityDate); err != nil {
+			_ = tx.Rollback()
+			return 0, err
+		}
+	}
+
+	return remaining, tx.Commit()
+}
+
+func getActivityKindCounts(ctx context.Context, tx *sql.Tx, userID, date string) (regularCount, sideQuestCount int, err error) {
+	var totalCount int
+	err = tx.QueryRowContext(ctx, `
+		SELECT COALESCE(report_count, 1), COALESCE(regular_report_count, 0), COALESCE(sidequest_count, 0)
+		FROM activity_logs
+		WHERE user_id = ? AND activity_date = ?
+	`, userID, date).Scan(&totalCount, &regularCount, &sideQuestCount)
+	if err != nil {
+		return 0, 0, err
+	}
+	if regularCount == 0 && sideQuestCount == 0 && totalCount > 0 {
+		regularCount = totalCount
+	}
+	return regularCount, sideQuestCount, nil
+}
+
+func saveActivityKindCounts(ctx context.Context, tx *sql.Tx, userID, date string, regularCount, sideQuestCount int) error {
+	if regularCount < 0 {
+		regularCount = 0
+	}
+	if sideQuestCount < 0 {
+		sideQuestCount = 0
+	}
+	totalCount := regularCount + sideQuestCount
+	if totalCount == 0 {
+		_, err := tx.ExecContext(ctx, `DELETE FROM activity_logs WHERE user_id = ? AND activity_date = ?`, userID, date)
+		return err
+	}
+	_, err := tx.ExecContext(ctx, `
+		UPDATE activity_logs
+		SET report_count = ?, regular_report_count = ?, sidequest_count = ?
+		WHERE user_id = ? AND activity_date = ?
+	`, totalCount, regularCount, sideQuestCount, userID, date)
+	return err
 }
 
 func reconcileGoalAfterActivityDelete(ctx context.Context, tx *sql.Tx, userID string, activityDate time.Time) error {

--- a/internal/infra/sqlite/report_repository_test.go
+++ b/internal/infra/sqlite/report_repository_test.go
@@ -803,3 +803,90 @@ func TestReportRepository_DeleteActivityLog_ReopensCompletedGoalWhenBelowTarget(
 		t.Fatalf("expected GoalsCompleted=0 after cancel, got %d", updated.GoalsCompleted)
 	}
 }
+
+func TestReportRepository_DeleteActivityLogByKind_KeepsOtherKind(t *testing.T) {
+	db, repo, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	today := domain.GetToday(time.Now())
+	report := &domain.Report{UserID: "user1", Name: "Budi", LastReportDate: today, StreakFreezes: 1}
+	if err := repo.UpsertReport(ctx, report); err != nil {
+		t.Fatalf("upsert report: %v", err)
+	}
+	if err := repo.UpsertReportWithActivityKind(ctx, report, today, domain.ActivityKindRegularReport); err != nil {
+		t.Fatalf("log regular: %v", err)
+	}
+	if err := repo.UpsertReportWithActivityKind(ctx, report, today, domain.ActivityKindSideQuest); err != nil {
+		t.Fatalf("log sidequest: %v", err)
+	}
+
+	if err := repo.DeleteActivityLogByKind(ctx, "user1", today, domain.ActivityKindRegularReport); err != nil {
+		t.Fatalf("delete regular: %v", err)
+	}
+
+	var totalCount, regularCount, sideQuestCount int
+	err := db.QueryRowContext(ctx, `
+		SELECT report_count, regular_report_count, sidequest_count
+		FROM activity_logs
+		WHERE user_id = ? AND activity_date = ?
+	`, "user1", today.Format(time.DateOnly)).Scan(&totalCount, &regularCount, &sideQuestCount)
+	if err != nil {
+		t.Fatalf("query activity log: %v", err)
+	}
+	if totalCount != 1 || regularCount != 0 || sideQuestCount != 1 {
+		t.Fatalf("expected only sidequest remaining, got total=%d regular=%d sidequest=%d", totalCount, regularCount, sideQuestCount)
+	}
+
+	if err := repo.DeleteActivityLogByKind(ctx, "user1", today, domain.ActivityKindSideQuest); err != nil {
+		t.Fatalf("delete sidequest: %v", err)
+	}
+	err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM activity_logs WHERE user_id = ? AND activity_date = ?`, "user1", today.Format(time.DateOnly)).Scan(&totalCount)
+	if err != nil {
+		t.Fatalf("count activity log: %v", err)
+	}
+	if totalCount != 0 {
+		t.Fatalf("expected activity log deleted after both kinds removed, got %d rows", totalCount)
+	}
+}
+
+func TestReportRepository_DeleteLatestActivityLogByKind_DecrementsOnlyRequestedKind(t *testing.T) {
+	db, repo, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	today := domain.GetToday(time.Now())
+	report := &domain.Report{UserID: "user1", Name: "Budi", LastReportDate: today, StreakFreezes: 1}
+	if err := repo.UpsertReport(ctx, report); err != nil {
+		t.Fatalf("upsert report: %v", err)
+	}
+	if err := repo.UpsertReportWithActivityKind(ctx, report, today, domain.ActivityKindRegularReport); err != nil {
+		t.Fatalf("log regular: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		if err := repo.UpsertReportWithActivityKind(ctx, report, today, domain.ActivityKindSideQuest); err != nil {
+			t.Fatalf("log sidequest %d: %v", i+1, err)
+		}
+	}
+
+	remaining, err := repo.DeleteLatestActivityLogByKind(ctx, "user1", today, domain.ActivityKindSideQuest)
+	if err != nil {
+		t.Fatalf("delete latest sidequest: %v", err)
+	}
+	if remaining != 1 {
+		t.Fatalf("expected 1 sidequest remaining, got %d", remaining)
+	}
+
+	var totalCount, regularCount, sideQuestCount int
+	err = db.QueryRowContext(ctx, `
+		SELECT report_count, regular_report_count, sidequest_count
+		FROM activity_logs
+		WHERE user_id = ? AND activity_date = ?
+	`, "user1", today.Format(time.DateOnly)).Scan(&totalCount, &regularCount, &sideQuestCount)
+	if err != nil {
+		t.Fatalf("query activity log: %v", err)
+	}
+	if totalCount != 2 || regularCount != 1 || sideQuestCount != 1 {
+		t.Fatalf("expected one regular and one sidequest remaining, got total=%d regular=%d sidequest=%d", totalCount, regularCount, sideQuestCount)
+	}
+}


### PR DESCRIPTION
- Add `/cancel sidequest` and `/cancel-all sidequest` commands to cancel side quests specifically.
- Update `CancelReportUsecase` and `ReportRepository` to handle activity kinds when canceling.
- Modify `handle_message_usecase` to parse `cancel` commands with kind arguments.
- Ensure regular reports and side quests are distinct when canceling.