### PR TITLE
feat(dailyquest): implement job-specific quest tasks

### DIFF
--- a/internal/app/usecase/get_help_usecase.go
+++ b/internal/app/usecase/get_help_usecase.go
@@ -35,7 +35,7 @@ var helpSections = []struct {
 	{
 		emoji:   "⚔️",
 		title:   "Status RPG (Attributes)",
-		content: "Bot akan membaca laporan `/lapor` atau `#lapor` dan menaikkan status tertentu berdasarkan kata kunci aktivitas.\n\n💪 *STR (Strength)*: beban, weight, strength, gym, angkat, powerlifting, push, pull, leg\n🏃‍♂️ *STA (Stamina)*: lari, run, running, sepeda, cycle, hiit, kardio, cardio, renang, swim\n⚡ *AGI (Agility)*: bola, futsal, basket, bulutangkis, tenis, sprint, muaythai, boxing, calisthenics, padel, padle\n🧘‍♂️ *VIT (Vitality)*: yoga, pilates, stretching, recovery, jalan, walk, meditasi\n\nJika tidak ada kata kunci spesifik, laporan akan otomatis meningkatkan *VIT*.",
+		content: "Bot membaca laporan `/lapor` atau `#lapor` dengan daftar kata kunci yang sama untuk semua user. Setiap attribute yang cocok naik +1 per laporan valid.\n\n💪 *STR (Strength)*: gym, beban, push-up, pull-up, squat, plank, lunges, glute bridge, calf raises\n🏃‍♂️ *STA (Stamina)*: lari, jogging, sepeda, cardio, renang, hiking, tangga, jumping jacks, skipping\n⚡ *AGI (Agility)*: futsal/sepak bola, basket, badminton, tenis/padel, sprint, HIIT/tabata, boxing/muay thai, high knees, lateral shuffle\n🧘‍♂️ *VIT (Vitality)*: yoga, pilates, stretching, mobility, recovery, jalan santai, meditasi, breathing, balance\n\nJika tidak ada kata kunci spesifik, laporan otomatis masuk *VIT*.",
 	},
 }
 
