### PR TITLE
feat(report): Improve attribute display logic for new users

### DIFF
--- a/internal/app/usecase/report_activity_usecase.go
+++ b/internal/app/usecase/report_activity_usecase.go
@@ -21,6 +21,7 @@ const (
 	ReportEventLedgerMonth = time.June
 	ReportEventLedgerDay   = 24
 	AttributeGainPerReport = 1
+	jobSetupURL            = "https://lapor-bot.web.id/"
 )
 
 type typedActivityRepository interface {
@@ -276,13 +277,12 @@ func (uc *ReportActivityUsecase) execute(ctx context.Context, userID, name strin
 			activityForParse += " " + ex
 		}
 	}
-	attrs, attrOK := domain.ResolveReportAttributes(activityForParse, report.JobClass)
-	if !attrOK {
-		msg := "⚠️ *Sistem Atribut Belum Aktif!*\n\nKamu belum memilih Job. Pilih job dulu agar atribut bisa aktif saat melapor tanpa aktivitas spesifik.\nPilih job via web dashboard: https://lapor-bot.web.id/\n\nAtau tulis aktivitas spesifik agar atribut terdeteksi otomatis (contoh: /lapor lari 5km, /lapor push up 50x). 💪"
-		msg += fmt.Sprintf("\n\n💬 _\"%s\"_", RandomQuote())
-		return msg, nil
+	attributesActive := hasSelectedJob(report)
+	var statGains []string
+	if attributesActive {
+		attrs, _ := domain.ResolveReportAttributes(activityForParse, report.JobClass)
+		statGains = applyAttributeGains(report, attrs, AttributeGainPerReport)
 	}
-	statGains := applyAttributeGains(report, attrs, AttributeGainPerReport)
 
 	var newAchievements []domain.Achievement
 	var comebackAchievements []domain.ComebackAchievement
@@ -401,6 +401,9 @@ func (uc *ReportActivityUsecase) execute(ctx context.Context, userID, name strin
 			response += fmt.Sprintf("\n🧭 Job: %s", domain.FormatJobClass(report.JobClass))
 		}
 	}
+	if !attributesActive {
+		response += "\n\n" + formatJobSetupNotice()
+	}
 
 	if isFullReport && report.ActivityCount == 1 && report.CenturionCycles > 0 && !isComeback {
 		response = "🔥 *ERA BARU DIMULAI!* 🔥\n" +
@@ -471,7 +474,9 @@ func (uc *ReportActivityUsecase) execute(ctx context.Context, userID, name strin
 
 	response += fmt.Sprintf("\n%s", domain.FormatNumericLevelProgressBar(report.TotalPoints))
 	response += fmt.Sprintf("\n%s", domain.FormatProgressBar(report.TotalPoints))
-	response += fmt.Sprintf("\n\n%s", formatCurrentAttributes(report))
+	if attributesActive {
+		response += fmt.Sprintf("\n\n%s", formatCurrentAttributes(report))
+	}
 
 	return response, nil
 }
@@ -617,13 +622,12 @@ func (uc *ReportActivityUsecase) executeYesterday(ctx context.Context, userID, n
 			activityForParse += " " + ex
 		}
 	}
-	attrs, attrOK := domain.ResolveReportAttributes(activityForParse, report.JobClass)
-	if !attrOK {
-		msg := "⚠️ *Sistem Atribut Belum Aktif!*\n\nKamu belum memilih Job. Pilih job dulu agar atribut bisa aktif saat melapor tanpa aktivitas spesifik.\nPilih job via web dashboard: https://lapor-bot.web.id/\n\nAtau tulis aktivitas spesifik agar atribut terdeteksi otomatis (contoh: /lapor-kemarin lari 5km). 💪"
-		msg += fmt.Sprintf("\n\n💬 _\"%s\"_", RandomQuote())
-		return msg, nil
+	attributesActive := hasSelectedJob(report)
+	var statGains []string
+	if attributesActive {
+		attrs, _ := domain.ResolveReportAttributes(activityForParse, report.JobClass)
+		statGains = applyAttributeGains(report, attrs, AttributeGainPerReport)
 	}
-	statGains := applyAttributeGains(report, attrs, AttributeGainPerReport)
 
 	newAchievements := domain.CheckNewSeasonAchievements(report)
 	pointsGained := 0
@@ -717,6 +721,9 @@ func (uc *ReportActivityUsecase) executeYesterday(ctx context.Context, userID, n
 			response += fmt.Sprintf("\n🧭 Job: %s", domain.FormatJobClass(report.JobClass))
 		}
 	}
+	if !attributesActive {
+		response += "\n\n" + formatJobSetupNotice()
+	}
 
 	if report.ActivityCount == 1 && report.CenturionCycles > 0 && !isComeback {
 		response = "🔥 *ERA BARU DIMULAI!* 🔥\n" +
@@ -781,7 +788,9 @@ func (uc *ReportActivityUsecase) executeYesterday(ctx context.Context, userID, n
 
 	response += fmt.Sprintf("\n%s", domain.FormatNumericLevelProgressBar(report.TotalPoints))
 	response += fmt.Sprintf("\n%s", domain.FormatProgressBar(report.TotalPoints))
-	response += fmt.Sprintf("\n\n%s", formatCurrentAttributes(report))
+	if attributesActive {
+		response += fmt.Sprintf("\n\n%s", formatCurrentAttributes(report))
+	}
 
 	return response, nil
 }
@@ -933,6 +942,14 @@ func applyAttributeGains(report *domain.Report, attrs []domain.AttributeType, st
 		}
 	}
 	return statGains
