### PR TITLE
feat(backend): Refactor report activity scoring and attribute grants

### DIFF
--- a/internal/app/usecase/report_activity_scoring_test.go
+++ b/internal/app/usecase/report_activity_scoring_test.go
@@ -1,0 +1,111 @@
+package usecase
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCappedStreakBonus(t *testing.T) {
+	cases := []struct {
+		name    string
+		steps   int64
+		cap     int64
+		perStep int64
+		want    int
+	}{
+		{"first period (no bonus)", 0, 10, 2, 0},
+		{"negative clamped to zero", -3, 10, 2, 0},
+		{"within cap scales linearly", 4, 10, 2, 8},
+		{"at cap boundary", 10, 10, 2, 20},
+		{"above cap is clamped", 50, 10, 2, 20},
+		{"daily per-step is 1", 3, 5, 1, 3},
+		{"daily capped at 5", 99, 5, 1, 5},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := cappedStreakBonus(c.steps, c.cap, c.perStep); got != c.want {
+				t.Fatalf("cappedStreakBonus(%d, %d, %d) = %d, want %d", c.steps, c.cap, c.perStep, got, c.want)
+			}
+		})
+	}
+}
+
+// TestScoring_WeeklyPerStepHigherThanDaily guards the requirement that the
+// weekly streak bonus per step must be larger than the daily one, so a weekly
+// streak is always worth more than an equally long daily streak.
+func TestScoring_WeeklyPerStepHigherThanDaily(t *testing.T) {
+	if weeklyStreakBonusPerStep <= dailyStreakBonusPerStep {
+		t.Fatalf("weekly per-step (%d) must be > daily per-step (%d)",
+			weeklyStreakBonusPerStep, dailyStreakBonusPerStep)
+	}
+}
+
+// TestScoring_WeeklyAndDailyBonusesAreAdditive guarantees that when both
+// streaks are at their caps, the combined bonus is the sum of the two caps
+// (i.e. having both streaks alive yields strictly more than either alone),
+// and that the weekly component stays the larger contributor.
+func TestScoring_WeeklyAndDailyBonusesAreAdditive(t *testing.T) {
+	weeklyMax := cappedStreakBonus(weeklyStreakBonusCap, weeklyStreakBonusCap, weeklyStreakBonusPerStep)
+	dailyMax := cappedStreakBonus(dailyStreakBonusCap, dailyStreakBonusCap, dailyStreakBonusPerStep)
+	combined := weeklyMax + dailyMax
+
+	if weeklyMax <= dailyMax {
+		t.Fatalf("weekly cap bonus (%d) must exceed daily cap bonus (%d)", weeklyMax, dailyMax)
+	}
+	if combined <= weeklyMax || combined <= dailyMax {
+		t.Fatalf("combined (%d) must be greater than weekly-only (%d) and daily-only (%d)",
+			combined, weeklyMax, dailyMax)
+	}
+	// The cap's job is to bound runaway XP: a streak-100 user must earn the
+	// same streak bonus as a streak-(cap+1) user. Verify that ceiling.
+	veryLong := cappedStreakBonus(100, weeklyStreakBonusCap, weeklyStreakBonusPerStep)
+	if veryLong != weeklyMax {
+		t.Fatalf("streak-100 weekly bonus (%d) must equal the cap (%d); cap is not bounding", veryLong, weeklyMax)
+	}
+}
+
+func TestDailyStreakFromDates(t *testing.T) {
+	today := time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name   string
+		dates  []time.Time
+		today  time.Time
+		want   int
+	}{
+		{
+			name:  "no history counts today only",
+			today: today,
+			want:  1,
+		},
+		{
+			name:  "consecutive days including today",
+			dates: []time.Time{today.AddDate(0, 0, -3), today.AddDate(0, 0, -2), today.AddDate(0, 0, -1)},
+			today: today,
+			want:  4,
+		},
+		{
+			name: "gap breaks the streak",
+			// Reported 5 and 4 days ago, then nothing until today: streak is 1.
+			dates: []time.Time{today.AddDate(0, 0, -5), today.AddDate(0, 0, -4)},
+			today: today,
+			want:  1,
+		},
+		{
+			name: "duplicate dates do not inflate the count",
+			dates: []time.Time{
+				today.AddDate(0, 0, -1), today.AddDate(0, 0, -1),
+				today.AddDate(0, 0, -2),
+			},
+			today: today,
+			want:  3,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := dailyStreakFromDates(c.dates, c.today); got != c.want {
+				t.Fatalf("dailyStreakFromDates = %d, want %d", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/app/usecase/report_activity_usecase.go
+++ b/internal/app/usecase/report_activity_usecase.go
@@ -22,6 +22,23 @@ const (
 	ReportEventLedgerDay   = 24
 	AttributeGainPerReport = 1
 	jobSetupURL            = "https://lapor-bot.web.id/"
+
+	// Scoring model. Base points are fixed per trigger so every user earns the
+	// same amount for the same command (lapor / lapor sidequest). Streak
+	// bonuses are additive and capped so a long streak cannot dominate the
+	// base reward (best practice: streak share stays ≤ ~30% of a report).
+	baseReportPoints         = 10
+	sideQuestFallbackPoints  = 5
+	seasonalFirstReportBonus = 5
+
+	// Weekly streak bonus is worth more per step than the daily one, but both
+	// apply additively when a user keeps both streaks alive — so a user with
+	// an active daily AND weekly streak always earns more than with either
+	// alone, while the weekly component stays the larger of the two.
+	weeklyStreakBonusPerStep = 2
+	weeklyStreakBonusCap     = 10 // max +20 pts per report from weekly streak
+	dailyStreakBonusPerStep  = 1
+	dailyStreakBonusCap      = 5  // max +5 pts per report from daily streak
 )
 
 type typedActivityRepository interface {
@@ -240,29 +257,35 @@ func (uc *ReportActivityUsecase) execute(ctx context.Context, userID, name strin
 		}
 	}
 
-	basePoints := 10
-	streakBonus := 0
+	basePoints := baseReportPoints
+	weeklyStreakBonus := 0
+	dailyStreakBonus := 0
 	seasonalFirstBonus := 0
 	if isFullReport {
-		streakBonus = 2 * (report.Streak - 1)
-		if streakBonus < 0 {
-			streakBonus = 0
-		}
+		weeklyStreakBonus = cappedStreakBonus(int64(report.Streak)-1, weeklyStreakBonusCap, weeklyStreakBonusPerStep)
+		dailyStreak := uc.computeDailyStreak(ctx, userID, today)
+		dailyStreakBonus = cappedStreakBonus(int64(dailyStreak)-1, dailyStreakBonusCap, dailyStreakBonusPerStep)
 		if report.SeasonalActivityCount == 1 {
-			seasonalFirstBonus = 5
+			seasonalFirstBonus = seasonalFirstReportBonus
 		}
 	}
 	if isSideQuest {
 		if opts.sideQuestPoints > 0 {
 			basePoints = opts.sideQuestPoints
 		} else {
-			basePoints = 5 // fallback for callers that don't pass difficulty points
+			basePoints = sideQuestFallbackPoints // fallback for callers that don't pass difficulty points
 		}
-		streakBonus = 0
+		weeklyStreakBonus = 0
+		dailyStreakBonus = 0
 		seasonalFirstBonus = 0
 		report.TotalSideQuests += opts.sideQuestCount
 		report.SeasonalSideQuests += opts.sideQuestCount
 	}
+	// streakBonus is the additive sum of weekly + daily components. Weekly
+	// per-step (2) > daily per-step (1), and both caps apply, so the weekly
+	// bonus is always the larger contributor and the two stack when both
+	// streaks are active.
+	streakBonus := weeklyStreakBonus + dailyStreakBonus
 	reportPoints := basePoints + streakBonus + seasonalFirstBonus
 	if isRepeatReport && !isSideQuest {
 		reportPoints = reportPoints / 2
@@ -280,8 +303,15 @@ func (uc *ReportActivityUsecase) execute(ctx context.Context, userID, name strin
 	attributesActive := hasSelectedJob(report)
 	var statGains []string
 	if attributesActive {
+		// A report grants a single, fair attribute point. The activity directs
+		// which attribute is rewarded; the job breaks ties among multiple
+		// matches and is the fallback when nothing matches. Granting +1 to
+		// every matched attribute would make mixed sessions worth several
+		// times the attribute points of focused ones.
 		attrs, _ := domain.ResolveReportAttributes(activityForParse, report.JobClass)
-		statGains = applyAttributeGains(report, attrs, AttributeGainPerReport)
+		chosen := domain.SelectReportAttribute(attrs, report.JobClass,
+			attributeSelectionSeed(userID, activityKind, today.Format(time.DateOnly), dailyCount+1, activityForParse))
+		statGains = applyAttributeGains(report, []domain.AttributeType{chosen}, AttributeGainPerReport)
 	}
 
 	var newAchievements []domain.Achievement
@@ -370,19 +400,10 @@ func (uc *ReportActivityUsecase) execute(ctx context.Context, userID, name strin
 			cyclePrefix = fmt.Sprintf("[C%d] ", report.CenturionCycles+1)
 		}
 
-		expBreakdown := fmt.Sprintf("⭐ +%d pts", basePoints)
-		if streakBonus > 0 {
-			expBreakdown += fmt.Sprintf(" (streak bonus +%d)", streakBonus)
-		}
-		if seasonalFirstBonus > 0 {
-			expBreakdown += " (first season report +5)"
-		}
-		if isSideQuest {
-			expBreakdown += " (side quest)"
-		} else if isRepeatReport {
-			expBreakdown += " (repeat report, ½ XP)"
-		}
-
+		// Only the final point result is shown; the per-component breakdown
+		// (base / weekly / daily / seasonal / repeat ½) is intentionally hidden
+		// from the user-facing message for both /lapor and /lapor sidequest.
+		expBreakdown := fmt.Sprintf("⭐ +%d pts", reportPoints)
 		if len(statGains) > 0 {
 			expBreakdown += fmt.Sprintf("\n💪 Attributes: %s", strings.Join(statGains, ", "))
 		}
@@ -503,7 +524,7 @@ func (uc *ReportActivityUsecase) executeYesterday(ctx context.Context, userID, n
 	today := domain.GetToday(now)
 	yesterday := today.AddDate(0, 0, -1)
 
-	dailyCount, err := uc.repo.GetDailyActivityCount(ctx, userID, yesterday)
+	dailyCount, err := uc.getDailyActivityCount(ctx, userID, yesterday, domain.ActivityKindRegularReport)
 	if err != nil {
 		return "", err
 	}
@@ -600,17 +621,20 @@ func (uc *ReportActivityUsecase) executeYesterday(ctx context.Context, userID, n
 	}
 
 	basePoints := 5
-	streakBonus := 0
+	weeklyStreakBonus := 0
 	seasonalFirstBonus := 0
 	if report.Streak > 1 {
-		streakBonus = (2 * (report.Streak - 1)) / 2
-		if streakBonus < 0 {
-			streakBonus = 0
+		// Yesterday catch-up reports earn ½ XP: halve the (already capped)
+		// weekly streak bonus so inflation stays bounded here too.
+		weeklyStreakBonus = cappedStreakBonus(int64(report.Streak)-1, weeklyStreakBonusCap, weeklyStreakBonusPerStep) / 2
+		if weeklyStreakBonus < 0 {
+			weeklyStreakBonus = 0
 		}
 	}
 	if report.SeasonalActivityCount == 1 {
 		seasonalFirstBonus = 2
 	}
+	streakBonus := weeklyStreakBonus
 	reportPoints := basePoints + streakBonus + seasonalFirstBonus
 	report.TotalPoints += reportPoints
 	report.SeasonalPoints += reportPoints
@@ -625,8 +649,15 @@ func (uc *ReportActivityUsecase) executeYesterday(ctx context.Context, userID, n
 	attributesActive := hasSelectedJob(report)
 	var statGains []string
 	if attributesActive {
+		// A report grants a single, fair attribute point. The activity directs
+		// which attribute is rewarded; the job breaks ties among multiple
+		// matches and is the fallback when nothing matches. Granting +1 to
+		// every matched attribute would make mixed sessions worth several
+		// times the attribute points of focused ones.
 		attrs, _ := domain.ResolveReportAttributes(activityForParse, report.JobClass)
-		statGains = applyAttributeGains(report, attrs, AttributeGainPerReport)
+		chosen := domain.SelectReportAttribute(attrs, report.JobClass,
+			attributeSelectionSeed(userID, domain.ActivityKindRegularReport, yesterday.Format(time.DateOnly), dailyCount+1, activityForParse))
+		statGains = applyAttributeGains(report, []domain.AttributeType{chosen}, AttributeGainPerReport)
 	}
 
 	newAchievements := domain.CheckNewSeasonAchievements(report)
@@ -702,14 +733,10 @@ func (uc *ReportActivityUsecase) executeYesterday(ctx context.Context, userID, n
 			cyclePrefix = fmt.Sprintf("[C%d] ", report.CenturionCycles+1)
 		}
 
-		expBreakdown := fmt.Sprintf("⭐ +%d pts", basePoints)
-		if streakBonus > 0 {
-			expBreakdown += fmt.Sprintf(" (streak bonus +%d)", streakBonus)
-		}
-		if seasonalFirstBonus > 0 {
-			expBreakdown += " (first season report +2)"
-		}
-		expBreakdown += " (lapor kemarin, ½ XP)"
+		// Only the final point result is shown; the per-component breakdown is
+		// intentionally hidden from the user-facing message.
+		expBreakdown := fmt.Sprintf("⭐ +%d pts", reportPoints)
+		expBreakdown += " (lapor kemarin)"
 
 		if len(statGains) > 0 {
 			expBreakdown += fmt.Sprintf("\n💪 Attributes: %s", strings.Join(statGains, ", "))
@@ -866,6 +893,60 @@ func boolToInt(v bool) int {
 		return 1
 	}
 	return 0
+}
+
+// cappedStreakBonus computes a capped linear streak bonus.
+// steps is the streak length minus one (the number of "extra" periods), clamped
+// to [0, cap]; the bonus is steps * perStep. Capping prevents a long streak
+// from dominating the fixed base reward (runaway XP).
+func cappedStreakBonus(steps, cap, perStep int64) int {
+	if steps < 0 {
+		steps = 0
+	}
+	if steps > cap {
+		steps = cap
+	}
+	return int(steps * perStep)
+}
+
+// attributeSelectionSeed builds a stable, per-report-slot seed used to
+// distribute attribute gains fairly for jobs without a single primary
+// attribute (Mage). The same report context always yields the same seed, so
+// the chosen attribute is deterministic; varying the slot/date/activity
+// spreads Mage's gains across its candidate attributes over time.
+func attributeSelectionSeed(userID, kind, date string, slot int, activityText string) string {
+	return fmt.Sprintf("%s|%s|%s|%d|%s", userID, kind, date, slot, activityText)
+}
+
+// computeDailyStreak returns the number of consecutive days (ending at today)
+// the user has logged any activity. today is counted even though the
+// activity_log row for the current report is upserted after scoring, so the
+// bonus reflects the streak this report is extending.
+func (uc *ReportActivityUsecase) computeDailyStreak(ctx context.Context, userID string, today time.Time) int {
+	dates, err := uc.repo.GetUserActivityDates(ctx, userID)
+	if err != nil {
+		// Fail open: treat as the first day so we never block a report on a
+		// read error. The bonus is simply not awarded.
+		return 1
+	}
+	return dailyStreakFromDates(dates, today)
+}
+
+// dailyStreakFromDates counts consecutive calendar days ending at today,
+// including today itself. priorDates are the user's historical activity
+// dates (which do not yet contain today for the current report).
+func dailyStreakFromDates(priorDates []time.Time, today time.Time) int {
+	active := make(map[string]bool, len(priorDates)+1)
+	for _, d := range priorDates {
+		active[d.Format(time.DateOnly)] = true
+	}
+	active[today.Format(time.DateOnly)] = true
+
+	streak := 0
+	for d := today; active[d.Format(time.DateOnly)]; d = d.AddDate(0, 0, -1) {
+		streak++
+	}
+	return streak
 }
 
 func reportName(storedName, incomingName string) string {

--- a/internal/app/usecase/report_activity_usecase_test.go
+++ b/internal/app/usecase/report_activity_usecase_test.go
@@ -2,12 +2,27 @@ package usecase_test
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/fardannozami/whatsapp-gateway/internal/app/usecase"
 	"github.com/fardannozami/whatsapp-gateway/internal/domain"
 )
+
+// allSeasonBadgeIDs returns every season achievement id joined into the stored
+// comma-separated form. Pre-seeding a report's SeasonalAchievements with this
+// prevents any season achievement from (re)firing during a test, so the
+// SeasonalPoints delta reflects only the report's own point calculation
+// (base + streak bonuses), letting tests assert exact point deltas.
+func allSeasonBadgeIDs() string {
+	ids := make([]string, 0, len(domain.AllSeasonAchievements))
+	for _, a := range domain.AllSeasonAchievements {
+		ids = append(ids, a.ID)
+	}
+	return strings.Join(ids, ",")
+}
 
 type mockRepo struct {
 	domain.ReportRepository
@@ -300,8 +315,10 @@ func TestStreak_SameDay_SecondReport(t *testing.T) {
 	if !containsSubstring(msg, "Laporan diterima (laporan ke-2 hari ini)") {
 		t.Errorf("Same day: expected repeat report message, got '%s'", msg)
 	}
-	if !containsSubstring(msg, "repeat report, ½ XP") {
-		t.Errorf("Same day: expected halved XP note, got '%s'", msg)
+	// The per-point breakdown (including the "½ XP" note) is intentionally
+	// hidden from the message; only the final total is shown.
+	if containsSubstring(msg, "½ XP") || containsSubstring(msg, "repeat report") {
+		t.Errorf("Same day: point breakdown should be hidden, got '%s'", msg)
 	}
 
 	// Values should NOT change (streak and activity count stay same)
@@ -920,6 +937,240 @@ func TestReportEventLedgerEnabled_StartsOnConfiguredDayInWIB(t *testing.T) {
 	start := time.Date(2026, time.June, 24, 0, 0, 0, 0, loc)
 	if !usecase.ReportEventLedgerEnabled(start) {
 		t.Fatalf("ledger should be enabled starting 24 Jun 2026 WIB")
+	}
+}
+
+// TestStreakBonus_DailyAndWeeklyAwardedTogether checks that a user who reports
+// on consecutive days AND consecutive weeks earns BOTH the daily and weekly
+// streak bonuses in a single /lapor, that the two stack (combined > either),
+// and that the per-component breakdown stays hidden — only the final total is
+// shown. SeasonalAchievements is pre-seeded so no achievement fires and the
+// SeasonalPoints delta equals the report's own point calculation.
+func TestStreakBonus_DailyAndWeeklyAwardedTogether(t *testing.T) {
+	repo := &mockRepo{
+		reports:       make(map[string]*domain.Report),
+		dailyCounts:   make(map[string]int),
+		activityDates: make(map[string][]time.Time),
+	}
+	uc := usecase.NewReportActivityUsecase(repo)
+	ctx := context.Background()
+
+	today := domain.GetToday(time.Now())
+	// Use a non-midnight LastReportDate so the -30m cutoff in domain.GetToday
+	// doesn't shift it across a day bound (matches existing streak tests).
+	lastWeek := time.Now().AddDate(0, 0, -7)
+	repo.reports["user1"] = &domain.Report{
+		UserID:                "user1",
+		Name:                  "Consistent",
+		JobClass:              "fighter",
+		Streak:                3,
+		MaxStreak:             5, // already past streak_4, so 3→4 doesn't re-fire it
+		SeasonalMaxStreak:     5,
+		ActivityCount:         30,
+		SeasonalActivityCount: 30,
+		SeasonalAchievements:  allSeasonBadgeIDs(), // suppress all achievement fires
+		LastReportDate:        lastWeek,
+	}
+	// Reported yesterday and the day before → daily streak after this report
+	// is 3 (today + 2 prior days) → 2 steps × 1 = +2 daily bonus.
+	repo.activityDates["user1"] = []time.Time{
+		today.AddDate(0, 0, -2), today.AddDate(0, 0, -1),
+	}
+	before := repo.reports["user1"].SeasonalPoints
+
+	msg, err := uc.Execute(ctx, "user1", "Consistent", nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Weekly streak 3→4 (consecutive week): 3 steps × 2 = +6.
+	// Daily streak 3: 2 steps × 1 = +2. Base 10. Total = 18. No achievements fire.
+	gained := repo.reports["user1"].SeasonalPoints - before
+	if gained != 18 {
+		t.Fatalf("expected +18 pts (base 10 + weekly 6 + daily 2), got %d", gained)
+	}
+	if !containsSubstring(msg, "⭐ +18 pts") {
+		t.Fatalf("expected final total '⭐ +18 pts' in message, got: %s", msg)
+	}
+	// Breakdown must be hidden.
+	for _, bad := range []string{"(weekly streak", "(daily streak", "(streak bonus", "½ XP"} {
+		if containsSubstring(msg, bad) {
+			t.Fatalf("point breakdown %q should be hidden, got: %s", bad, msg)
+		}
+	}
+}
+
+// TestStreakBonus_WeeklyCappedForLongStreak ensures a very long weekly streak
+// no longer produces runaway XP. With cap=10, a streak of 11 (→12) and 50 (→51)
+// must both yield the same capped weekly bonus (max +20), not +22 / +100.
+func TestStreakBonus_WeeklyCappedForLongStreak(t *testing.T) {
+	lastWeek := time.Now().AddDate(0, 0, -7)
+
+	for _, streak := range []int{11, 50} {
+		t.Run(fmt.Sprintf("streak_%d", streak), func(t *testing.T) {
+			repo := &mockRepo{
+				reports:       make(map[string]*domain.Report),
+				dailyCounts:   make(map[string]int),
+				activityDates: make(map[string][]time.Time),
+			}
+			uc := usecase.NewReportActivityUsecase(repo)
+			ctx := context.Background()
+			repo.reports["u"] = &domain.Report{
+				UserID: "u", Name: "Vet", JobClass: "fighter",
+				Streak: streak, MaxStreak: streak, SeasonalMaxStreak: streak,
+				ActivityCount: 30, SeasonalActivityCount: 30,
+				SeasonalAchievements: allSeasonBadgeIDs(),
+				LastReportDate:        lastWeek,
+			}
+			// No daily history → daily bonus 0, isolating the weekly cap.
+			before := repo.reports["u"].SeasonalPoints
+			msg, err := uc.Execute(ctx, "u", "Vet", nil)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			// Both long streaks: base 10 + capped weekly 20 = +30.
+			gained := repo.reports["u"].SeasonalPoints - before
+			if gained != 30 {
+				t.Fatalf("streak %d: expected capped +30 (base 10 + weekly 20), got %d", streak, gained)
+			}
+			if containsSubstring(msg, "(weekly streak") {
+				t.Fatalf("streak %d: breakdown should be hidden, got: %s", streak, msg)
+			}
+		})
+	}
+}
+
+// TestStreakBonus_SideQuestHasNoStreakBonus verifies side quest reports pay
+// only their difficulty-based points (consistent per trigger) and receive no
+// streak bonus — so a side quest's points do not vary by the user's streak
+// state. The breakdown is also hidden.
+func TestStreakBonus_SideQuestHasNoStreakBonus(t *testing.T) {
+	repo := &mockRepo{
+		reports:       make(map[string]*domain.Report),
+		dailyCounts:   make(map[string]int),
+		activityDates: make(map[string][]time.Time),
+	}
+	uc := usecase.NewReportActivityUsecase(repo)
+	ctx := context.Background()
+
+	today := domain.GetToday(time.Now())
+	repo.reports["u"] = &domain.Report{
+		UserID: "u", Name: "Questor", JobClass: "fighter",
+		Streak: 30, MaxStreak: 30, SeasonalMaxStreak: 30,
+		ActivityCount: 30, SeasonalActivityCount: 30,
+		SeasonalAchievements: allSeasonBadgeIDs(),
+		LastReportDate:        today.AddDate(0, 0, -7),
+	}
+	before := repo.reports["u"].TotalPoints
+
+	msg, err := uc.ExecuteSideQuest(ctx, "u", "Questor", "Side quest: jalan kaki", 1, 5, time.Now())
+	if err != nil {
+		t.Fatalf("ExecuteSideQuest: %v", err)
+	}
+	gained := repo.reports["u"].TotalPoints - before
+	// Only the side-quest difficulty points (5) should be awarded — no streak
+	// bonus despite the user having a 30-week streak.
+	if gained != 5 {
+		t.Fatalf("side quest should earn exactly its difficulty points (5), got %d", gained)
+	}
+	for _, bad := range []string{"(weekly streak", "(daily streak", "(side quest)"} {
+		if containsSubstring(msg, bad) {
+			t.Fatalf("side quest breakdown %q should be hidden, got: %s", bad, msg)
+		}
+	}
+}
+
+// TestReportPoints_RepeatReportHalved verifies a same-day repeat /lapor earns
+// exactly half of the first report's points (the first report's daily streak
+// bonus and isFullReport-only path don't apply to repeats). Achievements are
+// suppressed so the delta equals the raw point calculation.
+func TestReportPoints_RepeatReportHalved(t *testing.T) {
+	repo := &mockRepo{
+		reports:       make(map[string]*domain.Report),
+		dailyCounts:   make(map[string]int),
+		activityDates: make(map[string][]time.Time),
+	}
+	uc := usecase.NewReportActivityUsecase(repo)
+	ctx := context.Background()
+	repo.reports["u"] = &domain.Report{
+		UserID: "u", Name: "Repeat", JobClass: "fighter",
+		Streak: 3, MaxStreak: 5, SeasonalMaxStreak: 5,
+		ActivityCount: 30, SeasonalActivityCount: 30,
+		SeasonalAchievements: allSeasonBadgeIDs(),
+		LastReportDate:        time.Now().AddDate(0, 0, -7),
+	}
+
+	// First report of the day (isFullReport): base 10 + weekly (3→4, +6) = 16.
+	// No daily history → daily bonus 0.
+	before1 := repo.reports["u"].SeasonalPoints
+	if _, err := uc.Execute(ctx, "u", "Repeat", nil); err != nil {
+		t.Fatalf("first report: %v", err)
+	}
+	first := repo.reports["u"].SeasonalPoints - before1
+	if first != 16 {
+		t.Fatalf("first report: expected +16, got %d", first)
+	}
+
+	// Second report same day (isRepeatReport): halved, no streak bonuses.
+	before2 := repo.reports["u"].SeasonalPoints
+	msg, err := uc.Execute(ctx, "u", "Repeat", nil)
+	if err != nil {
+		t.Fatalf("second report: %v", err)
+	}
+	second := repo.reports["u"].SeasonalPoints - before2
+	// (base 10) / 2 = 5. Streak/ActivityCount unchanged so no bonus applies.
+	if second != 5 {
+		t.Fatalf("repeat report: expected halved +5, got %d", second)
+	}
+	if !containsSubstring(msg, "laporan ke-2 hari ini") {
+		t.Fatalf("expected repeat report label, got: %s", msg)
+	}
+	if containsSubstring(msg, "½ XP") {
+		t.Fatalf("halving breakdown should be hidden, got: %s", msg)
+	}
+}
+
+// TestReportActivity_MultiAttributeGrantsSinglePoint verifies the attribute
+// fairness fix at the usecase level: a mixed session ("gym lalu lari dan
+// stretching") that matches three attribute categories grants exactly ONE
+// attribute point (the fighter's specialty STR), not +1 to each. This keeps
+// the total attribute budget per report constant regardless of how many
+// categories the activity text touches.
+func TestReportActivity_MultiAttributeGrantsSinglePoint(t *testing.T) {
+	repo := &mockRepo{
+		reports:       make(map[string]*domain.Report),
+		dailyCounts:   make(map[string]int),
+		activityDates: make(map[string][]time.Time),
+	}
+	uc := usecase.NewReportActivityUsecase(repo)
+	ctx := context.Background()
+	repo.reports["u"] = &domain.Report{
+		UserID: "u", Name: "Mixed", JobClass: "fighter",
+		Streak: 3, MaxStreak: 5, SeasonalMaxStreak: 5,
+		ActivityCount: 30, SeasonalActivityCount: 30,
+		SeasonalAchievements: allSeasonBadgeIDs(),
+		LastReportDate:        time.Now().AddDate(0, 0, -7),
+		// Start above the attribute clamp floor so a single fair grant shows
+		// as a clean +1 delta on the chosen attribute and +0 on the rest.
+		Str: 5, Sta: 5, Agi: 5, Vit: 5,
+	}
+	strBefore := repo.reports["u"].Str
+	staBefore := repo.reports["u"].Sta
+	agiBefore := repo.reports["u"].Agi
+	vitBefore := repo.reports["u"].Vit
+
+	if _, err := uc.ExecuteWithMessage(ctx, "u", "Mixed", "gym lalu lari dan stretching", nil); err != nil {
+		t.Fatalf("ExecuteWithMessage: %v", err)
+	}
+	r := repo.reports["u"]
+	// Exactly one attribute (STR, the fighter specialty among the matches)
+	// gains +1. The others must not move — the old code gave +1 to each.
+	if r.Str-strBefore != 1 {
+		t.Fatalf("STR delta = %d, want 1 (single fair grant)", r.Str-strBefore)
+	}
+	if r.Sta-staBefore != 0 || r.Agi-agiBefore != 0 || r.Vit-vitBefore != 0 {
+		t.Fatalf("other attributes must not gain: STA Δ%d AGI Δ%d VIT Δ%d, want all 0",
+			r.Sta-staBefore, r.Agi-agiBefore, r.Vit-vitBefore)
 	}
 }
 

--- a/internal/domain/report.go
+++ b/internal/domain/report.go
@@ -158,6 +158,68 @@ func ResolveReportAttributes(text string, jobClass string) ([]AttributeType, boo
 	return nil, false
 }
 
+// SelectReportAttribute picks the single attribute that should actually be
+// rewarded for a report, given the activity-matched attributes and the user's
+// job. This keeps the attribute grant FAIR and CONSISTENT across reports:
+//
+//   - Every report grants the same total attribute budget (one attribute),
+//     regardless of how many categories the activity text happens to match.
+//     Without this, a mixed session ("gym lalu lari dan stretching") would
+//     grant +1 to each of STR/STA/VIT while a focused session grants only +1,
+//     making some workouts worth several times the attribute points of others.
+//   - The activity directs the reward (a run still boosts STA, not STR), so
+//     the grant reflects the sport that was reported.
+//   - The job acts as a tie-breaker when several attributes match (the hunter's
+//     specialty wins among the matches), and as the fallback when nothing
+//     matches — so the user's job always shapes the gain.
+//   - Jobs with no single primary attribute (Mage) distribute the gain across
+//     the matched attributes using a stable per-report seed, instead of always
+//     defaulting to the first match (which would bias Mage gains toward STR).
+//
+// seed must be stable for a given report slot (e.g. user+date+slot+activity)
+// so the same report context always picks the same attribute, while different
+// reports spread Mage's gains evenly across its candidate attributes.
+//
+// Returns the chosen attribute, or "" if attrs is empty.
+func SelectReportAttribute(attrs []AttributeType, jobClass, seed string) AttributeType {
+	if len(attrs) == 0 {
+		return ""
+	}
+	if primary := JobClassPrimaryAttribute(jobClass); primary != "" {
+		for _, a := range attrs {
+			if a == primary {
+				return a
+			}
+		}
+		// Job's specialty is not among the matches — keep a deterministic
+		// fallback (first matched) so the result is stable per input.
+		return attrs[0]
+	}
+	// No single primary (Mage, or an unknown job): distribute fairly across
+	// the matched attributes using the stable per-report seed.
+	if len(attrs) > 1 {
+		return attrs[stableAttributeIndex(seed, len(attrs))]
+	}
+	return attrs[0]
+}
+
+// stableAttributeIndex maps a seed string to a deterministic index in [0, n).
+// Same seed always yields the same index (reproducible tests), and as the seed
+// varies across report slots the indices spread uniformly over n.
+func stableAttributeIndex(seed string, n int) int {
+	if n <= 0 {
+		return 0
+	}
+	const fnvOffset uint32 = 2166136261
+	const fnvPrime uint32 = 16777619
+	h := fnvOffset
+	for i := 0; i < len(seed); i++ {
+		h ^= uint32(seed[i])
+		h *= fnvPrime
+	}
+	return int(h % uint32(n))
+}
+
 func normalizeActivityText(text string) string {
 	text = strings.ToLower(text)
 	var b strings.Builder

--- a/internal/domain/report_test.go
+++ b/internal/domain/report_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -31,5 +32,81 @@ func TestDetermineAttributes(t *testing.T) {
 				t.Fatalf("DetermineAttributes(%q) = %#v, want %#v", tt.text, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSelectReportAttribute(t *testing.T) {
+	tests := []struct {
+		name     string
+		attrs    []AttributeType
+		jobClass string
+		seed     string
+		want     AttributeType
+	}{
+		{"empty returns empty", nil, "fighter", "", ""},
+		{"single activity match is kept", []AttributeType{AttrSta}, "ranger", "", AttrSta},
+		// Activity directs the reward: a run (STA) still boosts STA even for a
+		// STR-focused fighter — the job does not override a clear activity match.
+		{"activity overrides job when only one matches", []AttributeType{AttrSta}, "fighter", "", AttrSta},
+		// Job breaks ties when several attributes match: the hunter's specialty
+		// wins among the matches.
+		{"job wins among multiple matches (fighter→STR)", []AttributeType{AttrSta, AttrStr, AttrVit}, "fighter", "", AttrStr},
+		{"job wins among multiple matches (ranger→STA)", []AttributeType{AttrStr, AttrSta, AttrVit}, "ranger", "", AttrSta},
+		{"job wins among multiple matches (healer→VIT)", []AttributeType{AttrSta, AttrAgi, AttrVit}, "healer", "", AttrVit},
+		// When the job's specialty is NOT among the matches, the first matched
+		// attribute wins (deterministic, no arbitrary preference).
+		{"job not among matches falls back to first", []AttributeType{AttrSta, AttrVit}, "fighter", "", AttrSta},
+		// Mage has no single primary → the seed distributes the gain across the
+		// matched attributes instead of always defaulting to the first (STR).
+		// The same seed must always yield the same attribute (deterministic).
+		{"mage multi-match is seed-determined", []AttributeType{AttrStr, AttrSta, AttrVit}, "mage", "userA|regular|2026-06-30|1|gym lari", AttrStr},
+		{"unknown job multi-match is seed-determined", []AttributeType{AttrAgi, AttrVit}, "", "u|regular|d|1|x", AttrVit},
+		{"single match unaffected by seed", []AttributeType{AttrAgi}, "mage", "any", AttrAgi},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SelectReportAttribute(tt.attrs, tt.jobClass, tt.seed); got != tt.want {
+				t.Fatalf("SelectReportAttribute(%#v, %q, %q) = %q, want %q", tt.attrs, tt.jobClass, tt.seed, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSelectReportAttribute_GrantsSinglePointPerReport is the fairness guard:
+// a mixed session that matches three categories must yield exactly ONE
+// attribute point (the job's specialty among the matches), not three. This
+// prevents the old behavior where "gym lalu lari dan stretching" gave +3 while
+// a focused session gave +1.
+func TestSelectReportAttribute_GrantsSinglePointPerReport(t *testing.T) {
+	mixed := DetermineAttributes("gym lalu lari dan stretching")
+	if len(mixed) < 2 {
+		t.Fatalf("sanity: expected mixed session to match several attributes, got %#v", mixed)
+	}
+	chosen := SelectReportAttribute(mixed, "fighter", "seed-irrelevant-when-primary-matches")
+	// Exactly one attribute is selected (the fighter specialty STR is among
+	// the matches here), so the report grants +1 STR — not +1 to each.
+	if chosen != AttrStr {
+		t.Fatalf("fighter mixed session should reward its specialty STR, got %q", chosen)
+	}
+}
+
+// TestSelectReportAttribute_MageDistributesFairly verifies that Mage (no single
+// primary attribute) does not bias toward one attribute: across many distinct
+// report seeds, all candidate attributes get selected. This guards against the
+// old always-first behavior that funneled every Mage gain into STR.
+func TestSelectReportAttribute_MageDistributesFairly(t *testing.T) {
+	attrs := []AttributeType{AttrStr, AttrSta, AttrAgi, AttrVit}
+	seen := make(map[AttributeType]bool)
+	const samples = 400
+	for i := 0; i < samples; i++ {
+		seed := fmt.Sprintf("mage-user|regular|2026-06-30|%d|mixed activity", i)
+		chosen := SelectReportAttribute(attrs, "mage", seed)
+		if chosen == "" {
+			t.Fatalf("seed %d returned empty attribute", i)
+		}
+		seen[chosen] = true
+	}
+	if len(seen) != 4 {
+		t.Fatalf("Mage expected to distribute across all 4 attributes over %d seeds, only got %v", samples, seen)
 	}
 }


### PR DESCRIPTION
- Introduce additive capped streak bonuses (weekly & daily)
- Revise attribute gain logic to grant a single, job-influenced attribute point
- Hide point breakdown from user-facing messages for conciseness
- Add comprehensive tests for new scoring and attribute selection logic