@@ -64,12 +64,12 @@ func (uc *GetHelpUsecase) Execute() string {
 
 func (uc *GetHelpUsecase) ExecuteAttributes() string {
 	msg := "⚔️ *Status RPG (Attributes)* ⚔️\n\n"
-	msg += "Setiap kali kamu `/lapor`, bot akan membaca kata kunci dari laporanmu dan memberikan atribut ke status tertentu. Berikut daftar kata kuncinya:\n\n"
-	msg += "💪 *STR (Strength)*: beban, weight, strength, gym, angkat, powerlifting, push, pull, leg\n"
-	msg += "🏃‍♂️ *STA (Stamina)*: lari, run, running, sepeda, cycle, hiit, kardio, cardio, renang, swim\n"
-	msg += "⚡ *AGI (Agility)*: bola, futsal, basket, bulutangkis, tenis, sprint, muaythai, boxing, calisthenics, padel, padle\n"
-	msg += "🧘‍♂️ *VIT (Vitality)*: yoga, pilates, stretching, recovery, jalan, walk, meditasi\n\n"
-	msg += "💡 *Tips:* Jika tidak ada kata kunci di atas yang cocok dalam teks laporanmu, secara default atributmu akan otomatis masuk ke *VIT*."
+	msg += "Setiap `/lapor` valid memberi +1 ke setiap attribute yang cocok. Aturannya sama untuk semua user; XP, level, streak, dan bonus tidak mengubah nilai attribute.\n\n"
+	msg += "💪 *STR (Strength)*: gym, beban, push-up, pull-up, squat, plank, lunges, glute bridge, calf raises\n"
+	msg += "🏃‍♂️ *STA (Stamina)*: lari/jogging, sepeda, cardio, renang, hiking, tangga, jumping jacks, skipping\n"
+	msg += "⚡ *AGI (Agility)*: futsal/sepak bola, basket, badminton, tenis/padel, sprint, HIIT/tabata, boxing/muay thai, high knees, lateral shuffle\n"
+	msg += "🧘‍♂️ *VIT (Vitality)*: yoga, pilates, stretching, mobility, recovery, jalan santai, meditasi, breathing, balance\n\n"
+	msg += "💡 *Tips:* Jika tidak ada kata kunci di atas yang cocok, laporan otomatis masuk *VIT*."
 	return msg
 }
 

--- a/internal/app/usecase/handle_message_usecase_test.go
+++ b/internal/app/usecase/handle_message_usecase_test.go
@@ -230,6 +230,14 @@ func TestHandleMessage_LaporCommand(t *testing.T) {
 
 	ctx := context.Background()
 
+	// Pre-set a report with a job so attribute resolution falls back to job primary.
+	repo.reports["user123"] = &domain.Report{
+		UserID:         "user123",
+		Name:           "TestUser",
+		JobClass:       "fighter",
+		LastReportDate: time.Now().AddDate(0, 0, -7),
+	}
+
 	// Test /lapor command
 	msg, err := handleUC.Execute(ctx, "user123", "TestUser", "/lapor")
 	if err != nil {
@@ -265,8 +273,10 @@ func TestHandleMessage_LaporCaseInsensitive(t *testing.T) {
 
 	testCases := []string{"/LAPOR", "/Lapor", "/LaPor", "/lapor"}
 	for _, cmd := range testCases {
-		// Reset repo for each test
-		repo.reports = make(map[string]*domain.Report)
+		// Reset repo for each test, pre-set with job for attribute resolution
+		repo.reports = map[string]*domain.Report{
+			"user1": {UserID: "user1", Name: "User", JobClass: "fighter", LastReportDate: time.Now().AddDate(0, 0, -7)},
+		}
 
 		msg, err := handleUC.Execute(ctx, "user1", "User", cmd)
 		if err != nil {
@@ -443,6 +453,12 @@ func TestHandleMessage_HashCommand_WorksLikeSlash(t *testing.T) {
 		// Reset for each test case
 		repo.reports = make(map[string]*domain.Report)
 
+		// Pre-set a report with job for /lapor with no activity text, so
+		// attribute resolution falls back to the job primary attribute.
+		if tt.input == "#lapor" || tt.input == "#LAPOR" {
+			repo.reports["user1"] = &domain.Report{UserID: "user1", Name: "User", JobClass: "fighter", LastReportDate: time.Now().AddDate(0, 0, -7)}
+		}
+
 		result, err := handleUC.Execute(ctx, "user1", "User", tt.input)
 		if err != nil {
 			t.Fatalf("Unexpected error for '%s': %v", tt.input, err)
@@ -532,7 +548,9 @@ func TestHandleMessage_WhitespaceHandling(t *testing.T) {
 	}
 
 	for i, cmd := range testCases {
-		repo.reports = make(map[string]*domain.Report) // Reset
+		repo.reports = map[string]*domain.Report{
+			"user1": {UserID: "user1", Name: "User", JobClass: "fighter"},
+		}
 		msg, err := handleUC.Execute(ctx, "user1", "User", cmd)
 		if err != nil {
 			t.Fatalf("Test %d: Unexpected error for '%q': %v", i, cmd, err)
@@ -705,6 +723,14 @@ func TestHandleMessage_LaporDoesNotUpdateName(t *testing.T) {
 	handleUC := usecase.NewHandleMessageUsecase(reportUC, leaderboardUC, myStatsUC, achievementsUC, comebackUC, usecase.NewCancelReportUsecase(repo), updateNameUC, nil, usecase.NewBroadcastUpdateUsecase(), usecase.NewGetMotivationUsecase(), usecase.NewGetHelpUsecase())
 
 	ctx := context.Background()
+
+	// Pre-set a report with a job so attribute resolution works with no activity text.
+	repo.reports["user1"] = &domain.Report{
+		UserID:   "user1",
+		Name:     "InitialPushName",
+		JobClass: "fighter",
+		LastReportDate: time.Now().AddDate(0, 0, -14),
+	}
 
 	// setname is disabled — PushName is used directly in /lapor instead
 	_, _ = handleUC.Execute(ctx, "user1", "InitialPushName", "/lapor")

--- a/internal/app/usecase/report_activity_usecase.go
+++ b/internal/app/usecase/report_activity_usecase.go
@@ -20,6 +20,7 @@ const (
 	ReportEventLedgerYear  = 2026
 	ReportEventLedgerMonth = time.June
 	ReportEventLedgerDay   = 24
+	AttributeGainPerReport = 1
 )
 
 type typedActivityRepository interface {
@@ -275,37 +276,13 @@ func (uc *ReportActivityUsecase) execute(ctx context.Context, userID, name strin
 			activityForParse += " " + ex
 		}
 	}
-	attrs := domain.DetermineAttributes(activityForParse)
-	var statGains []string
-	if reportPoints > 0 && len(attrs) > 0 {
-		statPoints := reportPoints / len(attrs)
-
-		scalingLevel := oldNumericLevel
-		if scalingLevel < 1 {
-			scalingLevel = 1
-		}
-		statPoints = statPoints / scalingLevel
-
-		if statPoints == 0 {
-			statPoints = 1 // Ensure at least 1 point if it divided down to 0
-		}
-		for _, attr := range attrs {
-			switch attr {
-			case domain.AttrStr:
-				report.Str += statPoints
-				statGains = append(statGains, fmt.Sprintf("STR +%d", statPoints))
-			case domain.AttrSta:
-				report.Sta += statPoints
-				statGains = append(statGains, fmt.Sprintf("STA +%d", statPoints))
-			case domain.AttrAgi:
-				report.Agi += statPoints
-				statGains = append(statGains, fmt.Sprintf("AGI +%d", statPoints))
-			case domain.AttrVit:
-				report.Vit += statPoints
-				statGains = append(statGains, fmt.Sprintf("VIT +%d", statPoints))
-			}
-		}
+	attrs, attrOK := domain.ResolveReportAttributes(activityForParse, report.JobClass)
+	if !attrOK {
+		msg := "⚠️ *Sistem Atribut Belum Aktif!*\n\nKamu belum memilih Job. Pilih job dulu agar atribut bisa aktif saat melapor tanpa aktivitas spesifik.\nPilih job via web dashboard: https://lapor-bot.web.id/\n\nAtau tulis aktivitas spesifik agar atribut terdeteksi otomatis (contoh: /lapor lari 5km, /lapor push up 50x). 💪"
+		msg += fmt.Sprintf("\n\n💬 _\"%s\"_", RandomQuote())
+		return msg, nil
 	}
+	statGains := applyAttributeGains(report, attrs, AttributeGainPerReport)
 
 	var newAchievements []domain.Achievement
 	var comebackAchievements []domain.ComebackAchievement
@@ -640,37 +617,13 @@ func (uc *ReportActivityUsecase) executeYesterday(ctx context.Context, userID, n
 			activityForParse += " " + ex
 		}
 	}
-	attrs := domain.DetermineAttributes(activityForParse)
-	var statGains []string
-	if reportPoints > 0 && len(attrs) > 0 {
-		statPoints := reportPoints / len(attrs)
-
-		scalingLevel := oldNumericLevel
-		if scalingLevel < 1 {
-			scalingLevel = 1
-		}
-		statPoints = statPoints / scalingLevel
-
-		if statPoints == 0 {
-			statPoints = 1 // Ensure at least 1 point
-		}
-		for _, attr := range attrs {
-			switch attr {
-			case domain.AttrStr:
-				report.Str += statPoints
-				statGains = append(statGains, fmt.Sprintf("STR +%d", statPoints))
-			case domain.AttrSta:
-				report.Sta += statPoints
-				statGains = append(statGains, fmt.Sprintf("STA +%d", statPoints))
-			case domain.AttrAgi:
-				report.Agi += statPoints
-				statGains = append(statGains, fmt.Sprintf("AGI +%d", statPoints))
-			case domain.AttrVit:
-				report.Vit += statPoints
-				statGains = append(statGains, fmt.Sprintf("VIT +%d", statPoints))
-			}
-		}
+	attrs, attrOK := domain.ResolveReportAttributes(activityForParse, report.JobClass)
+	if !attrOK {
+		msg := "⚠️ *Sistem Atribut Belum Aktif!*\n\nKamu belum memilih Job. Pilih job dulu agar atribut bisa aktif saat melapor tanpa aktivitas spesifik.\nPilih job via web dashboard: https://lapor-bot.web.id/\n\nAtau tulis aktivitas spesifik agar atribut terdeteksi otomatis (contoh: /lapor-kemarin lari 5km). 💪"
+		msg += fmt.Sprintf("\n\n💬 _\"%s\"_", RandomQuote())
+		return msg, nil
 	}
+	statGains := applyAttributeGains(report, attrs, AttributeGainPerReport)
 
 	newAchievements := domain.CheckNewSeasonAchievements(report)
 	pointsGained := 0
@@ -955,6 +908,31 @@ func (uc *ReportActivityUsecase) getNextComebackTarget(report *domain.Report) *d
 		}
 	}
 	return nil
+}
+
+func applyAttributeGains(report *domain.Report, attrs []domain.AttributeType, statPoints int) []string {
+	if report == nil || statPoints <= 0 || len(attrs) == 0 {
+		return nil
+	}
+
+	var statGains []string
+	for _, attr := range attrs {
+		switch attr {
+		case domain.AttrStr:
+			report.Str = domain.ClampedAttribute(report.Str) + statPoints
+			statGains = append(statGains, fmt.Sprintf("STR +%d", statPoints))
+		case domain.AttrSta:
+			report.Sta = domain.ClampedAttribute(report.Sta) + statPoints
+			statGains = append(statGains, fmt.Sprintf("STA +%d", statPoints))
+		case domain.AttrAgi:
+			report.Agi = domain.ClampedAttribute(report.Agi) + statPoints
+			statGains = append(statGains, fmt.Sprintf("AGI +%d", statPoints))
+		case domain.AttrVit:
+			report.Vit = domain.ClampedAttribute(report.Vit) + statPoints
+			statGains = append(statGains, fmt.Sprintf("VIT +%d", statPoints))
+		}
+	}
+	return statGains
 }
 
 func formatCurrentAttributes(report *domain.Report) string {

--- a/internal/app/usecase/report_activity_usecase_test.go
+++ b/internal/app/usecase/report_activity_usecase_test.go
@@ -172,8 +172,8 @@ func TestStreak_FirstReport(t *testing.T) {
 	uc := usecase.NewReportActivityUsecase(repo)
 	ctx := context.Background()
 
-	// First ever report
-	msg, err := uc.Execute(ctx, "user1", "Alice", nil)
+	// First ever report — use activity text with keyword so attrs resolve
+	msg, err := uc.ExecuteWithMessage(ctx, "user1", "Alice", "lari pagi", nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -222,6 +222,7 @@ func TestStreak_ConsecutiveDay_StreakIncreases(t *testing.T) {
 		Name:           "Bob",
 		Streak:         5,
 		ActivityCount:  10,
+		JobClass:       "fighter",
 		LastReportDate: lastWeek,
 	}
 
@@ -252,6 +253,7 @@ func TestStreak_MissedDay_StreakResets(t *testing.T) {
 		Name:           "Charlie",
 		Streak:         20, // Had a 20-week streak
 		ActivityCount:  25,
+		JobClass:       "fighter",
 		LastReportDate: twoWeeksAgo,
 	}
 
@@ -282,6 +284,7 @@ func TestStreak_SameDay_SecondReport(t *testing.T) {
 		Name:           "Diana",
 		Streak:         7,
 		ActivityCount:  15,
+		JobClass:       "fighter",
 		LastReportDate: now,
 	}
 	// Simulate that the user already has 1 activity logged today
@@ -322,6 +325,7 @@ func TestReportLimit_IsSeparateFromSideQuestLimit(t *testing.T) {
 		Name:           "Diana",
 		Streak:         7,
 		ActivityCount:  15,
+		JobClass:       "fighter",
 		LastReportDate: now,
 	}
 	repo.dailyCounts[todayKey] = 3
@@ -357,6 +361,7 @@ func TestReportActivity_AnnouncesLifetimeTierAndSeasonRankUp(t *testing.T) {
 		SeasonalActivityCount: 5,
 		TotalPoints:           1149,
 		SeasonalPoints:        149,
+		JobClass:              "fighter",
 		LastReportDate:        now,
 	}
 
@@ -410,6 +415,7 @@ func TestStreak_SameDay_UsesStoredNameWhenIncomingNameUnknown(t *testing.T) {
 		Name:           "Budi",
 		Streak:         3,
 		ActivityCount:  8,
+		JobClass:       "fighter",
 		LastReportDate: time.Now(),
 	}
 
@@ -436,6 +442,7 @@ func TestStreak_SameDay_HealsUnknownStoredName(t *testing.T) {
 		Name:           "Unknown",
 		Streak:         3,
 		ActivityCount:  8,
+		JobClass:       "fighter",
 		LastReportDate: time.Now(),
 	}
 
@@ -460,7 +467,7 @@ func TestStreak_FirstReport_DoesNotPersistUnknownName(t *testing.T) {
 	uc := usecase.NewReportActivityUsecase(repo)
 	ctx := context.Background()
 
-	msg, err := uc.Execute(ctx, "user1", "Unknown", nil)
+	msg, err := uc.ExecuteWithMessage(ctx, "user1", "Unknown", "lari pagi", nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -470,6 +477,95 @@ func TestStreak_FirstReport_DoesNotPersistUnknownName(t *testing.T) {
 	}
 	if containsSubstring(msg, "Unknown") {
 		t.Fatalf("First #lapor should not show Unknown fallback, got %q", msg)
+	}
+}
+
+func TestReportActivity_AttributeGainIsConsistentAcrossUsers(t *testing.T) {
+	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
+	uc := usecase.NewReportActivityUsecase(repo)
+	ctx := context.Background()
+	lastWeek := time.Now().AddDate(0, 0, -7)
+
+	repo.reports["newer"] = &domain.Report{
+		UserID:                "newer",
+		Name:                  "Newer",
+		Streak:                1,
+		ActivityCount:         5,
+		SeasonalActivityCount: 5,
+		TotalPoints:           0,
+		LastReportDate:        lastWeek,
+		Sta:                   3,
+	}
+	repo.reports["veteran"] = &domain.Report{
+		UserID:                "veteran",
+		Name:                  "Veteran",
+		Streak:                20,
+		ActivityCount:         80,
+		SeasonalActivityCount: 80,
+		TotalPoints:           5000,
+		LastReportDate:        lastWeek,
+		Sta:                   30,
+	}
+
+	newerBefore := repo.reports["newer"].Sta
+	veteranBefore := repo.reports["veteran"].Sta
+	if _, err := uc.ExecuteWithMessage(ctx, "newer", "Newer", "/lapor lari 5km", nil); err != nil {
+		t.Fatalf("newer report: %v", err)
+	}
+	if _, err := uc.ExecuteWithMessage(ctx, "veteran", "Veteran", "/lapor lari 5km", nil); err != nil {
+		t.Fatalf("veteran report: %v", err)
+	}
+
+	if got := repo.reports["newer"].Sta - newerBefore; got != 1 {
+		t.Fatalf("newer STA delta = %d, want 1", got)
+	}
+	if got := repo.reports["veteran"].Sta - veteranBefore; got != 1 {
+		t.Fatalf("veteran STA delta = %d, want 1", got)
+	}
+}
+
+func TestReportActivity_FirstAttributeGainStartsAboveDisplayedBaseline(t *testing.T) {
+	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
+	uc := usecase.NewReportActivityUsecase(repo)
+	ctx := context.Background()
+
+	msg, err := uc.ExecuteWithMessage(ctx, "runner", "Runner", "/lapor lari pagi", nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if got := repo.reports["runner"].Sta; got != 2 {
+		t.Fatalf("first STA gain should store baseline+gain = 2, got %d", got)
+	}
+	if !containsSubstring(msg, "STA +1") {
+		t.Fatalf("response should announce fixed STA gain, got %q", msg)
+	}
+}
+
+func TestReportActivity_SideQuestUsesSameAttributeClassifier(t *testing.T) {
+	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
+	uc := usecase.NewReportActivityUsecase(repo)
+	ctx := context.Background()
+	now := time.Now()
+	repo.reports["fighter"] = &domain.Report{
+		UserID:         "fighter",
+		Name:           "Fighter",
+		Streak:         1,
+		ActivityCount:  10,
+		LastReportDate: now,
+		Str:            1,
+	}
+
+	msg, err := uc.ExecuteSideQuest(ctx, "fighter", "Fighter", "Side quest: Wall Push-up / Desk Push-up", 1, 3, now)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if got := repo.reports["fighter"].Str; got != 2 {
+		t.Fatalf("sidequest STR gain = %d, want 2", got)
+	}
+	if !containsSubstring(msg, "STR +1") {
+		t.Fatalf("sidequest response should announce STR gain, got %q", msg)
 	}
 }
 
@@ -483,6 +579,7 @@ func TestStreak_ExistingUnknownStoredNameWithUnknownIncomingNormalizesToTeman(t 
 		Name:           "Unknown",
 		Streak:         3,
 		ActivityCount:  8,
+		JobClass:       "fighter",
 		LastReportDate: time.Now().AddDate(0, 0, -7),
 	}
 
@@ -511,6 +608,7 @@ func TestStreak_LongGap_StreakResets(t *testing.T) {
 		Name:           "Eve",
 		Streak:         36, // Was at max streak
 		ActivityCount:  36,
+		JobClass:       "fighter",
 		LastReportDate: thirtyDaysAgo,
 	}
 
@@ -619,6 +717,7 @@ func TestCenturion_PrestigeTransition(t *testing.T) {
 		Name:           "Centurion-to-be",
 		Streak:         12,
 		ActivityCount:  99,
+		JobClass:       "fighter",
 		LastReportDate: lastWeek,
 	}
 

--- a/internal/domain/level.go
+++ b/internal/domain/level.go
@@ -170,6 +170,23 @@ func FormatJobClass(id string) string {
 	return fmt.Sprintf("%s %s", job.Name, job.Icon)
 }
 
+// JobClassPrimaryAttribute returns the attribute specialty used for daily
+// side-quest rotation. Mage stays mixed by returning an empty attribute.
+func JobClassPrimaryAttribute(jobClass string) AttributeType {
+	switch strings.ToLower(strings.TrimSpace(jobClass)) {
+	case "fighter":
+		return AttrStr
+	case "ranger":
+		return AttrSta
+	case "assassin":
+		return AttrAgi
+	case "tank", "healer", "necromancer":
+		return AttrVit
+	default:
+		return ""
+	}
+}
+
 // GetNextLevel returns the next level and how many points are needed, or nil if max level.
 func GetNextLevel(totalPoints int) (*Level, int) {
 	for _, l := range AllLevels {

--- a/internal/domain/quest.go
+++ b/internal/domain/quest.go
@@ -52,108 +52,149 @@ func GenerateDailyQuestForUser(userID, jobClass string, level int, date time.Tim
 		hardBonus = 5
 	}
 
-	// Medium: light exercises doable at home/office as movement reminders.
-	// Level bonus gently scales with hunter level, capped at Lv.15.
-	mediumOptions := []QuestTask{
-		{ID: "squat", Name: "Chair Squat / Sit-to-Stand", Difficulty: "medium", Target: 18 + mediumBonus*2, Unit: "x", RewardPoints: 5},
-		{ID: "pushup", Name: "Wall Push-up / Desk Push-up", Difficulty: "medium", Target: 15 + mediumBonus*2, Unit: "x", RewardPoints: 5},
-		{ID: "stretching", Name: "Office Stretching / Mobility", Difficulty: "medium", Target: 8 + mediumBonus, Unit: "menit", RewardPoints: 5},
-		{ID: "highknees", Name: "High Knees (Marching)", Difficulty: "medium", Target: 1 + mediumBonus, Unit: "menit", RewardPoints: 5},
-		{ID: "armcircles", Name: "Arm Circles", Difficulty: "medium", Target: 2 + mediumBonus, Unit: "menit", RewardPoints: 5},
-		{ID: "calfraises", Name: "Calf Raises (Jinjit)", Difficulty: "medium", Target: 20 + mediumBonus*2, Unit: "x", RewardPoints: 5},
-		{ID: "stairs", Name: "Naik-Turun Tangga", Difficulty: "medium", Target: 5 + mediumBonus, Unit: "menit", RewardPoints: 5},
-		{ID: "deskplank", Name: "Desk Plank", Difficulty: "medium", Target: 30 + mediumBonus*5, Unit: "detik", RewardPoints: 5},
-	}
-	// Hard: slightly more effort, still home-friendly. Level bonus caps at Lv.20.
-	hardOptions := []QuestTask{
-		{ID: "plank", Name: "Plank", Difficulty: "hard", Target: 45 + hardBonus*5, Unit: "detik", RewardPoints: 5},
-		{ID: "jumpingjacks", Name: "Jumping Jacks", Difficulty: "hard", Target: 35 + hardBonus*3, Unit: "x", RewardPoints: 5},
-		{ID: "squatjump", Name: "Squat Jump Ringan", Difficulty: "hard", Target: 8 + hardBonus, Unit: "x", RewardPoints: 5},
-		{ID: "yoga", Name: "Mobility Flow", Difficulty: "hard", Target: 12 + hardBonus, Unit: "menit", RewardPoints: 5},
-		{ID: "mountainclimber", Name: "Mountain Climber", Difficulty: "hard", Target: 30 + hardBonus*5, Unit: "detik", RewardPoints: 5},
-		{ID: "lunges", Name: "Lunges (Bergantian)", Difficulty: "hard", Target: 10 + hardBonus, Unit: "x per kaki", RewardPoints: 5},
-		{ID: "glutebridge", Name: "Glute Bridge", Difficulty: "hard", Target: 15 + hardBonus*2, Unit: "x", RewardPoints: 5},
-		{ID: "reversecrunch", Name: "Reverse Crunch", Difficulty: "hard", Target: 10 + hardBonus, Unit: "x", RewardPoints: 5},
-		{ID: "lateralshuffle", Name: "Lateral Shuffle", Difficulty: "hard", Target: 45 + hardBonus*5, Unit: "detik", RewardPoints: 5},
-	}
+	mediumOptions, hardOptions := questOptionsForJob(jobClass, mediumBonus, hardBonus)
+
+	mediumTask := mediumOptions[hashValue%len(mediumOptions)]
+	hardTask := selectNonConflictingQuest(mediumTask, hardOptions, (hashValue/len(mediumOptions))%len(hardOptions))
 
 	return []QuestTask{
 		{ID: "easycardio", Name: "Jalan Kaki / Bersepeda", Difficulty: "easy", Target: 1, Unit: "opsi", RewardPoints: 5},
-		mediumOptions[hashValue%len(mediumOptions)],
-		hardOptions[(hashValue/len(mediumOptions))%len(hardOptions)],
+		mediumTask,
+		hardTask,
 	}
+}
+
+func selectNonConflictingQuest(medium QuestTask, hardOptions []QuestTask, start int) QuestTask {
+	for offset := 0; offset < len(hardOptions); offset++ {
+		candidate := hardOptions[(start+offset)%len(hardOptions)]
+		if !questTasksConflict(medium, candidate) {
+			return candidate
+		}
+	}
+	return hardOptions[start%len(hardOptions)]
+}
+
+func questTasksConflict(a, b QuestTask) bool {
+	return a.ID == b.ID || MatchTask(a.Name, b.ID) || MatchTask(b.Name, a.ID)
+}
+
+func questOptionsForJob(jobClass string, mediumBonus, hardBonus int) ([]QuestTask, []QuestTask) {
+	mediumByAttr := map[AttributeType][]QuestTask{
+		AttrStr: {
+			{ID: "squat", Name: "Chair Squat / Sit-to-Stand", Difficulty: "medium", Target: 18 + mediumBonus*2, Unit: "x", RewardPoints: 5},
+			{ID: "pushup", Name: "Wall Push-up / Desk Push-up", Difficulty: "medium", Target: 15 + mediumBonus*2, Unit: "x", RewardPoints: 5},
+			{ID: "calfraises", Name: "Calf Raises (Jinjit)", Difficulty: "medium", Target: 20 + mediumBonus*2, Unit: "x", RewardPoints: 5},
+			{ID: "deskplank", Name: "Desk Plank", Difficulty: "medium", Target: 30 + mediumBonus*5, Unit: "detik", RewardPoints: 5},
+			{ID: "wallsit", Name: "Wall Sit", Difficulty: "medium", Target: 30 + mediumBonus*5, Unit: "detik", RewardPoints: 5},
+		},
+		AttrSta: {
+			{ID: "stairs", Name: "Naik-Turun Tangga", Difficulty: "medium", Target: 5 + mediumBonus, Unit: "menit", RewardPoints: 5},
+			{ID: "stepups", Name: "Step-up", Difficulty: "medium", Target: 16 + mediumBonus*2, Unit: "x", RewardPoints: 5},
+			{ID: "jumpingjacks", Name: "Jumping Jacks", Difficulty: "medium", Target: 25 + mediumBonus*3, Unit: "x", RewardPoints: 5},
+			{ID: "skipping", Name: "Skipping / Rope Jump", Difficulty: "medium", Target: 2 + mediumBonus, Unit: "menit", RewardPoints: 5},
+		},
+		AttrAgi: {
+			{ID: "highknees", Name: "High Knees (Marching)", Difficulty: "medium", Target: 1 + mediumBonus, Unit: "menit", RewardPoints: 5},
+			{ID: "shadowboxing", Name: "Shadow Boxing", Difficulty: "medium", Target: 2 + mediumBonus, Unit: "menit", RewardPoints: 5},
+			{ID: "lateralshuffle", Name: "Lateral Shuffle", Difficulty: "medium", Target: 30 + mediumBonus*5, Unit: "detik", RewardPoints: 5},
+			{ID: "ladderdrill", Name: "Ladder Drill", Difficulty: "medium", Target: 2 + mediumBonus, Unit: "menit", RewardPoints: 5},
+		},
+		AttrVit: {
+			{ID: "stretching", Name: "Office Stretching / Mobility", Difficulty: "medium", Target: 8 + mediumBonus, Unit: "menit", RewardPoints: 5},
+			{ID: "armcircles", Name: "Arm Circles", Difficulty: "medium", Target: 2 + mediumBonus, Unit: "menit", RewardPoints: 5},
+			{ID: "deepbreathing", Name: "Deep Breathing", Difficulty: "medium", Target: 3 + mediumBonus, Unit: "menit", RewardPoints: 5},
+			{ID: "birddog", Name: "Bird Dog", Difficulty: "medium", Target: 12 + mediumBonus*2, Unit: "x", RewardPoints: 5},
+			{ID: "balance", Name: "Balance Drill", Difficulty: "medium", Target: 2 + mediumBonus, Unit: "menit", RewardPoints: 5},
+		},
+	}
+
+	hardByAttr := map[AttributeType][]QuestTask{
+		AttrStr: {
+			{ID: "plank", Name: "Plank", Difficulty: "hard", Target: 45 + hardBonus*5, Unit: "detik", RewardPoints: 5},
+			{ID: "lunges", Name: "Lunges (Bergantian)", Difficulty: "hard", Target: 10 + hardBonus, Unit: "x per kaki", RewardPoints: 5},
+			{ID: "glutebridge", Name: "Glute Bridge", Difficulty: "hard", Target: 15 + hardBonus*2, Unit: "x", RewardPoints: 5},
+			{ID: "reversecrunch", Name: "Reverse Crunch", Difficulty: "hard", Target: 10 + hardBonus, Unit: "x", RewardPoints: 5},
+			{ID: "deadbug", Name: "Dead Bug", Difficulty: "hard", Target: 12 + hardBonus*2, Unit: "x", RewardPoints: 5},
+		},
+		AttrSta: {
+			{ID: "mountainclimber", Name: "Mountain Climber", Difficulty: "hard", Target: 30 + hardBonus*5, Unit: "detik", RewardPoints: 5},
+			{ID: "jumpingjacks", Name: "Jumping Jacks", Difficulty: "hard", Target: 35 + hardBonus*3, Unit: "x", RewardPoints: 5},
+			{ID: "stairs", Name: "Naik-Turun Tangga", Difficulty: "hard", Target: 8 + hardBonus, Unit: "menit", RewardPoints: 5},
+			{ID: "shuttlerun", Name: "Shuttle Run", Difficulty: "hard", Target: 4 + hardBonus, Unit: "menit", RewardPoints: 5},
+		},
+		AttrAgi: {
+			{ID: "squatjump", Name: "Squat Jump Ringan", Difficulty: "hard", Target: 8 + hardBonus, Unit: "x", RewardPoints: 5},
+			{ID: "mountainclimber", Name: "Mountain Climber", Difficulty: "hard", Target: 30 + hardBonus*5, Unit: "detik", RewardPoints: 5},
+			{ID: "lateralshuffle", Name: "Lateral Shuffle", Difficulty: "hard", Target: 45 + hardBonus*5, Unit: "detik", RewardPoints: 5},
+			{ID: "shadowboxing", Name: "Shadow Boxing", Difficulty: "hard", Target: 4 + hardBonus, Unit: "menit", RewardPoints: 5},
+		},
+		AttrVit: {
+			{ID: "yoga", Name: "Mobility Flow", Difficulty: "hard", Target: 12 + hardBonus, Unit: "menit", RewardPoints: 5},
+			{ID: "stretching", Name: "Full Body Stretching", Difficulty: "hard", Target: 12 + hardBonus, Unit: "menit", RewardPoints: 5},
+			{ID: "deepbreathing", Name: "Deep Breathing", Difficulty: "hard", Target: 6 + hardBonus, Unit: "menit", RewardPoints: 5},
+			{ID: "balance", Name: "Balance Drill", Difficulty: "hard", Target: 4 + hardBonus, Unit: "menit", RewardPoints: 5},
+		},
+	}
+
+	primary := JobClassPrimaryAttribute(jobClass)
+	if primary != "" {
+		return mediumByAttr[primary], hardByAttr[primary]
+	}
+
+	var mediumOptions []QuestTask
+	var hardOptions []QuestTask
+	for _, attr := range []AttributeType{AttrStr, AttrSta, AttrAgi, AttrVit} {
+		mediumOptions = append(mediumOptions, mediumByAttr[attr]...)
+		hardOptions = append(hardOptions, hardByAttr[attr]...)
+	}
+	return mediumOptions, hardOptions
+}
+
+var questTaskKeywords = map[string][]string{
+	"pushup":          {"push up", "pushup", "wall push up", "desk push up"},
+	"situp":           {"sit up", "situp", "situps"},
+	"squat":           {"squat", "chair squat", "sit to stand"},
+	"plank":           {"plank"},
+	"burpee":          {"burpee", "burpees"},
+	"deskplank":       {"desk plank", "plank meja"},
+	"easycardio":      {"jalan", "walk", "walking", "jalan kaki", "sepeda", "bersepeda", "cycle", "cycling", "bike"},
+	"jalan":           {"jalan", "walk", "walking", "jalan kaki"},
+	"lari":            {"lari", "run", "running", "jogging", "sprint"},
+	"sepeda":          {"sepeda", "bersepeda", "cycle", "cycling", "bike"},
+	"hiit":            {"hiit", "tabata"},
+	"stretching":      {"stretch", "stretching", "peregangan", "mobility", "full body stretching"},
+	"yoga":            {"yoga", "mobility flow"},
+	"meditasi":        {"meditasi", "meditate", "meditation"},
+	"air":             {"air putih", "minum air", "water"},
+	"shadowboxing":    {"shadow boxing", "shadowboxing", "boxing", "tinju"},
+	"jumpingjacks":    {"jumping jacks", "jumpingjacks"},
+	"deepbreathing":   {"deep breathing", "breathing", "napas"},
+	"cardio":          {"cardio", "kardio"},
+	"weight":          {"beban", "weight", "strength", "weightlifting"},
+	"highknees":       {"high knees", "highknees", "marching"},
+	"armcircles":      {"arm circle", "arm circles", "armcircles", "putaran lengan"},
+	"calfraises":      {"calf raises", "calf raise", "calfraises", "jinjit"},
+	"shouldershrugs":  {"shoulder shrug", "shoulder shrugs", "shrug bahu"},
+	"stairs":          {"stairs", "tangga", "naik turun tangga"},
+	"mountainclimber": {"mountain climber", "mountainclimber", "gerakan panjat", "panjat"},
+	"lunges":          {"lunges", "lunge", "lunjak"},
+	"glutebridge":     {"glute bridge", "glutebridge", "jembatan pinggul"},
+	"reversecrunch":   {"reverse crunch", "reversecrunch"},
+	"squatjump":       {"squat jump", "jump squat"},
+	"lateralshuffle":  {"lateral shuffle", "lateralshuffle"},
+	"wallsit":         {"wall sit", "wallsit"},
+	"stepups":         {"step up", "stepup"},
+	"skipping":        {"skipping", "rope jump"},
+	"ladderdrill":     {"ladder drill", "ladderdrill"},
+	"shuttlerun":      {"shuttle run", "shuttlerun"},
+	"deadbug":         {"dead bug", "deadbug"},
+	"birddog":         {"bird dog", "birddog"},
+	"balance":         {"balance", "balance drill", "keseimbangan"},
 }
 
 // MatchTask checks if input contains keywords matching a specific task ID.
 func MatchTask(input string, taskID string) bool {
-	input = strings.ToLower(strings.TrimSpace(input))
-	switch taskID {
-	case "pushup":
-		return strings.Contains(input, "push")
-	case "situp":
-		return strings.Contains(input, "sit")
-	case "squat":
-		return strings.Contains(input, "squat")
-	case "plank":
-		return strings.Contains(input, "plank")
-	case "burpee":
-		return strings.Contains(input, "burpee")
-	case "easycardio":
-		return MatchTask(input, "jalan") || MatchTask(input, "sepeda")
-	case "jalan":
-		return strings.Contains(input, "jalan") || strings.Contains(input, "walk")
-	case "lari":
-		return strings.Contains(input, "lari") || strings.Contains(input, "run") || strings.Contains(input, "sprint")
-	case "sepeda":
-		return strings.Contains(input, "sepeda") || strings.Contains(input, "cycle") || strings.Contains(input, "cycling")
-	case "hiit":
-		return strings.Contains(input, "hiit") || strings.Contains(input, "tabata")
-	case "stretching":
-		return strings.Contains(input, "stretch") || strings.Contains(input, "peregangan")
-	case "yoga":
-		return strings.Contains(input, "yoga") || strings.Contains(input, "mobility")
-	case "meditasi":
-		return strings.Contains(input, "meditasi") || strings.Contains(input, "meditate") || strings.Contains(input, "meditation")
-	case "air":
-		return strings.Contains(input, "air") || strings.Contains(input, "minum") || strings.Contains(input, "water")
-	case "shadowboxing":
-		return strings.Contains(input, "box") || strings.Contains(input, "shadow")
-	case "jumpingjacks":
-		return strings.Contains(input, "jumping") || strings.Contains(input, "jack")
-	case "deepbreathing":
-		return strings.Contains(input, "napas") || strings.Contains(input, "breath") || strings.Contains(input, "breathing")
-	case "cardio":
-		return strings.Contains(input, "cardio") || strings.Contains(input, "kardio")
-	case "weight":
-		return strings.Contains(input, "beban") || strings.Contains(input, "weight") || strings.Contains(input, "strength")
-	// Medium additions — home/office movement reminders
-	case "highknees":
-		return strings.Contains(input, "high knee") || strings.Contains(input, "marching") || strings.Contains(input, "knee") && strings.Contains(input, "high")
-	case "armcircles":
-		return strings.Contains(input, "arm circle") || strings.Contains(input, "circle") || strings.Contains(input, "putaran lengan")
-	case "calfraises":
-		return strings.Contains(input, "calf") || strings.Contains(input, "jinjit")
-	case "shouldershrugs":
-		return strings.Contains(input, "shrug") || strings.Contains(input, "bahu")
-	case "stairs":
-		return strings.Contains(input, "tangga") || strings.Contains(input, "stair")
-	case "deskplank":
-		return strings.Contains(input, "desk plank") || strings.Contains(input, "plank meja")
-	// Hard additions — slightly more effort, still home-friendly
-	case "mountainclimber":
-		return strings.Contains(input, "mountain") || strings.Contains(input, "climber") || strings.Contains(input, "panjat")
-	case "lunges":
-		return strings.Contains(input, "lunge") || strings.Contains(input, "lunjak")
-	case "glutebridge":
-		return strings.Contains(input, "glute") || strings.Contains(input, "bridge") || strings.Contains(input, "pinggul") || strings.Contains(input, "jembatan")
-	case "reversecrunch":
-		return strings.Contains(input, "reverse crunch") || strings.Contains(input, "crunch") && !strings.Contains(input, "bicycle")
-	case "squatjump":
-		return strings.Contains(input, "squat jump") || strings.Contains(input, "jump squat")
-	case "lateralshuffle":
-		return strings.Contains(input, "lateral") || strings.Contains(input, "shuffle")
-	}
-	return false
+	return containsAnyActivityKeyword(normalizeActivityText(input), questTaskKeywords[taskID])
 }
 
 // FormatQuestProgressTask returns a descriptive string for a quest task, resolving Ranger 100m units to km.

--- a/internal/domain/quest_test.go
+++ b/internal/domain/quest_test.go
@@ -38,6 +38,64 @@ func TestGenerateDailyQuest(t *testing.T) {
 	if tasksUserA[1].ID == tasksUserB[1].ID && tasksUserA[2].ID == tasksUserB[2].ID {
 		t.Errorf("expected different users to get randomized medium/hard quests, got %+v and %+v", tasksUserA, tasksUserB)
 	}
+
+	// 5. Same user/job/day is deterministic.
+	tasksUserAAgain := GenerateDailyQuestForUser("628111", "fighter", 5, now)
+	for i := range tasksUserA {
+		if tasksUserA[i].ID != tasksUserAAgain[i].ID || tasksUserA[i].Target != tasksUserAAgain[i].Target {
+			t.Fatalf("expected deterministic quests, got %+v and %+v", tasksUserA, tasksUserAAgain)
+		}
+	}
+}
+
+func TestGenerateDailyQuest_JobAttributeSpecialists(t *testing.T) {
+	now := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		job  string
+		want AttributeType
+	}{
+		{"fighter", AttrStr},
+		{"ranger", AttrSta},
+		{"assassin", AttrAgi},
+		{"healer", AttrVit},
+		{"tank", AttrVit},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.job, func(t *testing.T) {
+			tasks := GenerateDailyQuestForUser("628111", tt.job, 5, now)
+			if len(tasks) != 3 {
+				t.Fatalf("expected 3 tasks, got %d", len(tasks))
+			}
+			for _, task := range tasks[1:] {
+				attrs, _ := ResolveReportAttributes(task.Name, tt.job)
+				if !hasAttribute(attrs, tt.want) {
+					t.Fatalf("%s task %q classified as %#v, want %s", tt.job, task.Name, attrs, tt.want)
+				}
+				if !MatchTask(task.Name, task.ID) {
+					t.Fatalf("generated task should be matchable by its name: %+v", task)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateDailyQuest_AvoidsOverlappingMediumAndHardTasks(t *testing.T) {
+	jobs := []string{"fighter", "ranger", "assassin", "mage", "healer", "tank", "necromancer"}
+	for day := 1; day <= 14; day++ {
+		date := time.Date(2026, 6, day, 0, 0, 0, 0, time.UTC)
+		for _, job := range jobs {
+			for _, userID := range []string{"628111", "628222", "628333"} {
+				tasks := GenerateDailyQuestForUser(userID, job, 8, date)
+				if len(tasks) != 3 {
+					t.Fatalf("expected 3 tasks for %s/%s/%s, got %d", userID, job, date.Format(time.DateOnly), len(tasks))
+				}
+				if questTasksConflict(tasks[1], tasks[2]) {
+					t.Fatalf("medium and hard tasks should not overlap for %s/%s/%s: %+v", userID, job, date.Format(time.DateOnly), tasks)
+				}
+			}
+		}
+	}
 }
 
 func TestMatchTask(t *testing.T) {
@@ -82,6 +140,9 @@ func TestMatchTask(t *testing.T) {
 		{"lateral shuffle 45 detik", "lateralshuffle", true},
 		// Negative cases
 		{"bicycle crunch 10", "reversecrunch", false}, // should not match: exclude "bicycle"
+		{"chair squat", "air", false},
+		{"rundown meeting", "lari", false},
+		{"legacy cleanup", "weight", false},
 		{"random text", "highknees", false},
 	}
 
@@ -91,4 +152,13 @@ func TestMatchTask(t *testing.T) {
 			t.Errorf("MatchTask(%q, %q) = %v, want %v", tt.input, tt.taskID, got, tt.want)
 		}
 	}
+}
+
+func hasAttribute(attrs []AttributeType, want AttributeType) bool {
+	for _, attr := range attrs {
+		if attr == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/domain/report.go
+++ b/internal/domain/report.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"time"
+	"unicode"
 )
 
 var ErrActiveGoalExists = errors.New("active goal exists")
@@ -81,30 +82,117 @@ func ClampedAttribute(v int) int {
 	return v
 }
 
+var attributeKeywordSets = []struct {
+	attr     AttributeType
+	keywords []string
+}{
+	{AttrStr, []string{
+		"beban", "weight", "weightlifting", "strength", "gym", "angkat", "powerlifting",
+		"push up", "pushup", "pull up", "pullup", "squat", "chair squat", "sit to stand",
+		"push day", "pull day", "push workout", "pull workout", "deadlift", "bench press",
+		"row", "leg day", "plank", "desk plank", "lunges", "lunge", "glute bridge",
+		"calf raises", "calf raise", "jinjit", "reverse crunch", "wall sit", "dead bug", "core",
+	}},
+	{AttrSta, []string{
+		"lari", "berlari", "run", "running", "jogging", "marathon", "sepeda", "bersepeda",
+		"cycle", "cycling", "bike", "kardio", "cardio", "renang", "berenang", "swim",
+		"swimming", "hiking", "trekking", "jalan jauh", "stairs", "tangga", "naik turun tangga",
+		"jumping jacks", "jumpingjacks", "step up", "stepup", "skipping", "rope jump",
+		"mountain climber", "mountainclimber",
+	}},
+	{AttrAgi, []string{
+		"bola", "sepak bola", "soccer", "football", "futsal", "basket", "basketball",
+		"bulutangkis", "bulu tangkis", "badminton", "tenis", "tennis", "padel", "padle",
+		"pickleball", "sprint", "hiit", "tabata", "muay thai", "muaythai", "boxing",
+		"tinju", "shadow boxing", "shadowboxing", "calisthenics", "voli", "volleyball",
+		"high knees", "highknees", "mountain climber", "mountainclimber", "lateral shuffle",
+		"lateralshuffle", "squat jump", "jump squat", "ladder drill", "shuttle run",
+	}},
+	{AttrVit, []string{
+		"yoga", "pilates", "stretching", "stretch", "peregangan", "mobility", "recovery",
+		"walk", "walking", "jalan kaki", "jalan santai", "meditasi", "meditation", "meditate",
+		"napas", "breathing", "deep breathing", "pemulihan", "mobility flow", "bird dog",
+		"balance", "keseimbangan", "shoulder mobility", "neck mobility",
+	}},
+}
+
 // DetermineAttributes parses an activity text to find matching RPG attributes.
+// Matching is table-driven and boundary-aware so unrelated words like
+// "legacy" or "rundown" do not accidentally grant STR/STA.
+// Returns an empty slice when no keywords match — callers should handle
+// the fallback via ResolveReportAttributes instead of hardcoding a default.
 func DetermineAttributes(text string) []AttributeType {
-	text = strings.ToLower(text)
+	normalized := normalizeActivityText(text)
 	var attrs []AttributeType
 
-	if strings.Contains(text, "beban") || strings.Contains(text, "weight") || strings.Contains(text, "strength") || strings.Contains(text, "gym") || strings.Contains(text, "angkat") || strings.Contains(text, "powerlifting") || strings.Contains(text, "push") || strings.Contains(text, "pull") || strings.Contains(text, "leg") {
-		attrs = append(attrs, AttrStr)
-	}
-	if strings.Contains(text, "lari") || strings.Contains(text, "run") || strings.Contains(text, "running") || strings.Contains(text, "sepeda") || strings.Contains(text, "cycle") || strings.Contains(text, "hiit") || strings.Contains(text, "kardio") || strings.Contains(text, "cardio") || strings.Contains(text, "renang") || strings.Contains(text, "swim") {
-		attrs = append(attrs, AttrSta)
-	}
-	if strings.Contains(text, "bola") || strings.Contains(text, "futsal") || strings.Contains(text, "basket") || strings.Contains(text, "bulutangkis") || strings.Contains(text, "tenis") || strings.Contains(text, "sprint") || strings.Contains(text, "muaythai") || strings.Contains(text, "boxing") || strings.Contains(text, "calisthenics") || strings.Contains(text, "padel") || strings.Contains(text, "padle") {
-		attrs = append(attrs, AttrAgi)
-	}
-	if strings.Contains(text, "yoga") || strings.Contains(text, "pilates") || strings.Contains(text, "stretching") || strings.Contains(text, "recovery") || strings.Contains(text, "jalan") || strings.Contains(text, "walk") || strings.Contains(text, "meditasi") {
-		attrs = append(attrs, AttrVit)
-	}
-
-	if len(attrs) == 0 {
-		// Default to VIT (General Health/Vitality) if no specific keywords match
-		attrs = append(attrs, AttrVit)
+	for _, set := range attributeKeywordSets {
+		if containsAnyActivityKeyword(normalized, set.keywords) {
+			attrs = append(attrs, set.attr)
+		}
 	}
 
 	return attrs
+}
+
+// ResolveReportAttributes determines which attributes are activated by an
+// activity, falling back to the user's job primary attribute when no keywords
+// match. Returns (attributes, ok). When ok is false the caller should prompt
+// the user to pick a job first.
+func ResolveReportAttributes(text string, jobClass string) ([]AttributeType, bool) {
+	attrs := DetermineAttributes(text)
+	if len(attrs) > 0 {
+		return attrs, true
+	}
+
+	// No keywords matched — fall back to job primary attribute.
+	if jobClass != "" {
+		primary := JobClassPrimaryAttribute(jobClass)
+		if primary != "" {
+			return []AttributeType{primary}, true
+		}
+		// Mage has no single primary attribute — give all attributes.
+		return []AttributeType{AttrStr, AttrSta, AttrAgi, AttrVit}, true
+	}
+
+	// No job selected — user needs to pick one.
+	return nil, false
+}
+
+func normalizeActivityText(text string) string {
+	text = strings.ToLower(text)
+	var b strings.Builder
+	lastSpace := true
+
+	for _, r := range text {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			lastSpace = false
+			continue
+		}
+		if !lastSpace {
+			b.WriteByte(' ')
+			lastSpace = true
+		}
+	}
+
+	return strings.TrimSpace(b.String())
+}
+
+func containsAnyActivityKeyword(normalizedText string, keywords []string) bool {
+	for _, keyword := range keywords {
+		if containsActivityKeyword(normalizedText, keyword) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsActivityKeyword(normalizedText, keyword string) bool {
+	normalizedKeyword := normalizeActivityText(keyword)
+	if normalizedText == "" || normalizedKeyword == "" {
+		return false
+	}
+	return strings.Contains(" "+normalizedText+" ", " "+normalizedKeyword+" ")
 }
 
 // ReportCutoffOffset is the spare time allowed for late-night reporting.

--- a/internal/domain/report_test.go
+++ b/internal/domain/report_test.go
@@ -1,67 +1,34 @@
 package domain
 
 import (
+	"reflect"
 	"testing"
-	"time"
 )
 
-func TestGetToday(t *testing.T) {
-	// 2026-03-14 00:15:00 UTC
-	t1 := time.Date(2026, 3, 14, 0, 15, 0, 0, time.UTC)
-	// With 30m offset, 00:15 should be "yesterday" (2026-03-13)
-	expected1 := time.Date(2026, 3, 13, 0, 0, 0, 0, time.UTC)
-	got1 := GetToday(t1)
-	if !got1.Equal(expected1) {
-		t.Errorf("For 00:15, expected %v, got %v", expected1, got1)
-	}
-
-	// 2026-03-14 00:31:00 UTC
-	t2 := time.Date(2026, 3, 14, 0, 31, 0, 0, time.UTC)
-	// With 30m offset, 00:31 should be "today" (2026-03-14)
-	expected2 := time.Date(2026, 3, 14, 0, 0, 0, 0, time.UTC)
-	got2 := GetToday(t2)
-	if !got2.Equal(expected2) {
-		t.Errorf("For 00:31, expected %v, got %v", expected2, got2)
-	}
-
-	// 2026-03-14 23:59:00 UTC
-	t3 := time.Date(2026, 3, 14, 23, 59, 0, 0, time.UTC)
-	// Should still be today
-	expected3 := time.Date(2026, 3, 14, 0, 0, 0, 0, time.UTC)
-	got3 := GetToday(t3)
-	if !got3.Equal(expected3) {
-		t.Errorf("For 23:59, expected %v, got %v", expected3, got3)
-	}
-}
-
-func TestGetStartOfISOWeekStrict_UsesMondayMidnightBoundary(t *testing.T) {
+func TestDetermineAttributes(t *testing.T) {
 	tests := []struct {
 		name string
-		now  time.Time
-		want time.Time
+		text string
+		want []AttributeType
 	}{
-		{
-			name: "Monday midnight starts new week",
-			now:  time.Date(2026, time.June, 15, 0, 0, 0, 0, time.UTC),
-			want: time.Date(2026, time.June, 15, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name: "Monday within report cutoff still starts new week",
-			now:  time.Date(2026, time.June, 15, 0, 29, 0, 0, time.UTC),
-			want: time.Date(2026, time.June, 15, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name: "Sunday belongs to previous Monday",
-			now:  time.Date(2026, time.June, 14, 23, 59, 0, 0, time.UTC),
-			want: time.Date(2026, time.June, 8, 0, 0, 0, 0, time.UTC),
-		},
+		{"stamina running", "lari 5km pagi", []AttributeType{AttrSta}},
+		{"stamina indonesian verb", "berlari 5km lalu berenang", []AttributeType{AttrSta}},
+		{"strength gym", "gym push-up squat", []AttributeType{AttrStr}},
+		{"strength push day", "Push Day chest dan triceps", []AttributeType{AttrStr}},
+		{"agility badminton", "main bulu tangkis dan padel", []AttributeType{AttrAgi}},
+		{"vitality recovery", "yoga stretching mobility", []AttributeType{AttrVit}},
+		{"hiking is stamina", "hiking jalan jauh", []AttributeType{AttrSta}},
+		{"multi attr stable order", "gym lalu lari dan stretching", []AttributeType{AttrStr, AttrSta, AttrVit}},
+		{"legacy does not match leg", "belajar legacy code", nil},
+		{"rundown does not match run", "rundown meeting pagi", nil},
+		{"push notification does not match push up", "push notification error", nil},
+		{"fallback", "aktivitas sehat", nil},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetStartOfISOWeekStrict(tt.now)
-			if !got.Equal(tt.want) {
-				t.Fatalf("expected %v, got %v", tt.want, got)
+			if got := DetermineAttributes(tt.text); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("DetermineAttributes(%q) = %#v, want %#v", tt.text, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
- Introduce attribute-based quest generation for specific job classes
- Refactor quest generation into job-specific functions, ensuring non-conflicting medium and hard tasks
- Update help messages and test cases to reflect new attribute resolution logic and quest generation
- Expand activity keywords for more precise attribute matching based on diverse user input
- Consolidate attribute determination to `DetermineAttributes` for better consistency and maintainability