+}
+
+func hasSelectedJob(report *domain.Report) bool {
+	return report != nil && strings.TrimSpace(report.JobClass) != ""
+}
+
+func formatJobSetupNotice() string {
+	return fmt.Sprintf("ℹ️ Atribut belum ditampilkan karena kamu belum memilih job. Laporan tetap masuk; setup job di dashboard agar atribut aktif: %s", jobSetupURL)
 }
 
 func formatCurrentAttributes(report *domain.Report) string {

--- a/internal/app/usecase/report_activity_usecase_test.go
+++ b/internal/app/usecase/report_activity_usecase_test.go
@@ -172,7 +172,7 @@ func TestStreak_FirstReport(t *testing.T) {
 	uc := usecase.NewReportActivityUsecase(repo)
 	ctx := context.Background()
 
-	// First ever report — use activity text with keyword so attrs resolve
+	// First ever report without a selected job still records the report.
 	msg, err := uc.ExecuteWithMessage(ctx, "user1", "Alice", "lari pagi", nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -489,6 +489,7 @@ func TestReportActivity_AttributeGainIsConsistentAcrossUsers(t *testing.T) {
 	repo.reports["newer"] = &domain.Report{
 		UserID:                "newer",
 		Name:                  "Newer",
+		JobClass:              "ranger",
 		Streak:                1,
 		ActivityCount:         5,
 		SeasonalActivityCount: 5,
@@ -499,6 +500,7 @@ func TestReportActivity_AttributeGainIsConsistentAcrossUsers(t *testing.T) {
 	repo.reports["veteran"] = &domain.Report{
 		UserID:                "veteran",
 		Name:                  "Veteran",
+		JobClass:              "ranger",
 		Streak:                20,
 		ActivityCount:         80,
 		SeasonalActivityCount: 80,
@@ -528,6 +530,12 @@ func TestReportActivity_FirstAttributeGainStartsAboveDisplayedBaseline(t *testin
 	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
 	uc := usecase.NewReportActivityUsecase(repo)
 	ctx := context.Background()
+	repo.reports["runner"] = &domain.Report{
+		UserID:         "runner",
+		Name:           "Runner",
+		JobClass:       "ranger",
+		LastReportDate: time.Now().AddDate(0, 0, -7),
+	}
 
 	msg, err := uc.ExecuteWithMessage(ctx, "runner", "Runner", "/lapor lari pagi", nil)
 	if err != nil {
@@ -542,6 +550,54 @@ func TestReportActivity_FirstAttributeGainStartsAboveDisplayedBaseline(t *testin
 	}
 }
 
+func TestReportActivity_NoJobStillAcceptsReportAndHidesAttributes(t *testing.T) {
+	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
+	uc := usecase.NewReportActivityUsecase(repo)
+	ctx := context.Background()
+
+	msg, err := uc.Execute(ctx, "newbie", "Newbie", nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !containsSubstring(msg, "Laporan diterima") {
+		t.Fatalf("report without job should still be accepted, got %q", msg)
+	}
+	if containsSubstring(msg, "Sistem Atribut Belum Aktif") {
+		t.Fatalf("report without job should not use warning response, got %q", msg)
+	}
+	if containsSubstring(msg, "Attributes:") || containsSubstring(msg, "🛡️ Stats:") {
+		t.Fatalf("report without job should hide attributes, got %q", msg)
+	}
+	if !containsSubstring(msg, "setup job di dashboard") {
+		t.Fatalf("report without job should include setup job notice, got %q", msg)
+	}
+	if repo.reports["newbie"] == nil || repo.reports["newbie"].ActivityCount != 1 {
+		t.Fatalf("report without job should be persisted, got %#v", repo.reports["newbie"])
+	}
+}
+
+func TestReportActivity_NoJobWithSpecificActivityDoesNotActivateAttributes(t *testing.T) {
+	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
+	uc := usecase.NewReportActivityUsecase(repo)
+	ctx := context.Background()
+
+	msg, err := uc.ExecuteWithMessage(ctx, "newbie", "Newbie", "/lapor lari pagi", nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if repo.reports["newbie"].Sta != 0 {
+		t.Fatalf("attributes should not change before job setup, got STA %d", repo.reports["newbie"].Sta)
+	}
+	if containsSubstring(msg, "STA +1") || containsSubstring(msg, "🛡️ Stats:") {
+		t.Fatalf("specific activity without job should still hide attributes, got %q", msg)
+	}
+	if !containsSubstring(msg, "setup job di dashboard") {
+		t.Fatalf("specific activity without job should include setup job notice, got %q", msg)
+	}
+}
+
 func TestReportActivity_SideQuestUsesSameAttributeClassifier(t *testing.T) {
 	repo := &mockRepo{reports: make(map[string]*domain.Report), dailyCounts: make(map[string]int)}
 	uc := usecase.NewReportActivityUsecase(repo)
@@ -550,6 +606,7 @@ func TestReportActivity_SideQuestUsesSameAttributeClassifier(t *testing.T) {
 	repo.reports["fighter"] = &domain.Report{
 		UserID:         "fighter",
 		Name:           "Fighter",
+		JobClass:       "fighter",
 		Streak:         1,
 		ActivityCount:  10,
 		LastReportDate: now,


### PR DESCRIPTION
- Reports are now accepted even without a selected job, preventing "Sistem Atribut Belum Aktif!" error messages.
- Attribute gains and current stats are hidden from the report message until a user selects a job.
- A clear notice guides users to the web dashboard to set up their job, enabling attribute tracking.
- Resolves previous UX friction where new users without a job received confusing attribute-related error messages.